### PR TITLE
feat: add rc update command and install.sh for Xcode-free install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,29 @@ rc charts show mrr
 
 ## Install
 
+**Homebrew** (macOS/Linux):
 ```bash
 brew install RevenueCat/tap/rc
 ```
 
-Or download a binary from the [releases page](../../releases).
+**Direct install** — no Xcode Command Line Tools required:
+```bash
+curl -fsSL https://raw.githubusercontent.com/RevenueCat/revenuecat-cli/main/install.sh | sh
+```
+
+Installs to `/usr/local/bin` by default. Use `--install-dir` to change:
+```bash
+curl -fsSL https://raw.githubusercontent.com/RevenueCat/revenuecat-cli/main/install.sh | sh -s -- --install-dir ~/.local/bin
+```
+
+Or download a binary directly from the [releases page](../../releases).
+
+## Updating
+
+```bash
+rc update          # download and install the latest version
+rc update --check  # exit 1 if an update is available (useful in CI)
+```
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ rc update          # download and install the latest version
 rc update --check  # exit 1 if an update is available (useful in CI)
 ```
 
+> **Windows:** `rc update` is not supported on Windows. Download the latest release directly from the [releases page](../../releases).
+
 ## Quick start
 
 ```bash

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -86,6 +86,7 @@ rc config                                                # show resolved config
 rc commands                                              # agent discovery (tree)
 rc schema <cmd>                                          # agent discovery (flags)
 rc version
+rc update                                                # self-update from GitHub Releases; --check exits 1 if stale (not supported on Windows)
 rc completion <shell>
 
 # Project / workspace

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,10 @@ INSTALL_DIR="/usr/local/bin"
 while [ $# -gt 0 ]; do
   case "$1" in
     --install-dir)
+      if [ -z "${2:-}" ]; then
+        echo "Error: --install-dir requires a value" >&2
+        exit 1
+      fi
       INSTALL_DIR="$2"
       shift 2
       ;;
@@ -24,6 +28,10 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     --version)
+      if [ -z "${2:-}" ]; then
+        echo "Error: --version requires a value" >&2
+        exit 1
+      fi
       PINNED_VERSION="$2"
       shift 2
       ;;
@@ -62,7 +70,7 @@ case "$ARCH" in
 esac
 
 # Resolve version — always normalize to include the 'v' prefix for the tag
-if [ -n "$PINNED_VERSION" ]; then
+if [ -n "${PINNED_VERSION:-}" ]; then
   case "$PINNED_VERSION" in
     v*) VERSION="$PINNED_VERSION" ;;
     *)  VERSION="v$PINNED_VERSION" ;;
@@ -84,8 +92,10 @@ VERSION_NUM="${VERSION#v}"
 
 if [ "$GOOS" = "windows" ]; then
   ARCHIVE="${BINARY}_${VERSION_NUM}_${GOOS}_${GOARCH}.zip"
+  INSTALL_NAME="rc.exe"
 else
   ARCHIVE="${BINARY}_${VERSION_NUM}_${GOOS}_${GOARCH}.tar.gz"
+  INSTALL_NAME="rc"
 fi
 
 DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
@@ -115,28 +125,26 @@ fi
 
 chmod +x "$EXTRACTED"
 
-# On Windows (Git Bash/MSYS), install as rc.exe
-if [ "$GOOS" = "windows" ]; then
-  INSTALL_NAME="rc.exe"
-else
-  INSTALL_NAME="rc"
-fi
+# Install — create dir and move binary, falling back to sudo if needed
+DEST="$INSTALL_DIR/$INSTALL_NAME"
 
-# Install
-mkdir -p "$INSTALL_DIR"
-if mv "$EXTRACTED" "$INSTALL_DIR/$INSTALL_NAME" 2>/dev/null; then
-  echo "Installed to $INSTALL_DIR/$INSTALL_NAME"
+install_binary() {
+  mkdir -p "$INSTALL_DIR" && mv "$EXTRACTED" "$DEST"
+}
+
+if install_binary 2>/dev/null; then
+  echo "Installed to $DEST"
 else
   echo "Permission denied. Retrying with sudo…"
-  sudo mv "$EXTRACTED" "$INSTALL_DIR/$INSTALL_NAME"
-  echo "Installed to $INSTALL_DIR/$INSTALL_NAME"
+  sudo sh -c "mkdir -p '$INSTALL_DIR' && mv '$EXTRACTED' '$DEST'"
+  echo "Installed to $DEST"
 fi
 
-# Verify
-if command -v "$BINARY" >/dev/null 2>&1; then
-  echo "$(rc --version)"
+# Verify using the installed path directly, not whatever is first on PATH
+if [ -x "$DEST" ]; then
+  "$DEST" --version
 else
   echo ""
-  echo "Make sure $INSTALL_DIR is in your PATH:"
+  echo "Installed, but $INSTALL_DIR is not on your PATH. Add it:"
   echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+# Install the latest rc (RevenueCat CLI) release from GitHub.
+# No Homebrew or Xcode Command Line Tools required.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/RevenueCat/revenuecat-cli/main/install.sh | sh
+#   curl -fsSL ... | sh -s -- --install-dir ~/.local/bin
+
+set -e
+
+REPO="RevenueCat/revenuecat-cli"
+BINARY="rc"
+INSTALL_DIR="/usr/local/bin"
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --install-dir)
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    --install-dir=*)
+      INSTALL_DIR="${1#*=}"
+      shift
+      ;;
+    --version)
+      PINNED_VERSION="$2"
+      shift 2
+      ;;
+    --version=*)
+      PINNED_VERSION="${1#*=}"
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Detect OS and arch
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  Darwin)  GOOS="darwin" ;;
+  Linux)   GOOS="linux" ;;
+  MINGW*|MSYS*|CYGWIN*) GOOS="windows" ;;
+  *)
+    echo "Unsupported OS: $OS" >&2
+    exit 1
+    ;;
+esac
+
+case "$ARCH" in
+  x86_64|amd64) GOARCH="amd64" ;;
+  arm64|aarch64) GOARCH="arm64" ;;
+  *)
+    echo "Unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+# Resolve version
+if [ -n "$PINNED_VERSION" ]; then
+  VERSION="$PINNED_VERSION"
+else
+  echo "Fetching latest version…"
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    -H "Accept: application/vnd.github+json" \
+    | grep '"tag_name"' \
+    | sed 's/.*"tag_name": *"\(.*\)".*/\1/')"
+  if [ -z "$VERSION" ]; then
+    echo "Could not determine latest version. Check your internet connection." >&2
+    exit 1
+  fi
+fi
+
+# Strip leading 'v' for the archive filename
+VERSION_NUM="${VERSION#v}"
+
+if [ "$GOOS" = "windows" ]; then
+  ARCHIVE="${BINARY}_${VERSION_NUM}_${GOOS}_${GOARCH}.zip"
+else
+  ARCHIVE="${BINARY}_${VERSION_NUM}_${GOOS}_${GOARCH}.tar.gz"
+fi
+
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
+
+echo "Installing ${BINARY} ${VERSION} (${GOOS}/${GOARCH})…"
+
+# Create a temp dir
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Download
+curl -fsSL "$DOWNLOAD_URL" -o "$TMP/$ARCHIVE"
+
+# Extract
+if [ "$GOOS" = "windows" ]; then
+  unzip -q "$TMP/$ARCHIVE" -d "$TMP"
+  EXTRACTED="$TMP/${BINARY}.exe"
+else
+  tar -xzf "$TMP/$ARCHIVE" -C "$TMP"
+  EXTRACTED="$TMP/${BINARY}"
+fi
+
+if [ ! -f "$EXTRACTED" ]; then
+  echo "Binary not found after extraction." >&2
+  exit 1
+fi
+
+chmod +x "$EXTRACTED"
+
+# Install
+mkdir -p "$INSTALL_DIR"
+if mv "$EXTRACTED" "$INSTALL_DIR/$BINARY" 2>/dev/null; then
+  echo "Installed to $INSTALL_DIR/$BINARY"
+else
+  echo "Permission denied. Retrying with sudo…"
+  sudo mv "$EXTRACTED" "$INSTALL_DIR/$BINARY"
+  echo "Installed to $INSTALL_DIR/$BINARY"
+fi
+
+# Verify
+if command -v "$BINARY" >/dev/null 2>&1; then
+  echo "$(rc --version)"
+else
+  echo ""
+  echo "Make sure $INSTALL_DIR is in your PATH:"
+  echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
+fi

--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}
 echo "Installing ${BINARY} ${VERSION} (${GOOS}/${GOARCH})…"
 
 # Create a temp dir
-TMP="$(mktemp -d)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/rc.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 # Download

--- a/install.sh
+++ b/install.sh
@@ -77,11 +77,20 @@ if [ -n "${PINNED_VERSION:-}" ]; then
   esac
 else
   echo "Fetching latest version…"
-  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-    -H "Accept: application/vnd.github+json" \
-    | grep '"tag_name"' \
-    | sed 's/.*"tag_name": *"\(.*\)".*/\1/')"
-  if [ -z "$VERSION" ]; then
+  API_RESPONSE="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    -H "Accept: application/vnd.github+json")"
+
+  # Use jq if available; fall back to a tightly anchored grep/sed
+  if command -v jq >/dev/null 2>&1; then
+    VERSION="$(printf '%s' "$API_RESPONSE" | jq -r '.tag_name')"
+  else
+    VERSION="$(printf '%s' "$API_RESPONSE" \
+      | grep -o '"tag_name": *"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+  fi
+
+  if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
     echo "Could not determine latest version. Check your internet connection." >&2
     exit 1
   fi
@@ -92,9 +101,11 @@ VERSION_NUM="${VERSION#v}"
 
 if [ "$GOOS" = "windows" ]; then
   ARCHIVE="${BINARY}_${VERSION_NUM}_${GOOS}_${GOARCH}.zip"
+  BINARY_IN_ARCHIVE="${BINARY}.exe"
   INSTALL_NAME="rc.exe"
 else
   ARCHIVE="${BINARY}_${VERSION_NUM}_${GOOS}_${GOARCH}.tar.gz"
+  BINARY_IN_ARCHIVE="${BINARY}"
   INSTALL_NAME="rc"
 fi
 
@@ -109,13 +120,12 @@ trap 'rm -rf "$TMP"' EXIT
 # Download
 curl -fsSL "$DOWNLOAD_URL" -o "$TMP/$ARCHIVE"
 
-# Extract
+# Extract only the rc binary — don't unpack the whole archive
+EXTRACTED="$TMP/$INSTALL_NAME"
 if [ "$GOOS" = "windows" ]; then
-  unzip -q "$TMP/$ARCHIVE" -d "$TMP"
-  EXTRACTED="$TMP/${BINARY}.exe"
+  unzip -q -j "$TMP/$ARCHIVE" "$BINARY_IN_ARCHIVE" -d "$TMP"
 else
-  tar -xzf "$TMP/$ARCHIVE" -C "$TMP"
-  EXTRACTED="$TMP/${BINARY}"
+  tar -xzf "$TMP/$ARCHIVE" -C "$TMP" "$BINARY_IN_ARCHIVE"
 fi
 
 if [ ! -f "$EXTRACTED" ]; then
@@ -125,9 +135,11 @@ fi
 
 chmod +x "$EXTRACTED"
 
-# Install — create dir and move binary, falling back to sudo if needed
 DEST="$INSTALL_DIR/$INSTALL_NAME"
 
+# Install — mkdir and mv in one function so sudo covers both operations.
+# sudo is invoked with explicit arguments (not via sh -c) to avoid
+# shell-injection from user-supplied --install-dir values.
 install_binary() {
   mkdir -p "$INSTALL_DIR" && mv "$EXTRACTED" "$DEST"
 }
@@ -136,7 +148,8 @@ if install_binary 2>/dev/null; then
   echo "Installed to $DEST"
 else
   echo "Permission denied. Retrying with sudo…"
-  sudo sh -c "mkdir -p '$INSTALL_DIR' && mv '$EXTRACTED' '$DEST'"
+  sudo mkdir -p -- "$INSTALL_DIR"
+  sudo mv -- "$EXTRACTED" "$DEST"
   echo "Installed to $DEST"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -61,9 +61,12 @@ case "$ARCH" in
     ;;
 esac
 
-# Resolve version
+# Resolve version — always normalize to include the 'v' prefix for the tag
 if [ -n "$PINNED_VERSION" ]; then
-  VERSION="$PINNED_VERSION"
+  case "$PINNED_VERSION" in
+    v*) VERSION="$PINNED_VERSION" ;;
+    *)  VERSION="v$PINNED_VERSION" ;;
+  esac
 else
   echo "Fetching latest version…"
   VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
@@ -112,14 +115,21 @@ fi
 
 chmod +x "$EXTRACTED"
 
+# On Windows (Git Bash/MSYS), install as rc.exe
+if [ "$GOOS" = "windows" ]; then
+  INSTALL_NAME="rc.exe"
+else
+  INSTALL_NAME="rc"
+fi
+
 # Install
 mkdir -p "$INSTALL_DIR"
-if mv "$EXTRACTED" "$INSTALL_DIR/$BINARY" 2>/dev/null; then
-  echo "Installed to $INSTALL_DIR/$BINARY"
+if mv "$EXTRACTED" "$INSTALL_DIR/$INSTALL_NAME" 2>/dev/null; then
+  echo "Installed to $INSTALL_DIR/$INSTALL_NAME"
 else
   echo "Permission denied. Retrying with sudo…"
-  sudo mv "$EXTRACTED" "$INSTALL_DIR/$BINARY"
-  echo "Installed to $INSTALL_DIR/$BINARY"
+  sudo mv "$EXTRACTED" "$INSTALL_DIR/$INSTALL_NAME"
+  echo "Installed to $INSTALL_DIR/$INSTALL_NAME"
 fi
 
 # Verify

--- a/install.sh
+++ b/install.sh
@@ -137,21 +137,23 @@ chmod +x "$EXTRACTED"
 
 DEST="$INSTALL_DIR/$INSTALL_NAME"
 
-# Install — mkdir and mv in one function so sudo covers both operations.
-# sudo is invoked with explicit arguments (not via sh -c) to avoid
-# shell-injection from user-supplied --install-dir values.
-install_binary() {
-  mkdir -p "$INSTALL_DIR" && mv "$EXTRACTED" "$DEST"
-}
-
-if install_binary 2>/dev/null; then
+# Install — sudo is invoked with explicit arguments (not via sh -c) to avoid
+# shell injection from user-supplied --install-dir values.
+# Capture the real error before falling back to sudo so we can report it
+# accurately if sudo also fails.
+INSTALL_ERR="$( { mkdir -p "$INSTALL_DIR" && mv "$EXTRACTED" "$DEST"; } 2>&1 )" && {
   echo "Installed to $DEST"
-else
-  echo "Permission denied. Retrying with sudo…"
+} || {
+  if [ -d "$INSTALL_DIR" ] && [ ! -w "$INSTALL_DIR" ]; then
+    echo "No write permission to $INSTALL_DIR. Retrying with sudo…"
+  else
+    echo "Install failed: $INSTALL_ERR" >&2
+    echo "Retrying with sudo…"
+  fi
   sudo mkdir -p -- "$INSTALL_DIR"
   sudo mv -- "$EXTRACTED" "$DEST"
   echo "Installed to $DEST"
-fi
+}
 
 # Verify using the installed path directly, not whatever is first on PATH
 if [ -x "$DEST" ]; then

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -120,6 +120,7 @@ Agent-friendly entrypoints:
 		newSchemaCmd(root),
 		newCommandsCmd(root),
 		newVersionCmd(),
+		newUpdateCmd(),
 	)
 
 	return root

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -22,6 +22,12 @@ func Run(version string) int {
 	if err == nil {
 		return 0
 	}
+	// SilentExitError means the command already wrote its output; skip the
+	// error envelope so there is only one JSON document on stdout.
+	var silent *SilentExitError
+	if errors.As(err, &silent) {
+		return silent.Code
+	}
 	jsonMode, _ := root.PersistentFlags().GetBool("json")
 	if jsonMode {
 		writeJSONError(os.Stderr, err)

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -92,6 +92,13 @@ func oauthClientID() string {
 
 var ErrNotAuthenticated = errors.New("not authenticated: run `rc login` or pass --api-key / set RC_API_KEY")
 
+// SilentExitError signals a specific exit code when the command has already
+// written its own complete output. run.go skips the error envelope for this
+// type so there is no duplicate output.
+type SilentExitError struct{ Code int }
+
+func (e *SilentExitError) Error() string { return "" }
+
 func ExitCodeFor(err error) int {
 	if err == nil {
 		return 0

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,308 @@
+package cli
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const githubReleasesURL = "https://api.github.com/repos/RevenueCat/revenuecat-cli/releases/latest"
+
+type githubRelease struct {
+	TagName string        `json:"tag_name"`
+	Assets  []githubAsset `json:"assets"`
+	HTMLURL string        `json:"html_url"`
+}
+
+type githubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+func newUpdateCmd() *cobra.Command {
+	var checkOnly bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update rc to the latest version",
+		Long: `Check for a newer version of rc and install it.
+
+The binary is downloaded directly from GitHub Releases — no Homebrew or
+Xcode Command Line Tools required. The running binary is replaced atomically.`,
+		Example: `  rc update            # check and install if newer
+  rc update --check    # check only, exit 1 if update available`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rt := RuntimeFrom(cmd.Context())
+			currentVersion := cmd.Root().Version
+
+			rt.Out.Info("Checking for updates…")
+			release, err := fetchLatestRelease()
+			if err != nil {
+				return fmt.Errorf("checking for updates: %w", err)
+			}
+
+			latestTag := release.TagName
+			latestVersion := strings.TrimPrefix(latestTag, "v")
+
+			if latestVersion == currentVersion || currentVersion == "dev" {
+				if currentVersion == "dev" {
+					rt.Out.Info("Running development build — skipping update.")
+					return nil
+				}
+				if rt.Globals.JSON {
+					return rt.Out.Render(map[string]any{
+						"current_version": currentVersion,
+						"latest_version":  latestVersion,
+						"up_to_date":      true,
+					})
+				}
+				rt.Out.Success(fmt.Sprintf("Already up to date (%s).", currentVersion))
+				return nil
+			}
+
+			if rt.Globals.JSON {
+				if checkOnly {
+					return rt.Out.Render(map[string]any{
+						"current_version": currentVersion,
+						"latest_version":  latestVersion,
+						"up_to_date":      false,
+					})
+				}
+			} else {
+				rt.Out.Info(fmt.Sprintf("Update available: %s → %s", currentVersion, latestVersion))
+			}
+
+			if checkOnly {
+				return fmt.Errorf("update available: %s (current: %s)", latestVersion, currentVersion)
+			}
+
+			assetName := assetFilename(latestVersion)
+			downloadURL := ""
+			for _, a := range release.Assets {
+				if a.Name == assetName {
+					downloadURL = a.BrowserDownloadURL
+					break
+				}
+			}
+			if downloadURL == "" {
+				return fmt.Errorf("no release asset found for %s/%s (looked for %q) — download manually: %s",
+					runtime.GOOS, runtime.GOARCH, assetName, release.HTMLURL)
+			}
+
+			rt.Out.Info(fmt.Sprintf("Downloading %s…", assetName))
+			tmpPath, err := downloadAsset(downloadURL, assetName)
+			if err != nil {
+				return fmt.Errorf("downloading update: %w", err)
+			}
+			defer os.Remove(tmpPath)
+
+			execPath, err := os.Executable()
+			if err != nil {
+				return fmt.Errorf("finding current binary: %w", err)
+			}
+			execPath, err = filepath.EvalSymlinks(execPath)
+			if err != nil {
+				return fmt.Errorf("resolving binary path: %w", err)
+			}
+
+			if err := installBinary(tmpPath, execPath); err != nil {
+				return fmt.Errorf("installing update: %w", err)
+			}
+
+			if rt.Globals.JSON {
+				return rt.Out.Render(map[string]any{
+					"previous_version": currentVersion,
+					"current_version":  latestVersion,
+					"up_to_date":       true,
+				})
+			}
+			rt.Out.Success(fmt.Sprintf("Updated to %s.", latestVersion))
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "check for updates without installing; exit 1 if update is available")
+	return cmd
+}
+
+func fetchLatestRelease() (*githubRelease, error) {
+	req, err := http.NewRequest(http.MethodGet, githubReleasesURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned %s", resp.Status)
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+	return &release, nil
+}
+
+func assetFilename(version string) string {
+	goos := runtime.GOOS
+	goarch := runtime.GOARCH
+	if goos == "windows" {
+		return fmt.Sprintf("rc_%s_%s_%s.zip", version, goos, goarch)
+	}
+	return fmt.Sprintf("rc_%s_%s_%s.tar.gz", version, goos, goarch)
+}
+
+// downloadAsset fetches the asset and extracts the rc binary to a temp file.
+func downloadAsset(url, assetName string) (string, error) {
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download returned %s", resp.Status)
+	}
+
+	tmp, err := os.CreateTemp("", "rc-update-*")
+	if err != nil {
+		return "", err
+	}
+	defer tmp.Close()
+
+	if strings.HasSuffix(assetName, ".zip") {
+		// Write zip to disk first since zip.NewReader needs io.ReaderAt.
+		if _, err := io.Copy(tmp, resp.Body); err != nil {
+			os.Remove(tmp.Name())
+			return "", err
+		}
+		if err := extractFromZip(tmp.Name()); err != nil {
+			os.Remove(tmp.Name())
+			return "", err
+		}
+		return tmp.Name(), nil
+	}
+
+	// tar.gz
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			os.Remove(tmp.Name())
+			return "", err
+		}
+		if filepath.Base(hdr.Name) == "rc" && hdr.Typeflag == tar.TypeReg {
+			if _, err := io.Copy(tmp, tr); err != nil {
+				os.Remove(tmp.Name())
+				return "", err
+			}
+			return tmp.Name(), nil
+		}
+	}
+
+	os.Remove(tmp.Name())
+	return "", fmt.Errorf("rc binary not found in archive")
+}
+
+// extractFromZip reads a zip already written to path and overwrites it with
+// the extracted rc binary.
+func extractFromZip(path string) error {
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		if filepath.Base(f.Name) == "rc.exe" || filepath.Base(f.Name) == "rc" {
+			rc, err := f.Open()
+			if err != nil {
+				return err
+			}
+			defer rc.Close()
+
+			tmp, err := os.CreateTemp(filepath.Dir(path), "rc-zip-*")
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(tmp, rc); err != nil {
+				tmp.Close()
+				os.Remove(tmp.Name())
+				return err
+			}
+			tmp.Close()
+			return os.Rename(tmp.Name(), path)
+		}
+	}
+	return fmt.Errorf("rc binary not found in zip archive")
+}
+
+// installBinary atomically replaces the current binary with the extracted one.
+func installBinary(srcPath, destPath string) error {
+	if err := os.Chmod(srcPath, 0755); err != nil {
+		return err
+	}
+
+	// Write to a sibling temp file so Rename is atomic on the same filesystem.
+	dir := filepath.Dir(destPath)
+	tmp, err := os.CreateTemp(dir, ".rc-update-*")
+	if err != nil {
+		// Fall back: dest dir may not be writable; try a direct rename.
+		return os.Rename(srcPath, destPath)
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+
+	if err := copyFile(srcPath, tmp.Name()); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp.Name(), 0755); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	return os.Rename(tmp.Name(), destPath)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -17,13 +17,13 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/revenuecat/cli/internal/tui"
 )
 
 const githubReleasesURL = "https://api.github.com/repos/RevenueCat/revenuecat-cli/releases/latest"
 
 var errUpdateAvailable = errors.New("update available")
-
-var updateHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 type githubRelease struct {
 	TagName string        `json:"tag_name"`
@@ -65,7 +65,8 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 			}
 
 			rt.Out.Info("Checking for updates…")
-			release, err := fetchLatestRelease(cmd.Context())
+			hc := &http.Client{Timeout: 30 * time.Second}
+			release, err := fetchLatestRelease(cmd.Context(), hc)
 			if err != nil {
 				return fmt.Errorf("checking for updates: %w", err)
 			}
@@ -73,7 +74,8 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 			latestTag := release.TagName
 			latestVersion := strings.TrimPrefix(latestTag, "v")
 
-			if latestVersion == currentVersion {
+			// Guard against downgrades (e.g. snapshot/pre-release tags).
+			if !isNewer(latestVersion, currentVersion) {
 				if rt.Globals.JSON {
 					return rt.Out.Render(map[string]any{
 						"current_version": currentVersion,
@@ -89,14 +91,26 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 
 			if checkOnly {
 				if rt.Globals.JSON {
-					// Render JSON first, then return the sentinel so exit code is 1.
-					_ = rt.Out.Render(map[string]any{
+					if err := rt.Out.Render(map[string]any{
 						"current_version": currentVersion,
 						"latest_version":  latestVersion,
 						"up_to_date":      false,
-					})
+					}); err != nil {
+						return err
+					}
 				}
 				return fmt.Errorf("%w: %s (current: %s)", errUpdateAvailable, latestVersion, currentVersion)
+			}
+
+			if !rt.Globals.AssumeYes {
+				ok, err := tui.Confirm(rt.Globals.NoInput,
+					fmt.Sprintf("Update rc from %s to %s?", currentVersion, latestVersion))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("aborted")
+				}
 			}
 
 			assetName := assetFilename(latestVersion)
@@ -113,7 +127,7 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 			}
 
 			rt.Out.Info(fmt.Sprintf("Downloading %s…", assetName))
-			tmpPath, err := downloadAsset(cmd.Context(), downloadURL, assetName)
+			tmpPath, err := downloadAsset(cmd.Context(), hc, downloadURL, assetName)
 			if err != nil {
 				return fmt.Errorf("downloading update: %w", err)
 			}
@@ -148,22 +162,66 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 	return cmd
 }
 
-func fetchLatestRelease(ctx context.Context) (*githubRelease, error) {
+// isNewer returns true only when latest is strictly greater than current using
+// simple semver comparison. Returns false for equal or unparseable versions so
+// we never downgrade.
+func isNewer(latest, current string) bool {
+	lp := parseSemver(latest)
+	cp := parseSemver(current)
+	if lp == nil || cp == nil {
+		// Can't parse — treat as equal to avoid unintended updates.
+		return false
+	}
+	if lp[0] != cp[0] {
+		return lp[0] > cp[0]
+	}
+	if lp[1] != cp[1] {
+		return lp[1] > cp[1]
+	}
+	return lp[2] > cp[2]
+}
+
+// parseSemver parses "X.Y.Z" or "vX.Y.Z" into [major, minor, patch].
+func parseSemver(v string) []int {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return nil
+	}
+	nums := make([]int, 3)
+	for i, p := range parts {
+		// Stop at any pre-release suffix (e.g. "0-next").
+		p, _, _ = strings.Cut(p, "-")
+		n := 0
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return nil
+			}
+			n = n*10 + int(c-'0')
+		}
+		nums[i] = n
+	}
+	return nums
+}
+
+func fetchLatestRelease(ctx context.Context, hc *http.Client) (*githubRelease, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubReleasesURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "revenuecat-cli")
 
-	resp, err := updateHTTPClient.Do(req)
+	resp, err := hc.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API returned %s", resp.Status)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("GitHub API returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
 	}
 
 	var release githubRelease
@@ -183,12 +241,12 @@ func assetFilename(version string) string {
 }
 
 // downloadAsset fetches the asset and extracts the rc binary to a temp file.
-func downloadAsset(ctx context.Context, url, assetName string) (string, error) {
+func downloadAsset(ctx context.Context, hc *http.Client, url, assetName string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", err
 	}
-	resp, err := updateHTTPClient.Do(req)
+	resp, err := hc.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -54,7 +54,11 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 			hc := &http.Client{Timeout: 30 * time.Second}
 
 			rt.Out.Info("Checking for updates…")
-			release, err := updater.FetchRelease(cmd.Context(), hc)
+			releasesURL := updater.DefaultReleasesURL
+			if override := os.Getenv("RC_UPDATER_RELEASES_URL"); override != "" {
+				releasesURL = override
+			}
+			release, err := updater.FetchRelease(cmd.Context(), hc, releasesURL)
 			if err != nil {
 				return fmt.Errorf("checking for updates: %w", err)
 			}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -55,9 +55,10 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 			if !updater.IsNewer(latestVersion, currentVersion) {
 				if rt.Globals.JSON {
 					return rt.Out.Render(map[string]any{
-						"current_version": currentVersion,
-						"latest_version":  latestVersion,
-						"up_to_date":      true,
+						"installed_version": currentVersion,
+						"latest_version":    latestVersion,
+						"up_to_date":        true,
+						"updated":           false,
 					})
 				}
 				rt.Out.Success(fmt.Sprintf("Already up to date (%s).", currentVersion))
@@ -71,9 +72,10 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 					// Write the JSON result to stdout, then return SilentExitError so
 					// run.go exits 1 without also emitting a JSON error envelope.
 					if err := rt.Out.Render(map[string]any{
-						"current_version": currentVersion,
-						"latest_version":  latestVersion,
-						"up_to_date":      false,
+						"installed_version": currentVersion,
+						"latest_version":    latestVersion,
+						"up_to_date":        false,
+						"updated":           false,
 					}); err != nil {
 						return err
 					}
@@ -115,9 +117,10 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 
 			if rt.Globals.JSON {
 				return rt.Out.Render(map[string]any{
-					"previous_version": currentVersion,
-					"current_version":  latestVersion,
-					"up_to_date":       true,
+					"installed_version": latestVersion,
+					"latest_version":    latestVersion,
+					"up_to_date":        true,
+					"updated":           true,
 				})
 			}
 			rt.Out.Success(fmt.Sprintf("Updated to %s.", latestVersion))

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -4,7 +4,9 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,11 +14,16 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 const githubReleasesURL = "https://api.github.com/repos/RevenueCat/revenuecat-cli/releases/latest"
+
+var errUpdateAvailable = errors.New("update available")
+
+var updateHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 type githubRelease struct {
 	TagName string        `json:"tag_name"`
@@ -38,15 +45,27 @@ func newUpdateCmd() *cobra.Command {
 		Long: `Check for a newer version of rc and install it.
 
 The binary is downloaded directly from GitHub Releases — no Homebrew or
-Xcode Command Line Tools required. The running binary is replaced atomically.`,
+Xcode Command Line Tools required. The running binary is replaced atomically.
+
+Not supported on Windows; download the latest release manually from
+https://github.com/RevenueCat/revenuecat-cli/releases`,
 		Example: `  rc update            # check and install if newer
   rc update --check    # check only, exit 1 if update available`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if runtime.GOOS == "windows" {
+				return fmt.Errorf("rc update is not supported on Windows — download the latest release from https://github.com/RevenueCat/revenuecat-cli/releases")
+			}
+
 			rt := RuntimeFrom(cmd.Context())
 			currentVersion := cmd.Root().Version
 
+			if currentVersion == "dev" {
+				rt.Out.Info("Running development build — skipping update.")
+				return nil
+			}
+
 			rt.Out.Info("Checking for updates…")
-			release, err := fetchLatestRelease()
+			release, err := fetchLatestRelease(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("checking for updates: %w", err)
 			}
@@ -54,11 +73,7 @@ Xcode Command Line Tools required. The running binary is replaced atomically.`,
 			latestTag := release.TagName
 			latestVersion := strings.TrimPrefix(latestTag, "v")
 
-			if latestVersion == currentVersion || currentVersion == "dev" {
-				if currentVersion == "dev" {
-					rt.Out.Info("Running development build — skipping update.")
-					return nil
-				}
+			if latestVersion == currentVersion {
 				if rt.Globals.JSON {
 					return rt.Out.Render(map[string]any{
 						"current_version": currentVersion,
@@ -70,20 +85,18 @@ Xcode Command Line Tools required. The running binary is replaced atomically.`,
 				return nil
 			}
 
-			if rt.Globals.JSON {
-				if checkOnly {
-					return rt.Out.Render(map[string]any{
+			rt.Out.Info(fmt.Sprintf("Update available: %s → %s", currentVersion, latestVersion))
+
+			if checkOnly {
+				if rt.Globals.JSON {
+					// Render JSON first, then return the sentinel so exit code is 1.
+					_ = rt.Out.Render(map[string]any{
 						"current_version": currentVersion,
 						"latest_version":  latestVersion,
 						"up_to_date":      false,
 					})
 				}
-			} else {
-				rt.Out.Info(fmt.Sprintf("Update available: %s → %s", currentVersion, latestVersion))
-			}
-
-			if checkOnly {
-				return fmt.Errorf("update available: %s (current: %s)", latestVersion, currentVersion)
+				return fmt.Errorf("%w: %s (current: %s)", errUpdateAvailable, latestVersion, currentVersion)
 			}
 
 			assetName := assetFilename(latestVersion)
@@ -100,7 +113,7 @@ Xcode Command Line Tools required. The running binary is replaced atomically.`,
 			}
 
 			rt.Out.Info(fmt.Sprintf("Downloading %s…", assetName))
-			tmpPath, err := downloadAsset(downloadURL, assetName)
+			tmpPath, err := downloadAsset(cmd.Context(), downloadURL, assetName)
 			if err != nil {
 				return fmt.Errorf("downloading update: %w", err)
 			}
@@ -135,15 +148,15 @@ Xcode Command Line Tools required. The running binary is replaced atomically.`,
 	return cmd
 }
 
-func fetchLatestRelease() (*githubRelease, error) {
-	req, err := http.NewRequest(http.MethodGet, githubReleasesURL, nil)
+func fetchLatestRelease(ctx context.Context) (*githubRelease, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubReleasesURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := updateHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -170,8 +183,12 @@ func assetFilename(version string) string {
 }
 
 // downloadAsset fetches the asset and extracts the rc binary to a temp file.
-func downloadAsset(url, assetName string) (string, error) {
-	resp, err := http.Get(url) //nolint:noctx
+func downloadAsset(ctx context.Context, url, assetName string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := updateHTTPClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -185,25 +202,28 @@ func downloadAsset(url, assetName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer tmp.Close()
+	tmpName := tmp.Name()
 
 	if strings.HasSuffix(assetName, ".zip") {
 		// Write zip to disk first since zip.NewReader needs io.ReaderAt.
-		if _, err := io.Copy(tmp, resp.Body); err != nil {
-			os.Remove(tmp.Name())
+		_, copyErr := io.Copy(tmp, resp.Body)
+		tmp.Close()
+		if copyErr != nil {
+			os.Remove(tmpName)
+			return "", copyErr
+		}
+		if err := extractFromZip(tmpName); err != nil {
+			os.Remove(tmpName)
 			return "", err
 		}
-		if err := extractFromZip(tmp.Name()); err != nil {
-			os.Remove(tmp.Name())
-			return "", err
-		}
-		return tmp.Name(), nil
+		return tmpName, nil
 	}
 
-	// tar.gz
+	// tar.gz — extract directly into tmp
 	gz, err := gzip.NewReader(resp.Body)
 	if err != nil {
-		os.Remove(tmp.Name())
+		tmp.Close()
+		os.Remove(tmpName)
 		return "", err
 	}
 	defer gz.Close()
@@ -215,19 +235,23 @@ func downloadAsset(url, assetName string) (string, error) {
 			break
 		}
 		if err != nil {
-			os.Remove(tmp.Name())
+			tmp.Close()
+			os.Remove(tmpName)
 			return "", err
 		}
 		if filepath.Base(hdr.Name) == "rc" && hdr.Typeflag == tar.TypeReg {
 			if _, err := io.Copy(tmp, tr); err != nil {
-				os.Remove(tmp.Name())
+				tmp.Close()
+				os.Remove(tmpName)
 				return "", err
 			}
-			return tmp.Name(), nil
+			tmp.Close()
+			return tmpName, nil
 		}
 	}
 
-	os.Remove(tmp.Name())
+	tmp.Close()
+	os.Remove(tmpName)
 	return "", fmt.Errorf("rc binary not found in archive")
 }
 
@@ -238,30 +262,46 @@ func extractFromZip(path string) error {
 	if err != nil {
 		return err
 	}
-	defer r.Close()
 
+	var found bool
+	var tmpName string
 	for _, f := range r.File {
 		if filepath.Base(f.Name) == "rc.exe" || filepath.Base(f.Name) == "rc" {
 			rc, err := f.Open()
 			if err != nil {
+				r.Close()
 				return err
 			}
-			defer rc.Close()
-
 			tmp, err := os.CreateTemp(filepath.Dir(path), "rc-zip-*")
 			if err != nil {
+				rc.Close()
+				r.Close()
 				return err
 			}
-			if _, err := io.Copy(tmp, rc); err != nil {
-				tmp.Close()
-				os.Remove(tmp.Name())
-				return err
-			}
+			_, copyErr := io.Copy(tmp, rc)
+			rc.Close()
 			tmp.Close()
-			return os.Rename(tmp.Name(), path)
+			if copyErr != nil {
+				os.Remove(tmp.Name())
+				r.Close()
+				return copyErr
+			}
+			tmpName = tmp.Name()
+			found = true
+			break
 		}
 	}
-	return fmt.Errorf("rc binary not found in zip archive")
+	// Close the zip reader before renaming so we don't hold the file open.
+	r.Close()
+
+	if !found {
+		return fmt.Errorf("rc binary not found in zip archive")
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return nil
 }
 
 // installBinary atomically replaces the current binary with the extracted one.
@@ -274,8 +314,7 @@ func installBinary(srcPath, destPath string) error {
 	dir := filepath.Dir(destPath)
 	tmp, err := os.CreateTemp(dir, ".rc-update-*")
 	if err != nil {
-		// Fall back: dest dir may not be writable; try a direct rename.
-		return os.Rename(srcPath, destPath)
+		return fmt.Errorf("cannot write to %s (check permissions): %w", dir, err)
 	}
 	tmp.Close()
 	os.Remove(tmp.Name())

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -38,6 +38,15 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 			currentVersion := cmd.Root().Version
 
 			if currentVersion == "dev" {
+				if rt.Globals.JSON {
+					return rt.Out.Render(map[string]any{
+						"installed_version": "dev",
+						"latest_version":    "",
+						"up_to_date":        true,
+						"updated":           false,
+						"development_build": true,
+					})
+				}
 				rt.Out.Info("Running development build — skipping update.")
 				return nil
 			}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,40 +1,18 @@
 package cli
 
 import (
-	"archive/tar"
-	"archive/zip"
-	"compress/gzip"
-	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/revenuecat/cli/internal/tui"
+	"github.com/revenuecat/cli/internal/updater"
 )
-
-const githubReleasesURL = "https://api.github.com/repos/RevenueCat/revenuecat-cli/releases/latest"
-
-var errUpdateAvailable = errors.New("update available")
-
-type githubRelease struct {
-	TagName string        `json:"tag_name"`
-	Assets  []githubAsset `json:"assets"`
-	HTMLURL string        `json:"html_url"`
-}
-
-type githubAsset struct {
-	Name               string `json:"name"`
-	BrowserDownloadURL string `json:"browser_download_url"`
-}
 
 func newUpdateCmd() *cobra.Command {
 	var checkOnly bool
@@ -64,18 +42,17 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 				return nil
 			}
 
-			rt.Out.Info("Checking for updates…")
 			hc := &http.Client{Timeout: 30 * time.Second}
-			release, err := fetchLatestRelease(cmd.Context(), hc)
+
+			rt.Out.Info("Checking for updates…")
+			release, err := updater.FetchRelease(cmd.Context(), hc)
 			if err != nil {
 				return fmt.Errorf("checking for updates: %w", err)
 			}
 
-			latestTag := release.TagName
-			latestVersion := strings.TrimPrefix(latestTag, "v")
+			latestVersion := release.Version()
 
-			// Guard against downgrades (e.g. snapshot/pre-release tags).
-			if !isNewer(latestVersion, currentVersion) {
+			if !updater.IsNewer(latestVersion, currentVersion) {
 				if rt.Globals.JSON {
 					return rt.Out.Render(map[string]any{
 						"current_version": currentVersion,
@@ -91,6 +68,8 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 
 			if checkOnly {
 				if rt.Globals.JSON {
+					// Write the JSON result to stdout, then return SilentExitError so
+					// run.go exits 1 without also emitting a JSON error envelope.
 					if err := rt.Out.Render(map[string]any{
 						"current_version": currentVersion,
 						"latest_version":  latestVersion,
@@ -98,8 +77,9 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 					}); err != nil {
 						return err
 					}
+					return &SilentExitError{Code: 1}
 				}
-				return fmt.Errorf("%w: %s (current: %s)", errUpdateAvailable, latestVersion, currentVersion)
+				return fmt.Errorf("update available: %s (current: %s)", latestVersion, currentVersion)
 			}
 
 			if !rt.Globals.AssumeYes {
@@ -113,21 +93,8 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 				}
 			}
 
-			assetName := assetFilename(latestVersion)
-			downloadURL := ""
-			for _, a := range release.Assets {
-				if a.Name == assetName {
-					downloadURL = a.BrowserDownloadURL
-					break
-				}
-			}
-			if downloadURL == "" {
-				return fmt.Errorf("no release asset found for %s/%s (looked for %q) — download manually: %s",
-					runtime.GOOS, runtime.GOARCH, assetName, release.HTMLURL)
-			}
-
-			rt.Out.Info(fmt.Sprintf("Downloading %s…", assetName))
-			tmpPath, err := downloadAsset(cmd.Context(), hc, downloadURL, assetName)
+			rt.Out.Info(fmt.Sprintf("Downloading %s…", release.AssetName(runtime.GOOS, runtime.GOARCH)))
+			tmpPath, err := updater.DownloadBinary(cmd.Context(), hc, release, runtime.GOOS, runtime.GOARCH)
 			if err != nil {
 				return fmt.Errorf("downloading update: %w", err)
 			}
@@ -142,7 +109,7 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 				return fmt.Errorf("resolving binary path: %w", err)
 			}
 
-			if err := installBinary(tmpPath, execPath); err != nil {
+			if err := updater.Install(tmpPath, execPath); err != nil {
 				return fmt.Errorf("installing update: %w", err)
 			}
 
@@ -160,246 +127,4 @@ https://github.com/RevenueCat/revenuecat-cli/releases`,
 
 	cmd.Flags().BoolVar(&checkOnly, "check", false, "check for updates without installing; exit 1 if update is available")
 	return cmd
-}
-
-// isNewer returns true only when latest is strictly greater than current using
-// simple semver comparison. Returns false for equal or unparseable versions so
-// we never downgrade.
-func isNewer(latest, current string) bool {
-	lp := parseSemver(latest)
-	cp := parseSemver(current)
-	if lp == nil || cp == nil {
-		// Can't parse — treat as equal to avoid unintended updates.
-		return false
-	}
-	if lp[0] != cp[0] {
-		return lp[0] > cp[0]
-	}
-	if lp[1] != cp[1] {
-		return lp[1] > cp[1]
-	}
-	return lp[2] > cp[2]
-}
-
-// parseSemver parses "X.Y.Z" or "vX.Y.Z" into [major, minor, patch].
-func parseSemver(v string) []int {
-	v = strings.TrimPrefix(v, "v")
-	parts := strings.SplitN(v, ".", 3)
-	if len(parts) != 3 {
-		return nil
-	}
-	nums := make([]int, 3)
-	for i, p := range parts {
-		// Stop at any pre-release suffix (e.g. "0-next").
-		p, _, _ = strings.Cut(p, "-")
-		n := 0
-		for _, c := range p {
-			if c < '0' || c > '9' {
-				return nil
-			}
-			n = n*10 + int(c-'0')
-		}
-		nums[i] = n
-	}
-	return nums
-}
-
-func fetchLatestRelease(ctx context.Context, hc *http.Client) (*githubRelease, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubReleasesURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	req.Header.Set("User-Agent", "revenuecat-cli")
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return nil, fmt.Errorf("GitHub API returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
-	}
-
-	var release githubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, err
-	}
-	return &release, nil
-}
-
-func assetFilename(version string) string {
-	goos := runtime.GOOS
-	goarch := runtime.GOARCH
-	if goos == "windows" {
-		return fmt.Sprintf("rc_%s_%s_%s.zip", version, goos, goarch)
-	}
-	return fmt.Sprintf("rc_%s_%s_%s.tar.gz", version, goos, goarch)
-}
-
-// downloadAsset fetches the asset and extracts the rc binary to a temp file.
-func downloadAsset(ctx context.Context, hc *http.Client, url, assetName string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return "", err
-	}
-	resp, err := hc.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("download returned %s", resp.Status)
-	}
-
-	tmp, err := os.CreateTemp("", "rc-update-*")
-	if err != nil {
-		return "", err
-	}
-	tmpName := tmp.Name()
-
-	if strings.HasSuffix(assetName, ".zip") {
-		// Write zip to disk first since zip.NewReader needs io.ReaderAt.
-		_, copyErr := io.Copy(tmp, resp.Body)
-		tmp.Close()
-		if copyErr != nil {
-			os.Remove(tmpName)
-			return "", copyErr
-		}
-		if err := extractFromZip(tmpName); err != nil {
-			os.Remove(tmpName)
-			return "", err
-		}
-		return tmpName, nil
-	}
-
-	// tar.gz — extract directly into tmp
-	gz, err := gzip.NewReader(resp.Body)
-	if err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
-		return "", err
-	}
-	defer gz.Close()
-
-	tr := tar.NewReader(gz)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			tmp.Close()
-			os.Remove(tmpName)
-			return "", err
-		}
-		if filepath.Base(hdr.Name) == "rc" && hdr.Typeflag == tar.TypeReg {
-			if _, err := io.Copy(tmp, tr); err != nil {
-				tmp.Close()
-				os.Remove(tmpName)
-				return "", err
-			}
-			tmp.Close()
-			return tmpName, nil
-		}
-	}
-
-	tmp.Close()
-	os.Remove(tmpName)
-	return "", fmt.Errorf("rc binary not found in archive")
-}
-
-// extractFromZip reads a zip already written to path and overwrites it with
-// the extracted rc binary.
-func extractFromZip(path string) error {
-	r, err := zip.OpenReader(path)
-	if err != nil {
-		return err
-	}
-
-	var found bool
-	var tmpName string
-	for _, f := range r.File {
-		if filepath.Base(f.Name) == "rc.exe" || filepath.Base(f.Name) == "rc" {
-			rc, err := f.Open()
-			if err != nil {
-				r.Close()
-				return err
-			}
-			tmp, err := os.CreateTemp(filepath.Dir(path), "rc-zip-*")
-			if err != nil {
-				rc.Close()
-				r.Close()
-				return err
-			}
-			_, copyErr := io.Copy(tmp, rc)
-			rc.Close()
-			tmp.Close()
-			if copyErr != nil {
-				os.Remove(tmp.Name())
-				r.Close()
-				return copyErr
-			}
-			tmpName = tmp.Name()
-			found = true
-			break
-		}
-	}
-	// Close the zip reader before renaming so we don't hold the file open.
-	r.Close()
-
-	if !found {
-		return fmt.Errorf("rc binary not found in zip archive")
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		os.Remove(tmpName)
-		return err
-	}
-	return nil
-}
-
-// installBinary atomically replaces the current binary with the extracted one.
-func installBinary(srcPath, destPath string) error {
-	if err := os.Chmod(srcPath, 0755); err != nil {
-		return err
-	}
-
-	// Write to a sibling temp file so Rename is atomic on the same filesystem.
-	dir := filepath.Dir(destPath)
-	tmp, err := os.CreateTemp(dir, ".rc-update-*")
-	if err != nil {
-		return fmt.Errorf("cannot write to %s (check permissions): %w", dir, err)
-	}
-	tmp.Close()
-	os.Remove(tmp.Name())
-
-	if err := copyFile(srcPath, tmp.Name()); err != nil {
-		return err
-	}
-	if err := os.Chmod(tmp.Name(), 0755); err != nil {
-		os.Remove(tmp.Name())
-		return err
-	}
-	return os.Rename(tmp.Name(), destPath)
-}
-
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, in)
-	return err
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -8,19 +8,14 @@ import (
 	"testing"
 
 	"github.com/revenuecat/cli/internal/cli"
-	"github.com/revenuecat/cli/internal/updater"
 )
 
-// serveRelease starts a test server that returns the given release JSON and
-// optionally serves the archive at /download. It sets updater.ReleasesURL and
-// restores the original value via t.Cleanup.
-func serveRelease(t *testing.T, tagName string, archiveData []byte) *httptest.Server {
+// serveRelease starts a test server returning the given release JSON and sets
+// RC_UPDATER_RELEASES_URL so the update command picks it up without any
+// package-level state mutation.
+func serveRelease(t *testing.T, tagName string) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/download" {
-			w.Write(archiveData)
-			return
-		}
 		json.NewEncoder(w).Encode(map[string]any{
 			"tag_name": tagName,
 			"html_url": "https://github.com/example",
@@ -30,25 +25,19 @@ func serveRelease(t *testing.T, tagName string, archiveData []byte) *httptest.Se
 			}},
 		})
 	}))
-	orig := updater.ReleasesURL
-	updater.ReleasesURL = srv.URL
-	t.Cleanup(func() {
-		srv.Close()
-		updater.ReleasesURL = orig
-	})
+	t.Setenv("RC_UPDATER_RELEASES_URL", srv.URL)
+	t.Cleanup(srv.Close)
 	return srv
 }
 
 // TestUpdate_DevBuild_JSON verifies that a dev build emits JSON with
 // development_build=true and exits 0 — not silence.
 func TestUpdate_DevBuild_JSON(t *testing.T) {
-	// Use version "dev" (the default for NewRootCmd("dev")).
 	t.Setenv("RC_CONFIG_DIR", t.TempDir())
 	var out, errBuf bytes.Buffer
 	root := newRootWithBuffers(t, "dev", &out, &errBuf)
 	root.SetArgs([]string{"update", "--json"})
-	err := root.Execute()
-	if err != nil {
+	if err := root.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if errBuf.Len() != 0 {
@@ -73,13 +62,11 @@ func TestUpdate_DevBuild_JSON(t *testing.T) {
 }
 
 // TestUpdate_UpToDate_JSON verifies the up-to-date JSON shape.
+// runCmd uses version "test" (non-semver) so IsNewer returns false.
 func TestUpdate_UpToDate_JSON(t *testing.T) {
-	serveRelease(t, "v1.2.3", nil)
-	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	serveRelease(t, "v1.2.3")
 
 	out, errb, err := runCmd(t, "update", "--json")
-	// runCmd uses version "test" which is not a valid semver, so IsNewer returns
-	// false and we get the up-to-date path.
 	if err != nil {
 		t.Fatalf("unexpected error: %v\nstderr: %s", err, errb)
 	}
@@ -104,30 +91,22 @@ func TestUpdate_UpToDate_JSON(t *testing.T) {
 	}
 }
 
-// TestUpdate_Check_UpdateAvailable_JSON verifies that --check --json writes one
-// JSON document to stdout and exits 1, with nothing on stderr (no second
-// error envelope).
+// TestUpdate_Check_UpdateAvailable_JSON verifies --check --json writes exactly
+// one JSON document to stdout and exits 1 with nothing on stderr.
 func TestUpdate_Check_UpdateAvailable_JSON(t *testing.T) {
-	serveRelease(t, "v9.9.9", nil)
-	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	serveRelease(t, "v9.9.9")
 
-	// runCmd uses version "test" (non-semver) so IsNewer("9.9.9","test")=false
-	// and we get the up-to-date path. We need a real semver current version.
-	// Use a fresh root with version "1.0.0".
 	var out, errBuf bytes.Buffer
 	root := newRootWithBuffers(t, "1.0.0", &out, &errBuf)
 	root.SetArgs([]string{"update", "--check", "--json"})
 	execErr := root.Execute()
 
-	// Should exit non-zero.
 	if execErr == nil {
 		t.Fatal("want non-zero exit for --check when update is available")
 	}
-	// stderr must be empty — no second JSON error envelope.
 	if errBuf.Len() != 0 {
 		t.Errorf("--check --json must not write to stderr; got %q", errBuf.String())
 	}
-	// stdout must be valid JSON with up_to_date=false.
 	var got struct {
 		Data struct {
 			UpToDate  bool   `json:"up_to_date"`
@@ -146,17 +125,15 @@ func TestUpdate_Check_UpdateAvailable_JSON(t *testing.T) {
 	}
 }
 
-// TestUpdate_Check_UpdateAvailable_Human verifies the human-mode --check path
-// exits non-zero with an informative message.
+// TestUpdate_Check_UpdateAvailable_Human verifies human-mode --check exits 1
+// with nothing on stdout.
 func TestUpdate_Check_UpdateAvailable_Human(t *testing.T) {
-	serveRelease(t, "v9.9.9", nil)
-	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	serveRelease(t, "v9.9.9")
 
 	var out, errBuf bytes.Buffer
 	root := newRootWithBuffers(t, "1.0.0", &out, &errBuf)
 	root.SetArgs([]string{"update", "--check"})
-	err := root.Execute()
-	if err == nil {
+	if err := root.Execute(); err == nil {
 		t.Fatal("want non-zero exit")
 	}
 	if out.Len() != 0 {
@@ -164,11 +141,10 @@ func TestUpdate_Check_UpdateAvailable_Human(t *testing.T) {
 	}
 }
 
-// TestUpdate_ConsistentJSONSchema verifies that installed_version/latest_version/
-// up_to_date/updated are present in all JSON output paths.
+// TestUpdate_ConsistentJSONSchema verifies the four stable keys are present
+// on every JSON output path.
 func TestUpdate_ConsistentJSONSchema(t *testing.T) {
-	serveRelease(t, "v1.0.0", nil)
-	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	serveRelease(t, "v1.0.0")
 
 	out, errb, err := runCmd(t, "update", "--json")
 	if err != nil {
@@ -187,8 +163,7 @@ func TestUpdate_ConsistentJSONSchema(t *testing.T) {
 	}
 }
 
-// newRootWithBuffers builds a root command wired to explicit buffers so tests
-// can capture output independently of runCmd's version string.
+// newRootWithBuffers builds a root command wired to explicit output buffers.
 func newRootWithBuffers(t *testing.T, version string, out, errBuf *bytes.Buffer) interface {
 	SetArgs([]string)
 	Execute() error

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -1,0 +1,206 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/cli"
+	"github.com/revenuecat/cli/internal/updater"
+)
+
+// serveRelease starts a test server that returns the given release JSON and
+// optionally serves the archive at /download. It sets updater.ReleasesURL and
+// restores the original value via t.Cleanup.
+func serveRelease(t *testing.T, tagName string, archiveData []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/download" {
+			w.Write(archiveData)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"tag_name": tagName,
+			"html_url": "https://github.com/example",
+			"assets": []map[string]any{{
+				"name":                 "rc_" + tagName[1:] + "_darwin_arm64.tar.gz",
+				"browser_download_url": "http://" + r.Host + "/download",
+			}},
+		})
+	}))
+	orig := updater.ReleasesURL
+	updater.ReleasesURL = srv.URL
+	t.Cleanup(func() {
+		srv.Close()
+		updater.ReleasesURL = orig
+	})
+	return srv
+}
+
+// TestUpdate_DevBuild_JSON verifies that a dev build emits JSON with
+// development_build=true and exits 0 — not silence.
+func TestUpdate_DevBuild_JSON(t *testing.T) {
+	// Use version "dev" (the default for NewRootCmd("dev")).
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	var out, errBuf bytes.Buffer
+	root := newRootWithBuffers(t, "dev", &out, &errBuf)
+	root.SetArgs([]string{"update", "--json"})
+	err := root.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if errBuf.Len() != 0 {
+		t.Errorf("--json must not write to stderr; got %q", errBuf.String())
+	}
+	var got struct {
+		Data struct {
+			DevBuild  bool   `json:"development_build"`
+			UpToDate  bool   `json:"up_to_date"`
+			Installed string `json:"installed_version"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, out.String())
+	}
+	if !got.Data.DevBuild {
+		t.Error("want development_build=true")
+	}
+	if !got.Data.UpToDate {
+		t.Error("want up_to_date=true for dev build")
+	}
+}
+
+// TestUpdate_UpToDate_JSON verifies the up-to-date JSON shape.
+func TestUpdate_UpToDate_JSON(t *testing.T) {
+	serveRelease(t, "v1.2.3", nil)
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+
+	out, errb, err := runCmd(t, "update", "--json")
+	// runCmd uses version "test" which is not a valid semver, so IsNewer returns
+	// false and we get the up-to-date path.
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr: %s", err, errb)
+	}
+	if errb != "" {
+		t.Errorf("--json must not write to stderr; got %q", errb)
+	}
+	var got struct {
+		Data struct {
+			UpToDate  bool   `json:"up_to_date"`
+			Installed string `json:"installed_version"`
+			Latest    string `json:"latest_version"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, out)
+	}
+	if !got.Data.UpToDate {
+		t.Errorf("want up_to_date=true, got false")
+	}
+	if got.Data.Latest != "1.2.3" {
+		t.Errorf("want latest_version=1.2.3, got %q", got.Data.Latest)
+	}
+}
+
+// TestUpdate_Check_UpdateAvailable_JSON verifies that --check --json writes one
+// JSON document to stdout and exits 1, with nothing on stderr (no second
+// error envelope).
+func TestUpdate_Check_UpdateAvailable_JSON(t *testing.T) {
+	serveRelease(t, "v9.9.9", nil)
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+
+	// runCmd uses version "test" (non-semver) so IsNewer("9.9.9","test")=false
+	// and we get the up-to-date path. We need a real semver current version.
+	// Use a fresh root with version "1.0.0".
+	var out, errBuf bytes.Buffer
+	root := newRootWithBuffers(t, "1.0.0", &out, &errBuf)
+	root.SetArgs([]string{"update", "--check", "--json"})
+	execErr := root.Execute()
+
+	// Should exit non-zero.
+	if execErr == nil {
+		t.Fatal("want non-zero exit for --check when update is available")
+	}
+	// stderr must be empty — no second JSON error envelope.
+	if errBuf.Len() != 0 {
+		t.Errorf("--check --json must not write to stderr; got %q", errBuf.String())
+	}
+	// stdout must be valid JSON with up_to_date=false.
+	var got struct {
+		Data struct {
+			UpToDate  bool   `json:"up_to_date"`
+			Installed string `json:"installed_version"`
+			Latest    string `json:"latest_version"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, out.String())
+	}
+	if got.Data.UpToDate {
+		t.Error("want up_to_date=false")
+	}
+	if got.Data.Latest != "9.9.9" {
+		t.Errorf("want latest_version=9.9.9, got %q", got.Data.Latest)
+	}
+}
+
+// TestUpdate_Check_UpdateAvailable_Human verifies the human-mode --check path
+// exits non-zero with an informative message.
+func TestUpdate_Check_UpdateAvailable_Human(t *testing.T) {
+	serveRelease(t, "v9.9.9", nil)
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+
+	var out, errBuf bytes.Buffer
+	root := newRootWithBuffers(t, "1.0.0", &out, &errBuf)
+	root.SetArgs([]string{"update", "--check"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("want non-zero exit")
+	}
+	if out.Len() != 0 {
+		t.Errorf("human mode should not write to stdout; got %q", out.String())
+	}
+}
+
+// TestUpdate_ConsistentJSONSchema verifies that installed_version/latest_version/
+// up_to_date/updated are present in all JSON output paths.
+func TestUpdate_ConsistentJSONSchema(t *testing.T) {
+	serveRelease(t, "v1.0.0", nil)
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+
+	out, errb, err := runCmd(t, "update", "--json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr: %s", err, errb)
+	}
+	var got struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	for _, key := range []string{"installed_version", "latest_version", "up_to_date", "updated"} {
+		if _, ok := got.Data[key]; !ok {
+			t.Errorf("JSON output missing key %q", key)
+		}
+	}
+}
+
+// newRootWithBuffers builds a root command wired to explicit buffers so tests
+// can capture output independently of runCmd's version string.
+func newRootWithBuffers(t *testing.T, version string, out, errBuf *bytes.Buffer) interface {
+	SetArgs([]string)
+	Execute() error
+} {
+	t.Helper()
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	t.Setenv("RC_API_KEY", "")
+	t.Setenv("RC_PROJECT_ID", "")
+	t.Setenv("RC_BASE_URL", "")
+	t.Setenv("RC_PROFILE", "")
+	root := cli.NewRootCmd(version)
+	root.SetOut(out)
+	root.SetErr(errBuf)
+	return root
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -37,103 +37,8 @@ func (r *Release) AssetName(goos, goarch string) string {
 	return archiveName(r.Version(), goos, goarch)
 }
 
-// LatestVersion returns the version string (without leading "v") of the latest
-// published release.
-func LatestVersion(ctx context.Context, hc *http.Client) (string, error) {
-	r, err := fetchRelease(ctx, hc)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimPrefix(r.TagName, "v"), nil
-}
-
-// DownloadBinary fetches the release asset matching goos/goarch, extracts the
-// rc binary, and returns the path to a temporary file. The caller must remove
-// it when done.
-func DownloadBinary(ctx context.Context, hc *http.Client, r *Release, goos, goarch string) (string, error) {
-	assetName := archiveName(strings.TrimPrefix(r.TagName, "v"), goos, goarch)
-	url := ""
-	for _, a := range r.Assets {
-		if a.Name == assetName {
-			url = a.BrowserDownloadURL
-			break
-		}
-	}
-	if url == "" {
-		return "", fmt.Errorf("no release asset for %s/%s (looked for %q) — download manually: %s",
-			goos, goarch, assetName, r.HTMLURL)
-	}
-	return downloadBinary(ctx, hc, url)
-}
-
 // FetchRelease returns the latest release metadata.
 func FetchRelease(ctx context.Context, hc *http.Client) (*Release, error) {
-	return fetchRelease(ctx, hc)
-}
-
-// Install atomically replaces destPath with the binary at srcPath.
-func Install(srcPath, destPath string) error {
-	if err := os.Chmod(srcPath, 0755); err != nil {
-		return err
-	}
-	dir := filepath.Dir(destPath)
-	tmp, err := os.CreateTemp(dir, ".rc-update-*")
-	if err != nil {
-		return fmt.Errorf("cannot write to %s (check permissions): %w", dir, err)
-	}
-	tmp.Close()
-	os.Remove(tmp.Name())
-
-	if err := copyFile(srcPath, tmp.Name()); err != nil {
-		return err
-	}
-	if err := os.Chmod(tmp.Name(), 0755); err != nil {
-		os.Remove(tmp.Name())
-		return err
-	}
-	return os.Rename(tmp.Name(), destPath)
-}
-
-// IsNewer reports whether latest is strictly greater than current using semver.
-// Returns false when versions are equal, unparseable, or latest looks like a
-// pre-release/snapshot relative to current.
-func IsNewer(latest, current string) bool {
-	lp := parseSemver(latest)
-	cp := parseSemver(current)
-	if lp == nil || cp == nil {
-		return false
-	}
-	if lp[0] != cp[0] {
-		return lp[0] > cp[0]
-	}
-	if lp[1] != cp[1] {
-		return lp[1] > cp[1]
-	}
-	return lp[2] > cp[2]
-}
-
-func parseSemver(v string) []int {
-	v = strings.TrimPrefix(v, "v")
-	parts := strings.SplitN(v, ".", 3)
-	if len(parts) != 3 {
-		return nil
-	}
-	nums := make([]int, 3)
-	for i, p := range parts {
-		p, _, _ = strings.Cut(p, "-")
-		n := 0
-		for _, c := range p {
-			if c < '0' || c > '9' {
-				return nil
-			}
-			n = n*10 + int(c-'0')
-		}
-		nums[i] = n
-	}
-	return nums
-}
-
-func fetchRelease(ctx context.Context, hc *http.Client) (*Release, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesURL, nil)
 	if err != nil {
 		return nil, err
@@ -160,6 +65,118 @@ func fetchRelease(ctx context.Context, hc *http.Client) (*Release, error) {
 	return &r, nil
 }
 
+// DownloadBinary fetches the release asset matching goos/goarch, extracts the
+// rc binary, and returns the path to a temporary file. The caller must remove
+// it when done. Returns an error for Windows (zip format not supported).
+func DownloadBinary(ctx context.Context, hc *http.Client, r *Release, goos, goarch string) (string, error) {
+	if goos == "windows" {
+		return "", fmt.Errorf("DownloadBinary does not support Windows — download manually: %s", r.HTMLURL)
+	}
+	assetName := archiveName(r.Version(), goos, goarch)
+	url := ""
+	for _, a := range r.Assets {
+		if a.Name == assetName {
+			url = a.BrowserDownloadURL
+			break
+		}
+	}
+	if url == "" {
+		return "", fmt.Errorf("no release asset for %s/%s (looked for %q) — download manually: %s",
+			goos, goarch, assetName, r.HTMLURL)
+	}
+	return downloadTarGz(ctx, hc, url)
+}
+
+// Install atomically replaces destPath with the binary at srcPath.
+func Install(srcPath, destPath string) error {
+	if err := os.Chmod(srcPath, 0755); err != nil {
+		return err
+	}
+	dir := filepath.Dir(destPath)
+	tmp, err := os.CreateTemp(dir, ".rc-update-*")
+	if err != nil {
+		return fmt.Errorf("cannot write to %s (check permissions): %w", dir, err)
+	}
+	tmpName := tmp.Name()
+
+	// Clean up the temp file on any failure path.
+	installed := false
+	defer func() {
+		if !installed {
+			os.Remove(tmpName)
+		}
+	}()
+
+	// Write directly into the temp file we just created — no TOCTOU gap.
+	src, err := os.Open(srcPath)
+	if err != nil {
+		tmp.Close()
+		return err
+	}
+	_, copyErr := io.Copy(tmp, src)
+	src.Close()
+	if err := tmp.Close(); err != nil && copyErr == nil {
+		copyErr = err
+	}
+	if copyErr != nil {
+		return copyErr
+	}
+
+	if err := os.Chmod(tmpName, 0755); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, destPath); err != nil {
+		return err
+	}
+	installed = true
+	return nil
+}
+
+// IsNewer reports whether latest is strictly greater than current.
+//
+// Pre-release handling: if the numeric parts are equal and current has a
+// pre-release suffix while latest does not, latest is considered newer (a
+// stable release supersedes its own pre-release). If latest has a pre-release
+// suffix and current does not, we never downgrade.
+func IsNewer(latest, current string) bool {
+	latestNums, latestPre := parseSemver(latest)
+	currentNums, currentPre := parseSemver(current)
+	if latestNums == nil || currentNums == nil {
+		return false
+	}
+	for i := range 3 {
+		if latestNums[i] != currentNums[i] {
+			return latestNums[i] > currentNums[i]
+		}
+	}
+	// Numeric parts are equal — a stable release is newer than a pre-release.
+	return currentPre && !latestPre
+}
+
+// parseSemver parses "X.Y.Z" or "vX.Y.Z[-pre]" and returns ([major,minor,patch], hasPre).
+func parseSemver(v string) ([]int, bool) {
+	v = strings.TrimPrefix(v, "v")
+	// Split off pre-release suffix before splitting on dots.
+	core, pre, _ := strings.Cut(v, "-")
+	hasPre := pre != ""
+	parts := strings.SplitN(core, ".", 3)
+	if len(parts) != 3 {
+		return nil, false
+	}
+	nums := make([]int, 3)
+	for i, p := range parts {
+		n := 0
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return nil, false
+			}
+			n = n*10 + int(c-'0')
+		}
+		nums[i] = n
+	}
+	return nums, hasPre
+}
+
 func archiveName(version, goos, goarch string) string {
 	if goos == "windows" {
 		return fmt.Sprintf("rc_%s_%s_%s.zip", version, goos, goarch)
@@ -167,9 +184,8 @@ func archiveName(version, goos, goarch string) string {
 	return fmt.Sprintf("rc_%s_%s_%s.tar.gz", version, goos, goarch)
 }
 
-// downloadBinary downloads the archive at url and extracts only the rc binary
-// to a temp file.
-func downloadBinary(ctx context.Context, hc *http.Client, url string) (string, error) {
+// downloadTarGz downloads the tar.gz at url and extracts only the rc binary.
+func downloadTarGz(ctx context.Context, hc *http.Client, url string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", err
@@ -225,21 +241,4 @@ func downloadBinary(ctx context.Context, hc *http.Client, url string) (string, e
 	tmp.Close()
 	os.Remove(tmpName)
 	return "", fmt.Errorf("rc binary not found in archive")
-}
-
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, in)
-	return err
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -14,7 +14,9 @@ import (
 	"strings"
 )
 
-const releasesURL = "https://api.github.com/repos/RevenueCat/revenuecat-cli/releases/latest"
+// ReleasesURL is the GitHub API endpoint for the latest release. Tests may
+// override this to point at an httptest.Server.
+var ReleasesURL = "https://api.github.com/repos/RevenueCat/revenuecat-cli/releases/latest"
 
 // maxBinaryBytes is a sanity cap on the extracted binary size (64 MiB).
 const maxBinaryBytes = 64 << 20
@@ -42,7 +44,7 @@ func (r *Release) AssetName(goos, goarch string) string {
 
 // FetchRelease returns the latest release metadata.
 func FetchRelease(ctx context.Context, hc *http.Client) (*Release, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ReleasesURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -16,6 +16,9 @@ import (
 
 const releasesURL = "https://api.github.com/repos/RevenueCat/revenuecat-cli/releases/latest"
 
+// maxBinaryBytes is a sanity cap on the extracted binary size (64 MiB).
+const maxBinaryBytes = 64 << 20
+
 type Release struct {
 	TagName string  `json:"tag_name"`
 	HTMLURL string  `json:"html_url"`
@@ -225,13 +228,22 @@ func downloadTarGz(ctx context.Context, hc *http.Client, url string) (string, er
 			os.Remove(tmpName)
 			return "", err
 		}
-		// Accept only the top-level binary; reject path traversal attempts.
-		if filepath.Base(hdr.Name) == "rc" && hdr.Typeflag == tar.TypeReg &&
-			!strings.Contains(hdr.Name, "..") {
-			if _, err := io.Copy(tmp, tr); err != nil {
+		// Accept only a true top-level "rc" entry: no path separators and no
+		// dot-dot components, so nested paths like "bin/rc" are rejected.
+		clean := filepath.Clean(hdr.Name)
+		isTopLevel := clean == "rc" || clean == filepath.Base(clean) && !strings.ContainsAny(hdr.Name, "/\\")
+		if isTopLevel && filepath.Base(hdr.Name) == "rc" && hdr.Typeflag == tar.TypeReg {
+			lr := io.LimitReader(tr, maxBinaryBytes+1)
+			n, err := io.Copy(tmp, lr)
+			if err != nil {
 				tmp.Close()
 				os.Remove(tmpName)
 				return "", err
+			}
+			if n > maxBinaryBytes {
+				tmp.Close()
+				os.Remove(tmpName)
+				return "", fmt.Errorf("binary exceeds maximum allowed size (%d MiB)", maxBinaryBytes>>20)
 			}
 			tmp.Close()
 			return tmpName, nil

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,245 @@
+// Package updater fetches and installs rc releases from GitHub.
+package updater
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const releasesURL = "https://api.github.com/repos/RevenueCat/revenuecat-cli/releases/latest"
+
+type Release struct {
+	TagName string  `json:"tag_name"`
+	HTMLURL string  `json:"html_url"`
+	Assets  []Asset `json:"assets"`
+}
+
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// Version returns the release version without the leading "v".
+func (r *Release) Version() string {
+	return strings.TrimPrefix(r.TagName, "v")
+}
+
+// AssetName returns the expected archive filename for the given platform.
+func (r *Release) AssetName(goos, goarch string) string {
+	return archiveName(r.Version(), goos, goarch)
+}
+
+// LatestVersion returns the version string (without leading "v") of the latest
+// published release.
+func LatestVersion(ctx context.Context, hc *http.Client) (string, error) {
+	r, err := fetchRelease(ctx, hc)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(r.TagName, "v"), nil
+}
+
+// DownloadBinary fetches the release asset matching goos/goarch, extracts the
+// rc binary, and returns the path to a temporary file. The caller must remove
+// it when done.
+func DownloadBinary(ctx context.Context, hc *http.Client, r *Release, goos, goarch string) (string, error) {
+	assetName := archiveName(strings.TrimPrefix(r.TagName, "v"), goos, goarch)
+	url := ""
+	for _, a := range r.Assets {
+		if a.Name == assetName {
+			url = a.BrowserDownloadURL
+			break
+		}
+	}
+	if url == "" {
+		return "", fmt.Errorf("no release asset for %s/%s (looked for %q) — download manually: %s",
+			goos, goarch, assetName, r.HTMLURL)
+	}
+	return downloadBinary(ctx, hc, url)
+}
+
+// FetchRelease returns the latest release metadata.
+func FetchRelease(ctx context.Context, hc *http.Client) (*Release, error) {
+	return fetchRelease(ctx, hc)
+}
+
+// Install atomically replaces destPath with the binary at srcPath.
+func Install(srcPath, destPath string) error {
+	if err := os.Chmod(srcPath, 0755); err != nil {
+		return err
+	}
+	dir := filepath.Dir(destPath)
+	tmp, err := os.CreateTemp(dir, ".rc-update-*")
+	if err != nil {
+		return fmt.Errorf("cannot write to %s (check permissions): %w", dir, err)
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+
+	if err := copyFile(srcPath, tmp.Name()); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp.Name(), 0755); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	return os.Rename(tmp.Name(), destPath)
+}
+
+// IsNewer reports whether latest is strictly greater than current using semver.
+// Returns false when versions are equal, unparseable, or latest looks like a
+// pre-release/snapshot relative to current.
+func IsNewer(latest, current string) bool {
+	lp := parseSemver(latest)
+	cp := parseSemver(current)
+	if lp == nil || cp == nil {
+		return false
+	}
+	if lp[0] != cp[0] {
+		return lp[0] > cp[0]
+	}
+	if lp[1] != cp[1] {
+		return lp[1] > cp[1]
+	}
+	return lp[2] > cp[2]
+}
+
+func parseSemver(v string) []int {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return nil
+	}
+	nums := make([]int, 3)
+	for i, p := range parts {
+		p, _, _ = strings.Cut(p, "-")
+		n := 0
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return nil
+			}
+			n = n*10 + int(c-'0')
+		}
+		nums[i] = n
+	}
+	return nums
+}
+
+func fetchRelease(ctx context.Context, hc *http.Client) (*Release, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "revenuecat-cli")
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("GitHub API returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var r Release
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func archiveName(version, goos, goarch string) string {
+	if goos == "windows" {
+		return fmt.Sprintf("rc_%s_%s_%s.zip", version, goos, goarch)
+	}
+	return fmt.Sprintf("rc_%s_%s_%s.tar.gz", version, goos, goarch)
+}
+
+// downloadBinary downloads the archive at url and extracts only the rc binary
+// to a temp file.
+func downloadBinary(ctx context.Context, hc *http.Client, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download returned %s", resp.Status)
+	}
+
+	tmp, err := os.CreateTemp("", "rc-update-*")
+	if err != nil {
+		return "", err
+	}
+	tmpName := tmp.Name()
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return "", err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			tmp.Close()
+			os.Remove(tmpName)
+			return "", err
+		}
+		// Accept only the top-level binary; reject path traversal attempts.
+		if filepath.Base(hdr.Name) == "rc" && hdr.Typeflag == tar.TypeReg &&
+			!strings.Contains(hdr.Name, "..") {
+			if _, err := io.Copy(tmp, tr); err != nil {
+				tmp.Close()
+				os.Remove(tmpName)
+				return "", err
+			}
+			tmp.Close()
+			return tmpName, nil
+		}
+	}
+
+	tmp.Close()
+	os.Remove(tmpName)
+	return "", fmt.Errorf("rc binary not found in archive")
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -246,7 +246,10 @@ func downloadTarGz(ctx context.Context, hc *http.Client, url string) (string, er
 				os.Remove(tmpName)
 				return "", fmt.Errorf("binary exceeds maximum allowed size (%d MiB)", maxBinaryBytes>>20)
 			}
-			tmp.Close()
+			if err := tmp.Close(); err != nil {
+				os.Remove(tmpName)
+				return "", fmt.Errorf("flushing extracted binary: %w", err)
+			}
 			return tmpName, nil
 		}
 	}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -14,9 +14,8 @@ import (
 	"strings"
 )
 
-// ReleasesURL is the GitHub API endpoint for the latest release. Tests may
-// override this to point at an httptest.Server.
-var ReleasesURL = "https://api.github.com/repos/RevenueCat/revenuecat-cli/releases/latest"
+// DefaultReleasesURL is the GitHub API endpoint for the latest release.
+const DefaultReleasesURL = "https://api.github.com/repos/RevenueCat/revenuecat-cli/releases/latest"
 
 // maxBinaryBytes is a sanity cap on the extracted binary size (64 MiB).
 const maxBinaryBytes = 64 << 20
@@ -42,9 +41,10 @@ func (r *Release) AssetName(goos, goarch string) string {
 	return archiveName(r.Version(), goos, goarch)
 }
 
-// FetchRelease returns the latest release metadata.
-func FetchRelease(ctx context.Context, hc *http.Client) (*Release, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ReleasesURL, nil)
+// FetchRelease returns the latest release metadata from the given URL.
+// Pass DefaultReleasesURL in production; tests may pass an httptest.Server URL.
+func FetchRelease(ctx context.Context, hc *http.Client, url string) (*Release, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -230,11 +230,10 @@ func downloadTarGz(ctx context.Context, hc *http.Client, url string) (string, er
 			os.Remove(tmpName)
 			return "", err
 		}
-		// Accept only a true top-level "rc" entry: no path separators and no
-		// dot-dot components, so nested paths like "bin/rc" are rejected.
-		clean := filepath.Clean(hdr.Name)
-		isTopLevel := clean == "rc" || clean == filepath.Base(clean) && !strings.ContainsAny(hdr.Name, "/\\")
-		if isTopLevel && filepath.Base(hdr.Name) == "rc" && hdr.Typeflag == tar.TypeReg {
+		// Require the entry to be named exactly "rc" with no path components.
+		// filepath.Clean is intentionally avoided here — it can normalise
+		// traversal sequences like "bin/../rc" into "rc" and bypass the check.
+		if hdr.Name == "rc" && hdr.Typeflag == tar.TypeReg {
 			lr := io.LimitReader(tr, maxBinaryBytes+1)
 			n, err := io.Copy(tmp, lr)
 			if err != nil {

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,216 @@
+package updater_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/updater"
+)
+
+// --- IsNewer ---
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		// Strictly newer
+		{"1.2.3", "1.2.2", true},
+		{"1.3.0", "1.2.9", true},
+		{"2.0.0", "1.9.9", true},
+		// Equal
+		{"1.2.3", "1.2.3", false},
+		// Older
+		{"1.2.2", "1.2.3", false},
+		{"1.0.0", "2.0.0", false},
+		// v-prefix stripped
+		{"v1.2.3", "1.2.2", true},
+		{"1.2.3", "v1.2.2", true},
+		// Pre-release: stable supersedes its pre-release
+		{"1.0.0", "1.0.0-rc1", true},
+		{"1.0.0", "1.0.0-beta.1", true},
+		// Pre-release latest never downgrades stable
+		{"1.0.0-rc1", "1.0.0", false},
+		// Both pre-release same numbers → not newer
+		{"1.0.0-rc2", "1.0.0-rc1", false},
+		// Unparseable → not newer
+		{"not-a-version", "1.0.0", false},
+		{"1.0.0", "not-a-version", false},
+		{"", "1.0.0", false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s_vs_%s", tc.latest, tc.current), func(t *testing.T) {
+			got := updater.IsNewer(tc.latest, tc.current)
+			if got != tc.want {
+				t.Errorf("IsNewer(%q, %q) = %v, want %v", tc.latest, tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- FetchRelease ---
+
+func TestFetchRelease_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("User-Agent") == "" {
+			t.Error("expected User-Agent header")
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"tag_name": "v1.2.3",
+			"html_url": "https://github.com/example",
+			"assets": []map[string]any{
+				{"name": "rc_1.2.3_darwin_arm64.tar.gz", "browser_download_url": "https://example.com/rc.tar.gz"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	orig := updater.ReleasesURL
+	updater.ReleasesURL = srv.URL
+	defer func() { updater.ReleasesURL = orig }()
+
+	r, err := updater.FetchRelease(context.Background(), &http.Client{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Version() != "1.2.3" {
+		t.Errorf("want version 1.2.3, got %q", r.Version())
+	}
+	if len(r.Assets) != 1 {
+		t.Errorf("want 1 asset, got %d", len(r.Assets))
+	}
+}
+
+func TestFetchRelease_NonOKIncludesBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"message":"rate limited"}`)
+	}))
+	defer srv.Close()
+
+	orig := updater.ReleasesURL
+	updater.ReleasesURL = srv.URL
+	defer func() { updater.ReleasesURL = orig }()
+
+	_, err := updater.FetchRelease(context.Background(), &http.Client{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if msg := err.Error(); !contains(msg, "403") || !contains(msg, "rate limited") {
+		t.Errorf("error should include status and body, got: %v", err)
+	}
+}
+
+// --- DownloadBinary ---
+
+func TestDownloadBinary_Success(t *testing.T) {
+	const fakeContent = "#!/bin/sh\necho hello"
+	tarGzData := makeTarGz(t, "rc", []byte(fakeContent))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(tarGzData)
+	}))
+	defer srv.Close()
+
+	release := &updater.Release{
+		TagName: "v1.2.3",
+		HTMLURL: "https://example.com",
+		Assets: []updater.Asset{
+			{Name: "rc_1.2.3_linux_amd64.tar.gz", BrowserDownloadURL: srv.URL + "/rc.tar.gz"},
+		},
+	}
+
+	path, err := updater.DownloadBinary(context.Background(), &http.Client{}, release, "linux", "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(path)
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading extracted binary: %v", err)
+	}
+	if string(got) != fakeContent {
+		t.Errorf("want %q, got %q", fakeContent, string(got))
+	}
+}
+
+func TestDownloadBinary_WindowsUnsupported(t *testing.T) {
+	r := &updater.Release{TagName: "v1.0.0", HTMLURL: "https://example.com"}
+	_, err := updater.DownloadBinary(context.Background(), &http.Client{}, r, "windows", "amd64")
+	if err == nil {
+		t.Fatal("expected error for windows")
+	}
+}
+
+func TestDownloadBinary_MissingAsset(t *testing.T) {
+	r := &updater.Release{TagName: "v1.0.0", HTMLURL: "https://example.com", Assets: nil}
+	_, err := updater.DownloadBinary(context.Background(), &http.Client{}, r, "linux", "amd64")
+	if err == nil {
+		t.Fatal("expected error for missing asset")
+	}
+}
+
+func TestDownloadBinary_RejectsNestedPath(t *testing.T) {
+	// Archive contains "bin/rc" — should not be accepted as the top-level binary.
+	tarGzData := makeTarGzNamed(t, "bin/rc", []byte("fake"))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(tarGzData)
+	}))
+	defer srv.Close()
+
+	release := &updater.Release{
+		TagName: "v1.0.0",
+		HTMLURL: "https://example.com",
+		Assets:  []updater.Asset{{Name: "rc_1.0.0_linux_amd64.tar.gz", BrowserDownloadURL: srv.URL}},
+	}
+	_, err := updater.DownloadBinary(context.Background(), &http.Client{}, release, "linux", "amd64")
+	if err == nil {
+		t.Fatal("expected error: nested path bin/rc should be rejected")
+	}
+}
+
+// --- helpers ---
+
+func makeTarGz(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+	return makeTarGzNamed(t, name, content)
+}
+
+func makeTarGzNamed(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	_ = tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(content)),
+		Mode:     0755,
+	})
+	tw.Write(content)
+	tw.Close()
+	gw.Close()
+	return buf.Bytes()
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -73,11 +73,7 @@ func TestFetchRelease_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := updater.ReleasesURL
-	updater.ReleasesURL = srv.URL
-	defer func() { updater.ReleasesURL = orig }()
-
-	r, err := updater.FetchRelease(context.Background(), &http.Client{})
+	r, err := updater.FetchRelease(context.Background(), &http.Client{}, srv.URL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -96,11 +92,7 @@ func TestFetchRelease_NonOKIncludesBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := updater.ReleasesURL
-	updater.ReleasesURL = srv.URL
-	defer func() { updater.ReleasesURL = orig }()
-
-	_, err := updater.FetchRelease(context.Background(), &http.Client{})
+	_, err := updater.FetchRelease(context.Background(), &http.Client{}, srv.URL)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -113,7 +105,7 @@ func TestFetchRelease_NonOKIncludesBody(t *testing.T) {
 
 func TestDownloadBinary_Success(t *testing.T) {
 	const fakeContent = "#!/bin/sh\necho hello"
-	tarGzData := makeTarGz(t, "rc", []byte(fakeContent))
+	tarGzData := makeTarGzNamed(t, "rc", []byte(fakeContent))
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write(tarGzData)
@@ -123,9 +115,7 @@ func TestDownloadBinary_Success(t *testing.T) {
 	release := &updater.Release{
 		TagName: "v1.2.3",
 		HTMLURL: "https://example.com",
-		Assets: []updater.Asset{
-			{Name: "rc_1.2.3_linux_amd64.tar.gz", BrowserDownloadURL: srv.URL + "/rc.tar.gz"},
-		},
+		Assets:  []updater.Asset{{Name: "rc_1.2.3_linux_amd64.tar.gz", BrowserDownloadURL: srv.URL + "/rc.tar.gz"}},
 	}
 
 	path, err := updater.DownloadBinary(context.Background(), &http.Client{}, release, "linux", "amd64")
@@ -160,11 +150,8 @@ func TestDownloadBinary_MissingAsset(t *testing.T) {
 }
 
 func TestDownloadBinary_RejectsNestedPath(t *testing.T) {
-	// Archive contains "bin/rc" — should not be accepted as the top-level binary.
-	tarGzData := makeTarGzNamed(t, "bin/rc", []byte("fake"))
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Write(tarGzData)
+		w.Write(makeTarGzNamed(t, "bin/rc", []byte("fake")))
 	}))
 	defer srv.Close()
 
@@ -179,11 +166,93 @@ func TestDownloadBinary_RejectsNestedPath(t *testing.T) {
 	}
 }
 
+func TestDownloadBinary_RejectsTraversalBypass(t *testing.T) {
+	// "bin/../rc" normalises to "rc" via filepath.Clean — must still be rejected.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(makeTarGzNamed(t, "bin/../rc", []byte("fake")))
+	}))
+	defer srv.Close()
+
+	release := &updater.Release{
+		TagName: "v1.0.0",
+		HTMLURL: "https://example.com",
+		Assets:  []updater.Asset{{Name: "rc_1.0.0_linux_amd64.tar.gz", BrowserDownloadURL: srv.URL}},
+	}
+	_, err := updater.DownloadBinary(context.Background(), &http.Client{}, release, "linux", "amd64")
+	if err == nil {
+		t.Fatal("expected error: traversal path bin/../rc should be rejected")
+	}
+}
+
+// --- Install ---
+
+func TestInstall_ReplacesDestination(t *testing.T) {
+	src := writeTempFile(t, []byte("new binary content"))
+	dest := writeTempFile(t, []byte("old binary content"))
+
+	if err := updater.Install(src, dest); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("reading dest: %v", err)
+	}
+	if string(got) != "new binary content" {
+		t.Errorf("dest not updated: got %q", got)
+	}
+}
+
+func TestInstall_DestIsExecutable(t *testing.T) {
+	src := writeTempFile(t, []byte("#!/bin/sh"))
+	dest := writeTempFile(t, []byte("old"))
+
+	if err := updater.Install(src, dest); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode()&0111 == 0 {
+		t.Errorf("dest should be executable, mode=%v", info.Mode())
+	}
+}
+
+func TestInstall_CleansUpTempOnFailure(t *testing.T) {
+	src := writeTempFile(t, []byte("content"))
+	dir := t.TempDir()
+	// Destination in a read-only directory — Install should fail.
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Skip("cannot make dir read-only:", err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0755) })
+
+	dest := dir + "/rc"
+	err := updater.Install(src, dest)
+	if err == nil {
+		t.Fatal("expected error installing to read-only dir")
+	}
+
+	// No temp files should be left behind in the dir.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("temp file left behind after failed install: %v", entries)
+	}
+}
+
 // --- helpers ---
 
-func makeTarGz(t *testing.T, name string, content []byte) []byte {
+func writeTempFile(t *testing.T, content []byte) string {
 	t.Helper()
-	return makeTarGzNamed(t, name, content)
+	f, err := os.CreateTemp(t.TempDir(), "updater-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Write(content)
+	f.Close()
+	return f.Name()
 }
 
 func makeTarGzNamed(t *testing.T, name string, content []byte) []byte {
@@ -204,13 +273,10 @@ func makeTarGzNamed(t *testing.T, name string, content []byte) []byte {
 }
 
 func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
-		func() bool {
-			for i := 0; i <= len(s)-len(sub); i++ {
-				if s[i:i+len(sub)] == sub {
-					return true
-				}
-			}
-			return false
-		}())
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- Adds `rc update` — checks GitHub Releases for a newer version and atomically replaces the running binary (no Homebrew or Xcode CLT required)
- Adds `install.sh` — curl-pipe installer that detects OS/arch and downloads the right pre-built binary directly from GitHub Releases
- Supports `--check` flag on `rc update` for CI use (exits 1 if update available), and `--json` for scripted output

## Motivation

Homebrew requires Xcode Command Line Tools as a hard prerequisite, even when installing a pre-built binary formula. This gives users a path to install and update `rc` without any Apple toolchain.

```sh
# Fresh install (no CLT needed)
curl -fsSL https://raw.githubusercontent.com/RevenueCat/revenuecat-cli/main/install.sh | sh

# Self-update
rc update

# CI / scripts
rc update --check   # exits 1 if stale, 0 if up to date
rc update --json    # machine-readable result
```

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (50 tests)
- [ ] `rc update` on a dev build prints "Running development build — skipping update"
- [ ] `install.sh` on macOS arm64 downloads and installs to `/usr/local/bin`
- [ ] `install.sh --install-dir ~/.local/bin` installs to the custom path

🤖 Generated with [Claude Code](https://claude.com/claude-code)