### PR TITLE
[10/10] feat: sync product store state from CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ rc charts show mrr
 | **Entitlements** | `list` · `show` · `create` · `update` · `attach` · `detach` |
 | **Offerings** | `list` · `show` · `create` · `update` · `archive` |
 | **Packages** | `list` (across all offerings) · `show` · `create` · `update` · `delete` · `attach` · `detach` |
-| **Products** | `list` · `show` · `create` · `archive` · `restore` · `delete` |
+| **Products** | `list` · `show` · `create` · `archive` · `restore` · `delete` · `store sync` |
 | **Charts & metrics** | Interactive bar/line charts · daily/weekly/monthly/quarterly/yearly |
 | **Apps** | `list` · `show` · `create` · `update` · `delete` |
 | **Audit log** | `rc audit` with `--limit` and `--since` |
@@ -71,6 +71,37 @@ rc charts show mrr
 rc --help          # see everything
 rc customer --help # see subcommands for any noun
 ```
+
+### Store-state CSV sync (experimental)
+
+Preview a canonical Khepri product store-state CSV without changing Apple or
+RevenueCat products:
+
+```bash
+rc products store sync app_abc --file catalog.csv --plan-only
+```
+
+The command parses the file locally, creates a RevenueCat store-state plan,
+waits for Khepri to compare it with the live store, and returns every diff and
+warning. Remove `--plan-only` to review the same preview and confirm before it
+is applied:
+
+```bash
+rc products store sync app_abc --file catalog.csv
+```
+
+For CI, use `--yes --no-input --json`. `RC_STORE_STATE_FILE` can replace
+`--file`. A full CSV exported by Khepri is accepted; this is a minimal App Store
+example:
+
+```csv
+row_type,store,store_identifier,product_type,display_name,title,duration,territory,amount,currency,start_date,available,available_in_new_territories,locale,localized_name,localized_description
+price,app_store,com.example.pro_monthly,subscription,Pro Monthly,Premium Monthly,P1M,US,9.99,USD,,true,true,,,
+localization,app_store,com.example.pro_monthly,subscription,Pro Monthly,Premium Monthly,P1M,,,,,,,en-US,Premium Monthly,Monthly premium access
+```
+
+These v2 endpoints are still development-only and require Khepri's
+`PRODUCT_CATALOG_PRODUCT_PRICE_MANAGER` feature flag.
 
 ## Profiles
 

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -165,6 +165,7 @@ rc products delete <id>
 rc products archive <id>
 rc products restore <id>
 rc products push <id>                                    # push to store
+rc products store sync [app-id] --file <catalog.csv>     # plan/review/apply canonical store-state CSV; --plan-only stops before apply
 
 # Paywalls
 rc paywalls list
@@ -264,10 +265,16 @@ rc chat                                                  # internal agent chat
 5. **Long tail**: `webhooks` ✅ (under `/integrations/webhooks`), `paywalls` ✅. `currencies` catalog, `discounts`, `experiments` deferred — fixtures empty so write shapes unverified.
 6. **Cross-resource utilities**: `metrics` ✅, `charts list/show/options` ✅ (with client-side enum validation + shell completion), `benchmarks` ✅, `audit` ✅. `find` still TODO (search query format unconfirmed).
 7. **Apps** ✅ — list/show/create/update/delete/keys/storekit-config.
-4. **Support toolkit**: `subscriptions`, `purchases`, `invoices`, `customer wallet`. The SE-debug surface.
-5. **Long tail**: `webhooks` (via `/integrations/webhooks`), `paywalls`, `currencies` catalog, `discounts`, `experiments`.
-6. **Cross-resource utilities**: `find`, `audit`, `metrics`, `charts`, `benchmarks`.
-7. **Streaming**: `events tail`, then `chat` — both blocked on backend.
+8. **Product store-state CSV sync POC** — `products store sync` reads Khepri's
+   canonical CSV format locally, creates a product store-state plan, waits for
+   its preview, displays per-product diffs and warnings, and only applies after
+   confirmation. `--plan-only` leaves the reviewed plan unapplied. This surface
+   uses development-only v2 endpoints and requires the
+   `PRODUCT_CATALOG_PRODUCT_PRICE_MANAGER` feature flag until they ship.
+9. **Support toolkit**: `subscriptions`, `purchases`, `invoices`, `customer wallet`. The SE-debug surface.
+10. **Long tail**: `webhooks` (via `/integrations/webhooks`), `paywalls`, `currencies` catalog, `discounts`, `experiments`.
+11. **Cross-resource utilities**: `find`, `audit`, `metrics`, `charts`, `benchmarks`.
+12. **Streaming**: `events tail`, then `chat` — both blocked on backend.
 
 ## Open questions (need RevenueCat-internal answers)
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -42,22 +42,23 @@ type Client struct {
 	userAgent string
 	cache     sync.Map // url string → cacheEntry; GET-only, session-scoped
 
-	Projects      *ProjectsService
-	Customers     *CustomersService
-	Entitlements  *EntitlementsService
-	Offerings     *OfferingsService
-	Packages      *PackagesService
-	Products      *ProductsService
-	Subscriptions *SubscriptionsService
-	Purchases     *PurchasesService
-	Invoices      *InvoicesService
-	Webhooks      *WebhooksService
-	Paywalls      *PaywallsService
-	Charts        *ChartsService
-	Metrics       *MetricsService
-	Audit         *AuditService
-	Benchmarks    *BenchmarksService
-	Apps          *AppsService
+	Projects        *ProjectsService
+	Customers       *CustomersService
+	Entitlements    *EntitlementsService
+	Offerings       *OfferingsService
+	Packages        *PackagesService
+	Products        *ProductsService
+	Subscriptions   *SubscriptionsService
+	Purchases       *PurchasesService
+	Invoices        *InvoicesService
+	Webhooks        *WebhooksService
+	Paywalls        *PaywallsService
+	Charts          *ChartsService
+	Metrics         *MetricsService
+	Audit           *AuditService
+	Benchmarks      *BenchmarksService
+	Apps            *AppsService
+	StoreStatePlans *StoreStatePlansService
 	// add as we go: Discounts, Experiments, VirtualCurrencies catalog
 }
 
@@ -92,6 +93,7 @@ func NewClient(opts Options) *Client {
 	c.Audit = &AuditService{c: c}
 	c.Benchmarks = &BenchmarksService{c: c}
 	c.Apps = &AppsService{c: c}
+	c.StoreStatePlans = &StoreStatePlansService{c: c}
 	return c
 }
 

--- a/internal/api/store_state_plans.go
+++ b/internal/api/store_state_plans.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"net/http"
+)
+
+type StoreStatePlansService struct{ c *Client }
+
+type StoreStatePlanDesiredState struct {
+	ProductID               string                       `json:"product_id,omitempty"`
+	CreateRevenueCatProduct *StoreStatePlanProductCreate `json:"create_revenuecat_product,omitempty"`
+	Store                   string                       `json:"store"`
+	Common                  map[string]any               `json:"common,omitempty"`
+	StoreState              map[string]any               `json:"store_state,omitempty"`
+}
+
+type StoreStatePlanProductCreate struct {
+	AppID           string `json:"app_id"`
+	StoreIdentifier string `json:"store_identifier"`
+	Type            string `json:"type"`
+	DisplayName     string `json:"display_name"`
+	Title           string `json:"title"`
+}
+
+type StoreStatePlanCreate struct {
+	DesiredStates []StoreStatePlanDesiredState `json:"desired_states"`
+}
+
+type StoreStatePlanActionResponse struct {
+	ID         string `json:"id"`
+	Object     string `json:"object"`
+	Status     string `json:"status"`
+	PollingURL string `json:"polling_url,omitempty"`
+}
+
+type StoreStatePlan struct {
+	ID            string                       `json:"id"`
+	Object        string                       `json:"object"`
+	Status        string                       `json:"status"`
+	HasChanges    *bool                        `json:"has_changes"`
+	Actions       []string                     `json:"actions"`
+	Summary       *StoreStatePlanSummary       `json:"summary"`
+	DesiredStates []StoreStatePlanDesiredState `json:"desired_states"`
+	PlanItems     []StoreStatePlanItem         `json:"plan_items"`
+	ErrorMessage  *string                      `json:"error_message"`
+	Warnings      []StoreStatePlanWarning      `json:"warnings"`
+}
+
+type StoreStatePlanSummary struct {
+	ProductsAdded     int64 `json:"products_added"`
+	ProductsModified  int64 `json:"products_modified"`
+	ProductsUnchanged int64 `json:"products_unchanged"`
+}
+
+type StoreStatePlanItem struct {
+	ProductID         *string                 `json:"product_id"`
+	AppID             *string                 `json:"app_id"`
+	StoreIdentifier   *string                 `json:"store_identifier"`
+	Action            string                  `json:"action"`
+	Diff              []StoreStatePlanDiff    `json:"diff"`
+	Warnings          []StoreStatePlanWarning `json:"warnings"`
+	ErrorMessage      *string                 `json:"error_message"`
+	ApplyStatus       *string                 `json:"apply_status"`
+	ApplyErrorMessage *string                 `json:"apply_error_message"`
+}
+
+type StoreStatePlanDiff struct {
+	Field     string `json:"field"`
+	FromValue any    `json:"from_value"`
+	ToValue   any    `json:"to_value"`
+}
+
+type StoreStatePlanWarning struct {
+	Severity string `json:"severity"`
+	Field    string `json:"field"`
+	Message  string `json:"message"`
+}
+
+func (s *StoreStatePlansService) Create(ctx context.Context, projectID string, body StoreStatePlanCreate) (*StoreStatePlanActionResponse, error) {
+	var out StoreStatePlanActionResponse
+	err := s.c.do(ctx, http.MethodPost, encodePath("projects", projectID, "store_state", "plans"), body, &out)
+	return &out, err
+}
+
+func (s *StoreStatePlansService) Get(ctx context.Context, projectID, planID string) (*StoreStatePlan, error) {
+	var out StoreStatePlan
+	err := s.c.do(ctx, http.MethodGet, encodePath("projects", projectID, "store_state", "plans", planID), nil, &out)
+	return &out, err
+}
+
+func (s *StoreStatePlansService) Plan(ctx context.Context, projectID, planID string) (*StoreStatePlanActionResponse, error) {
+	return s.action(ctx, projectID, planID, "plan")
+}
+
+func (s *StoreStatePlansService) Apply(ctx context.Context, projectID, planID string) (*StoreStatePlanActionResponse, error) {
+	return s.action(ctx, projectID, planID, "apply")
+}
+
+func (s *StoreStatePlansService) Discard(ctx context.Context, projectID, planID string) (*StoreStatePlanActionResponse, error) {
+	return s.action(ctx, projectID, planID, "discard")
+}
+
+func (s *StoreStatePlansService) action(ctx context.Context, projectID, planID, action string) (*StoreStatePlanActionResponse, error) {
+	var out StoreStatePlanActionResponse
+	path := encodePath("projects", projectID, "store_state", "plans", planID, "actions", action)
+	err := s.c.do(ctx, http.MethodPost, path, struct{}{}, &out)
+	return &out, err
+}

--- a/internal/api/store_state_plans_test.go
+++ b/internal/api/store_state_plans_test.go
@@ -1,0 +1,87 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+func TestStoreStatePlanLifecyclePathsAndBodies(t *testing.T) {
+	requests := []string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/projects/proj/store_state/plans":
+			var body api.StoreStatePlanCreate
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if len(body.DesiredStates) != 1 || body.DesiredStates[0].CreateRevenueCatProduct.AppID != "app" {
+				t.Fatalf("unexpected create body: %+v", body)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"id":"plan","object":"product_store_state_plan","status":"draft"}`)
+		case "/projects/proj/store_state/plans/plan":
+			_, _ = io.WriteString(w, `{"id":"plan","object":"product_store_state_plan","status":"planned","has_changes":false,"actions":[],"summary":{"products_added":0,"products_modified":0,"products_unchanged":1},"desired_states":[],"plan_items":[],"error_message":null,"warnings":[]}`)
+		default:
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+			}
+			_, _ = io.WriteString(w, `{"id":"plan","object":"product_store_state_plan","status":"queued","polling_url":"/poll"}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := api.NewClient(api.Options{APIKey: "sk_test", BaseURL: srv.URL})
+	body := api.StoreStatePlanCreate{DesiredStates: []api.StoreStatePlanDesiredState{{
+		Store: "app_store",
+		CreateRevenueCatProduct: &api.StoreStatePlanProductCreate{
+			AppID: "app", StoreIdentifier: "com.example.pro", Type: "subscription", DisplayName: "Pro", Title: "Pro",
+		},
+	}}}
+	created, err := client.StoreStatePlans.Create(context.Background(), "proj", body)
+	if err != nil || created.ID != "plan" {
+		t.Fatalf("create: %+v, %v", created, err)
+	}
+	if _, err := client.StoreStatePlans.Plan(context.Background(), "proj", "plan"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.StoreStatePlans.Get(context.Background(), "proj", "plan"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.StoreStatePlans.Apply(context.Background(), "proj", "plan"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.StoreStatePlans.Discard(context.Background(), "proj", "plan"); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"POST /projects/proj/store_state/plans",
+		"POST /projects/proj/store_state/plans/plan/actions/plan",
+		"GET /projects/proj/store_state/plans/plan",
+		"POST /projects/proj/store_state/plans/plan/actions/apply",
+		"POST /projects/proj/store_state/plans/plan/actions/discard",
+	}
+	if !equalStringSlices(requests, want) {
+		t.Fatalf("requests = %v, want %v", requests, want)
+	}
+}
+
+func equalStringSlices(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -30,6 +30,7 @@ func newProductsCmd() *cobra.Command {
 		newProductsArchiveCmd(),
 		newProductsRestoreCmd(),
 		newProductsPushCmd(),
+		newProductsStoreCmd(),
 	)
 	return cmd
 }

--- a/internal/cli/products_store.go
+++ b/internal/cli/products_store.go
@@ -1,0 +1,253 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+
+	"github.com/revenuecat/cli/internal/api"
+	"github.com/revenuecat/cli/internal/output"
+	"github.com/revenuecat/cli/internal/tui"
+)
+
+func newProductsStoreCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "store",
+		Short: "Plan and sync product configuration with an app store",
+	}
+	cmd.AddCommand(newProductsStoreSyncCmd())
+	return cmd
+}
+
+func newProductsStoreSyncCmd() *cobra.Command {
+	var file string
+	var planOnly bool
+	var timeout time.Duration
+	cmd := &cobra.Command{
+		Use:   "sync [app-id]",
+		Short: "Plan, review, and apply a canonical store-state CSV",
+		Long: `Reads Khepri's canonical product store-state CSV locally and sends its
+desired product states to RevenueCat. RevenueCat compares them with the live
+App Store or Play Store state before anything is changed.
+
+The planned product diffs and warnings are always reviewed before apply.
+Interactive runs prompt for confirmation; non-interactive runs require --yes.
+Use --plan-only to create and inspect the backend plan without applying it.
+
+This POC uses development-only RevenueCat v2 endpoints and currently requires
+the PRODUCT_CATALOG_PRODUCT_PRICE_MANAGER feature flag in Khepri.`,
+		Example: `  rc products store sync app_abc --file catalog.csv --plan-only
+  rc products store sync app_abc --file catalog.csv
+  rc products store sync app_abc --file catalog.csv --yes --json`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rt := RuntimeFrom(cmd.Context())
+			projectID, err := requireProject(rt)
+			if err != nil {
+				return err
+			}
+			client, err := rt.API()
+			if err != nil {
+				return err
+			}
+			appID, err := requireID(rt, argAt(args, 0), "app", func() ([]PickerItem, error) {
+				page, err := client.Apps.List(cmd.Context(), projectID)
+				if err != nil {
+					return nil, err
+				}
+				items := make([]PickerItem, len(page.Items))
+				for i, app := range page.Items {
+					items[i] = PickerItem{ID: app.ID, Label: app.Name}
+				}
+				return items, nil
+			})
+			if err != nil {
+				return err
+			}
+			if file == "" {
+				file = os.Getenv("RC_STORE_STATE_FILE")
+			}
+			if file == "" {
+				if rt.Globals.NoInput || !tui.IsInteractive() {
+					return errors.New("--file is required")
+				}
+				if err := tui.Form(false).Field(
+					huh.NewInput().Title("Canonical store-state CSV path").Value(&file).Validate(tui.Required("CSV path")),
+				).Run(); err != nil {
+					return err
+				}
+			}
+			desiredStates, err := readStoreStateCSV(file, appID)
+			if err != nil {
+				return err
+			}
+			rt.Out.Info(fmt.Sprintf("Loaded %d product desired state(s) from %s", len(desiredStates), file))
+			created, err := client.StoreStatePlans.Create(cmd.Context(), projectID, api.StoreStatePlanCreate{DesiredStates: desiredStates})
+			if err != nil {
+				return err
+			}
+			rt.Out.Info("Created store-state plan " + created.ID)
+			if _, err := client.StoreStatePlans.Plan(cmd.Context(), projectID, created.ID); err != nil {
+				return err
+			}
+			plan, err := waitForStoreStatePlan(cmd.Context(), client.StoreStatePlans, projectID, created.ID, timeout, planningFinished)
+			if err != nil {
+				return err
+			}
+			printStoreStatePlanPreview(rt, plan)
+			if plan.Status == "plan_errored" {
+				return fmt.Errorf("store-state plan %s failed: %s", plan.ID, optionalString(plan.ErrorMessage, "inspect plan items for details"))
+			}
+			if planOnly {
+				return renderStoreStatePlanResult(rt, plan)
+			}
+			if hasStoreStateBlocker(plan) {
+				return fmt.Errorf("store-state plan %s has blocker warnings and cannot be applied", plan.ID)
+			}
+			if !slices.Contains(plan.Actions, "apply") {
+				rt.Out.Success("Store state already matches the CSV; nothing to apply")
+				return renderStoreStatePlanResult(rt, plan)
+			}
+			if !rt.Globals.AssumeYes {
+				confirmed, err := tui.Confirm(rt.Globals.NoInput, fmt.Sprintf("Apply plan %s to the app store?", plan.ID))
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					return errors.New("cancelled; the RevenueCat plan was left unapplied")
+				}
+			}
+			if _, err := client.StoreStatePlans.Apply(cmd.Context(), projectID, plan.ID); err != nil {
+				return err
+			}
+			plan, err = waitForStoreStatePlan(cmd.Context(), client.StoreStatePlans, projectID, plan.ID, timeout, applyingFinished)
+			if err != nil {
+				return err
+			}
+			if plan.Status == "apply_errored" {
+				return fmt.Errorf("store-state plan %s failed while applying: %s", plan.ID, storeStateApplyErrors(plan))
+			}
+			rt.Out.Success("Applied product store state plan " + plan.ID)
+			return renderStoreStatePlanResult(rt, plan)
+		},
+	}
+	cmd.Flags().StringVarP(&file, "file", "f", "", "canonical store-state CSV path (env: RC_STORE_STATE_FILE)")
+	cmd.Flags().BoolVar(&planOnly, "plan-only", false, "create and review the plan without applying it")
+	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Minute, "maximum time to wait for planning and apply")
+	return cmd
+}
+
+type storeStatePlansAPI interface {
+	Get(context.Context, string, string) (*api.StoreStatePlan, error)
+}
+
+func waitForStoreStatePlan(ctx context.Context, service storeStatePlansAPI, projectID, planID string, timeout time.Duration, finished func(string) bool) (*api.StoreStatePlan, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for {
+		plan, err := service.Get(ctx, projectID, planID)
+		if err != nil {
+			return nil, err
+		}
+		if finished(plan.Status) {
+			return plan, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out waiting for store-state plan %s: %w", planID, ctx.Err())
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func planningFinished(status string) bool {
+	return status == "planned" || status == "planned_and_finished" || status == "plan_errored"
+}
+
+func applyingFinished(status string) bool {
+	return status == "applied" || status == "apply_errored"
+}
+
+func printStoreStatePlanPreview(rt *Runtime, plan *api.StoreStatePlan) {
+	if plan.Summary != nil {
+		rt.Out.Info(fmt.Sprintf("Plan %s: %d create, %d modify, %d unchanged", plan.ID, plan.Summary.ProductsAdded, plan.Summary.ProductsModified, plan.Summary.ProductsUnchanged))
+	}
+	for _, item := range plan.PlanItems {
+		identifier := optionalString(item.StoreIdentifier, optionalString(item.ProductID, "unknown product"))
+		rt.Out.Info(fmt.Sprintf("%s %s", strings.ToUpper(item.Action), identifier))
+		for _, diff := range item.Diff {
+			rt.Out.Info(fmt.Sprintf("  %s: %v -> %v", diff.Field, diff.FromValue, diff.ToValue))
+		}
+		for _, warning := range item.Warnings {
+			rt.Out.Warn(fmt.Sprintf("%s [%s]: %s", warning.Severity, warning.Field, warning.Message))
+		}
+	}
+	for _, warning := range plan.Warnings {
+		rt.Out.Warn(fmt.Sprintf("%s [%s]: %s", warning.Severity, warning.Field, warning.Message))
+	}
+}
+
+func renderStoreStatePlanResult(rt *Runtime, plan *api.StoreStatePlan) error {
+	rows := make([][]string, 0, len(plan.PlanItems))
+	for _, item := range plan.PlanItems {
+		rows = append(rows, []string{
+			optionalString(item.StoreIdentifier, optionalString(item.ProductID, "")),
+			item.Action,
+			strconvLen(item.Diff),
+			strconvLen(item.Warnings),
+			optionalString(item.ApplyStatus, ""),
+		})
+	}
+	return rt.Out.RenderTable(output.Table{
+		Columns: []string{"PRODUCT", "ACTION", "CHANGES", "WARNINGS", "APPLY STATUS"},
+		Rows:    rows,
+		Raw:     plan,
+	})
+}
+
+func hasStoreStateBlocker(plan *api.StoreStatePlan) bool {
+	for _, warning := range plan.Warnings {
+		if warning.Severity == "blocker" {
+			return true
+		}
+	}
+	for _, item := range plan.PlanItems {
+		for _, warning := range item.Warnings {
+			if warning.Severity == "blocker" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func storeStateApplyErrors(plan *api.StoreStatePlan) string {
+	errors := make([]string, 0)
+	for _, item := range plan.PlanItems {
+		if item.ApplyErrorMessage != nil {
+			errors = append(errors, *item.ApplyErrorMessage)
+		}
+	}
+	if len(errors) == 0 {
+		return optionalString(plan.ErrorMessage, "inspect plan items for details")
+	}
+	return strings.Join(errors, "; ")
+}
+
+func optionalString(value *string, fallback string) string {
+	if value == nil || *value == "" {
+		return fallback
+	}
+	return *value
+}
+
+func strconvLen[T any](values []T) string {
+	return fmt.Sprintf("%d", len(values))
+}

--- a/internal/cli/products_store_csv.go
+++ b/internal/cli/products_store_csv.go
@@ -1,0 +1,408 @@
+package cli
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+var storeCSVRequiredColumns = []string{
+	"store", "store_identifier", "product_type", "display_name", "title",
+}
+
+type storeCSVProduct struct {
+	line            int
+	store           string
+	storeIdentifier string
+	productType     string
+	displayName     string
+	title           string
+	duration        string
+	common          map[string]any
+	storeState      map[string]any
+}
+
+func readStoreStateCSV(path, appID string) ([]api.StoreStatePlanDesiredState, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open store-state CSV: %w", err)
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	r.TrimLeadingSpace = true
+	header, err := r.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read store-state CSV header: %w", err)
+	}
+	if len(header) > 0 {
+		header[0] = strings.TrimPrefix(header[0], "\ufeff")
+	}
+	columns := make(map[string]int, len(header))
+	for i, name := range header {
+		columns[strings.TrimSpace(name)] = i
+	}
+	for _, name := range storeCSVRequiredColumns {
+		if _, ok := columns[name]; !ok {
+			return nil, fmt.Errorf("store-state CSV is missing required column %q", name)
+		}
+	}
+
+	products := map[string]*storeCSVProduct{}
+	order := make([]string, 0)
+	for line := 2; ; line++ {
+		row, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read store-state CSV line %d: %w", line, err)
+		}
+		value := func(name string) string {
+			i, ok := columns[name]
+			if !ok || i >= len(row) {
+				return ""
+			}
+			return strings.TrimSpace(row[i])
+		}
+		if emptyCSVRow(row) {
+			continue
+		}
+		store, identifier := value("store"), value("store_identifier")
+		if store != "app_store" && store != "play_store" {
+			return nil, fmt.Errorf("store-state CSV line %d: store must be app_store or play_store", line)
+		}
+		if identifier == "" {
+			return nil, fmt.Errorf("store-state CSV line %d: store_identifier is required", line)
+		}
+		key := store + "\x00" + identifier
+		product := products[key]
+		if product == nil {
+			product = &storeCSVProduct{line: line, store: store, storeIdentifier: identifier, common: map[string]any{}, storeState: map[string]any{}}
+			products[key] = product
+			order = append(order, key)
+		}
+		for name, target := range map[string]*string{
+			"product_type": &product.productType,
+			"display_name": &product.displayName,
+			"title":        &product.title,
+			"duration":     &product.duration,
+		} {
+			if err := mergeCSVScalar(target, value(name), name, line); err != nil {
+				return nil, err
+			}
+		}
+		if err := mergeStoreCSVRow(product, value, line); err != nil {
+			return nil, err
+		}
+	}
+	if len(order) == 0 {
+		return nil, fmt.Errorf("store-state CSV contains no product rows")
+	}
+
+	states := make([]api.StoreStatePlanDesiredState, 0, len(order))
+	for _, key := range order {
+		p := products[key]
+		if p.productType == "" || p.displayName == "" || p.title == "" {
+			return nil, fmt.Errorf("store-state CSV product %q: product_type, display_name, and title are required", p.storeIdentifier)
+		}
+		if p.title != "" {
+			p.common["title"] = p.title
+		}
+		if p.duration != "" {
+			p.common["duration"] = p.duration
+		}
+		state := api.StoreStatePlanDesiredState{
+			Store: p.store,
+			CreateRevenueCatProduct: &api.StoreStatePlanProductCreate{
+				AppID: appID, StoreIdentifier: p.storeIdentifier, Type: p.productType,
+				DisplayName: p.displayName, Title: p.title,
+			},
+			Common: p.common,
+		}
+		if len(p.storeState) > 0 {
+			state.StoreState = p.storeState
+		}
+		states = append(states, state)
+	}
+	return states, nil
+}
+
+func mergeStoreCSVRow(p *storeCSVProduct, value func(string) string, line int) error {
+	territory := strings.ToUpper(value("territory"))
+	amount, currency := value("amount"), strings.ToUpper(value("currency"))
+	if amount != "" || currency != "" {
+		if territory == "" || amount == "" || currency == "" {
+			return fmt.Errorf("store-state CSV line %d: territory, amount, and currency must be provided together", line)
+		}
+		micros, err := decimalToMicros(amount)
+		if err != nil {
+			return fmt.Errorf("store-state CSV line %d: invalid amount: %w", line, err)
+		}
+		price := map[string]any{"amount_micros": micros, "currency": currency}
+		if startDate := value("start_date"); startDate != "" {
+			price["start_date"] = startDate
+		}
+		pricing := childMap(p.common, "pricing")
+		prices := childMap(pricing, "territory_prices")
+		if err := mergeCSVMapValue(prices, territory, price, "price", line); err != nil {
+			return err
+		}
+	}
+	if available := value("available"); available != "" {
+		if territory == "" {
+			return fmt.Errorf("store-state CSV line %d: territory is required when available is set", line)
+		}
+		parsed, err := parseCSVBool(available)
+		if err != nil {
+			return fmt.Errorf("store-state CSV line %d: available: %w", line, err)
+		}
+		childMap(childMap(p.common, "availability"), "territories")[territory] = parsed
+	}
+	if raw := value("available_in_new_territories"); raw != "" {
+		parsed, err := parseCSVBool(raw)
+		if err != nil {
+			return fmt.Errorf("store-state CSV line %d: available_in_new_territories: %w", line, err)
+		}
+		availability := childMap(p.common, "availability")
+		if err := mergeCSVMapValue(availability, "available_in_new_territories", parsed, "available_in_new_territories", line); err != nil {
+			return err
+		}
+	}
+	locale := value("locale")
+	localizedName, localizedDescription := value("localized_name"), value("localized_description")
+	if locale != "" || localizedName != "" || localizedDescription != "" {
+		if locale == "" || localizedName == "" {
+			return fmt.Errorf("store-state CSV line %d: locale and localized_name must be provided together", line)
+		}
+		localization := map[string]any{"name": localizedName, "description": nil}
+		if localizedDescription != "" {
+			localization["description"] = localizedDescription
+		}
+		if err := mergeCSVMapValue(childMap(p.common, "localizations"), locale, localization, "localization", line); err != nil {
+			return err
+		}
+	}
+
+	if p.store == "app_store" {
+		return mergeAppStoreCSVRow(p, value, locale, line)
+	}
+	return mergePlayStoreCSVRow(p, value, line)
+}
+
+func mergeAppStoreCSVRow(p *storeCSVProduct, value func(string) string, locale string, line int) error {
+	if groupName := value("app_store_subscription_group_name"); groupName != "" {
+		if err := mergeCSVMapValue(p.storeState, "subscription_group_name", groupName, "app_store_subscription_group_name", line); err != nil {
+			return err
+		}
+	}
+	name := value("app_store_subscription_group_localized_name")
+	customName := value("app_store_subscription_group_custom_app_name")
+	if name == "" && customName == "" {
+		return nil
+	}
+	if locale == "" || name == "" {
+		return fmt.Errorf("store-state CSV line %d: locale and app_store_subscription_group_localized_name must be provided together", line)
+	}
+	localization := map[string]any{"name": name}
+	if customName != "" {
+		localization["custom_app_name"] = customName
+	}
+	return mergeCSVMapValue(childMap(p.storeState, "subscription_group_localizations"), locale, localization, "subscription group localization", line)
+}
+
+func mergePlayStoreCSVRow(p *storeCSVProduct, value func(string) string, line int) error {
+	parts := strings.SplitN(p.storeIdentifier, ":", 2)
+	planType := value("play_store_base_plan_type")
+	playFields := []string{
+		"play_store_base_plan_offer_tags",
+		"play_store_auto_renewing_grace_period_duration",
+		"play_store_auto_renewing_account_hold_duration",
+		"play_store_auto_renewing_resubscribe_state",
+		"play_store_auto_renewing_proration_mode",
+		"play_store_auto_renewing_legacy_compatible",
+		"play_store_auto_renewing_legacy_compatible_subscription_offer_id",
+		"play_store_prepaid_time_extension",
+		"play_store_installments_committed_payments_count",
+		"play_store_installments_renewal_type",
+		"play_store_installments_grace_period_duration",
+		"play_store_installments_account_hold_duration",
+		"play_store_installments_resubscribe_state",
+		"play_store_installments_proration_mode",
+		"play_store_other_regions_available_in_new_territories",
+		"play_store_other_regions_usd_amount",
+		"play_store_other_regions_usd_currency",
+		"play_store_other_regions_eur_amount",
+		"play_store_other_regions_eur_currency",
+	}
+	hasPlayState := planType != ""
+	for _, field := range playFields {
+		hasPlayState = hasPlayState || value(field) != ""
+	}
+	if !hasPlayState {
+		return nil
+	}
+	if len(parts) != 2 {
+		return fmt.Errorf("store-state CSV line %d: Play Store subscription identifiers must be <subscription_id>:<base_plan_id>", line)
+	}
+	basePlan := childMap(childMap(p.storeState, "base_plans"), parts[1])
+	if planType != "" {
+		field := map[string]string{"auto_renewing": "auto_renewing_base_plan_type", "prepaid": "prepaid_base_plan_type", "installments": "installments_base_plan_type"}[planType]
+		if field == "" {
+			return fmt.Errorf("store-state CSV line %d: invalid play_store_base_plan_type %q", line, planType)
+		}
+		if p.duration == "" {
+			return fmt.Errorf("store-state CSV line %d: duration is required for a Play Store base plan", line)
+		}
+		config := childMap(basePlan, field)
+		config["billing_period_duration"] = p.duration
+		prefix := "play_store_" + planType + "_"
+		stringFields := map[string]string{
+			"grace_period_duration": "grace_period_duration", "account_hold_duration": "account_hold_duration",
+			"resubscribe_state": "resubscribe_state", "proration_mode": "proration_mode",
+			"legacy_compatible_subscription_offer_id": "legacy_compatible_subscription_offer_id",
+			"time_extension": "time_extension", "renewal_type": "renewal_type",
+		}
+		for suffix, target := range stringFields {
+			if raw := value(prefix + suffix); raw != "" {
+				config[target] = raw
+			}
+		}
+		if raw := value(prefix + "legacy_compatible"); raw != "" {
+			parsed, err := parseCSVBool(raw)
+			if err != nil {
+				return fmt.Errorf("store-state CSV line %d: %slegacy_compatible: %w", line, prefix, err)
+			}
+			config["legacy_compatible"] = parsed
+		}
+		if raw := value(prefix + "committed_payments_count"); raw != "" {
+			parsed, err := strconv.Atoi(raw)
+			if err != nil {
+				return fmt.Errorf("store-state CSV line %d: committed payments count must be an integer", line)
+			}
+			config["committed_payments_count"] = parsed
+		}
+	}
+	if raw := value("play_store_base_plan_offer_tags"); raw != "" {
+		tags := strings.Split(raw, ";")
+		for i := range tags {
+			tags[i] = strings.TrimSpace(tags[i])
+		}
+		basePlan["offer_tags"] = tags
+	}
+	return mergePlayOtherRegions(basePlan, value, line)
+}
+
+func mergePlayOtherRegions(basePlan map[string]any, value func(string) string, line int) error {
+	other := map[string]any{}
+	if raw := value("play_store_other_regions_available_in_new_territories"); raw != "" {
+		parsed, err := parseCSVBool(raw)
+		if err != nil {
+			return fmt.Errorf("store-state CSV line %d: other regions availability: %w", line, err)
+		}
+		other["new_subscriber_availability"] = parsed
+	}
+	for _, currency := range []string{"usd", "eur"} {
+		amount := value("play_store_other_regions_" + currency + "_amount")
+		code := strings.ToUpper(value("play_store_other_regions_" + currency + "_currency"))
+		if amount == "" && code == "" {
+			continue
+		}
+		if amount == "" || code == "" {
+			return fmt.Errorf("store-state CSV line %d: other-regions %s amount and currency must be provided together", line, currency)
+		}
+		micros, err := decimalToMicros(amount)
+		if err != nil {
+			return fmt.Errorf("store-state CSV line %d: other-regions %s amount: %w", line, currency, err)
+		}
+		other[currency+"_price"] = map[string]any{"amount_micros": micros, "currency": code}
+	}
+	if len(other) > 0 {
+		basePlan["other_regions_config"] = other
+	}
+	return nil
+}
+
+func decimalToMicros(value string) (int64, error) {
+	negative := strings.HasPrefix(value, "-")
+	value = strings.TrimPrefix(value, "+")
+	value = strings.TrimPrefix(value, "-")
+	parts := strings.Split(value, ".")
+	if len(parts) > 2 || parts[0] == "" || (len(parts) == 2 && len(parts[1]) > 6) {
+		return 0, fmt.Errorf("%q must be a decimal with at most 6 fractional digits", value)
+	}
+	whole, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a decimal", value)
+	}
+	fraction := ""
+	if len(parts) == 2 {
+		fraction = parts[1]
+	}
+	for len(fraction) < 6 {
+		fraction += "0"
+	}
+	frac := int64(0)
+	if fraction != "" {
+		frac, err = strconv.ParseInt(fraction, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("%q is not a decimal", value)
+		}
+	}
+	micros := whole*1_000_000 + frac
+	if negative {
+		micros = -micros
+	}
+	return micros, nil
+}
+
+func parseCSVBool(value string) (bool, error) {
+	parsed, err := strconv.ParseBool(strings.ToLower(value))
+	if err != nil {
+		return false, fmt.Errorf("%q must be true or false", value)
+	}
+	return parsed, nil
+}
+
+func childMap(parent map[string]any, key string) map[string]any {
+	if child, ok := parent[key].(map[string]any); ok {
+		return child
+	}
+	child := map[string]any{}
+	parent[key] = child
+	return child
+}
+
+func mergeCSVScalar(target *string, value, field string, line int) error {
+	if value == "" {
+		return nil
+	}
+	if *target != "" && *target != value {
+		return fmt.Errorf("store-state CSV line %d: conflicting %s values %q and %q", line, field, *target, value)
+	}
+	*target = value
+	return nil
+}
+
+func mergeCSVMapValue(target map[string]any, key string, value any, field string, line int) error {
+	if existing, ok := target[key]; ok && !reflect.DeepEqual(existing, value) {
+		return fmt.Errorf("store-state CSV line %d: conflicting %s values", line, field)
+	}
+	target[key] = value
+	return nil
+}
+
+func emptyCSVRow(row []string) bool {
+	for _, value := range row {
+		if strings.TrimSpace(value) != "" {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/products_store_csv_test.go
+++ b/internal/cli/products_store_csv_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadStoreStateCSV_AppStoreCanonicalRows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.csv")
+	content := `row_type,store,store_identifier,product_type,display_name,title,duration,territory,amount,currency,start_date,available,available_in_new_territories,locale,localized_name,localized_description,app_store_subscription_group_name,app_store_subscription_group_localized_name,app_store_subscription_group_custom_app_name
+price,app_store,com.example.pro,subscription,Pro Monthly,Premium,P1M,US,3.99,USD,2026-07-20,true,true,,,,Premium Group,,
+localization,app_store,com.example.pro,subscription,Pro Monthly,Premium,P1M,,,,,,,en-US,Premium,Premium subscription,Premium Group,Premium Subscriptions,Example
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	states, err := readStoreStateCSV(path, "app_abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 {
+		t.Fatalf("states = %d, want 1", len(states))
+	}
+	state := states[0]
+	if state.Store != "app_store" || state.CreateRevenueCatProduct.AppID != "app_abc" || state.CreateRevenueCatProduct.StoreIdentifier != "com.example.pro" {
+		t.Fatalf("unexpected identity: %+v", state)
+	}
+	pricing := state.Common["pricing"].(map[string]any)
+	prices := pricing["territory_prices"].(map[string]any)
+	us := prices["US"].(map[string]any)
+	if us["amount_micros"] != int64(3_990_000) || us["currency"] != "USD" {
+		t.Fatalf("unexpected US price: %+v", us)
+	}
+	localizations := state.Common["localizations"].(map[string]any)
+	if localizations["en-US"].(map[string]any)["name"] != "Premium" {
+		t.Fatalf("unexpected localizations: %+v", localizations)
+	}
+	if state.StoreState["subscription_group_name"] != "Premium Group" {
+		t.Fatalf("unexpected store state: %+v", state.StoreState)
+	}
+}
+
+func TestReadStoreStateCSV_RejectsConflictingProductMetadata(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.csv")
+	content := `store,store_identifier,product_type,display_name,title
+app_store,com.example.pro,subscription,Pro,Premium
+app_store,com.example.pro,subscription,Pro,Other
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readStoreStateCSV(path, "app"); err == nil {
+		t.Fatal("expected conflicting title error")
+	}
+}
+
+func TestDecimalToMicros(t *testing.T) {
+	for input, want := range map[string]int64{"3.99": 3_990_000, "0": 0, "-5": -5_000_000, "1.000001": 1_000_001} {
+		got, err := decimalToMicros(input)
+		if err != nil || got != want {
+			t.Errorf("decimalToMicros(%q) = %d, %v; want %d", input, got, err, want)
+		}
+	}
+}

--- a/internal/cli/products_store_test.go
+++ b/internal/cli/products_store_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProductsStoreSync_PlanOnlyNeverApplies(t *testing.T) {
+	requests, stdout, stderr, err := runStoreSync(t, true)
+	if err != nil {
+		t.Fatalf("execute: %v\nstderr: %s", err, stderr)
+	}
+	if strings.Contains(strings.Join(requests, "\n"), "/actions/apply") {
+		t.Fatalf("plan-only made apply request: %v", requests)
+	}
+	var result struct {
+		Data struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if result.Data.ID != "plan_123" || result.Data.Status != "planned" {
+		t.Fatalf("unexpected output: %+v", result.Data)
+	}
+}
+
+func TestProductsStoreSync_AppliesAfterExplicitYes(t *testing.T) {
+	requests, stdout, stderr, err := runStoreSync(t, false)
+	if err != nil {
+		t.Fatalf("execute: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(strings.Join(requests, "\n"), "POST /projects/proj/store_state/plans/plan_123/actions/apply") {
+		t.Fatalf("missing apply request: %v", requests)
+	}
+	var result struct {
+		Data struct {
+			Status string `json:"status"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if result.Data.Status != "applied" {
+		t.Fatalf("status = %q, want applied", result.Data.Status)
+	}
+}
+
+func runStoreSync(t *testing.T, planOnly bool) (requests []string, stdout, stderr string, err error) {
+	t.Helper()
+	getCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/projects/proj/store_state/plans":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"id":"plan_123","object":"product_store_state_plan","status":"draft"}`)
+		case "/projects/proj/store_state/plans/plan_123/actions/plan":
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"id":"plan_123","object":"product_store_state_plan","status":"plan_queued","polling_url":"/poll"}`)
+		case "/projects/proj/store_state/plans/plan_123/actions/apply":
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"id":"plan_123","object":"product_store_state_plan","status":"apply_queued","polling_url":"/poll"}`)
+		case "/projects/proj/store_state/plans/plan_123":
+			getCount++
+			status, applyStatus := "planned", "pending"
+			if getCount > 1 {
+				status, applyStatus = "applied", "applied"
+			}
+			_, _ = fmt.Fprintf(w, `{"id":"plan_123","object":"product_store_state_plan","status":%q,"has_changes":true,"actions":["apply","discard"],"summary":{"products_added":1,"products_modified":0,"products_unchanged":0},"desired_states":[],"plan_items":[{"product_id":null,"app_id":"app","store_identifier":"com.example.pro","action":"create","diff":[{"field":"common.title","from_value":null,"to_value":"Premium"}],"warnings":[],"error_message":null,"apply_status":%q,"apply_error_message":null}],"error_message":null,"warnings":[]}`, status, applyStatus)
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	file := filepath.Join(t.TempDir(), "catalog.csv")
+	if writeErr := os.WriteFile(file, []byte("store,store_identifier,product_type,display_name,title,duration,territory,amount,currency,available\napp_store,com.example.pro,subscription,Pro,Premium,P1M,US,3.99,USD,true\n"), 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	t.Setenv("RC_BASE_URL", srv.URL)
+	var out, errOut bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	args := []string{"products", "store", "sync", "app", "--file", file, "--api-key", "sk_test", "--project-id", "proj", "--no-input", "--yes", "--json"}
+	if planOnly {
+		args = append(args, "--plan-only")
+	}
+	root.SetArgs(args)
+	err = root.ExecuteContext(context.Background())
+	return requests, out.String(), errOut.String(), err
+}


### PR DESCRIPTION
## What changed

- adds typed v2 client support for the product store-state plan lifecycle
- adds `rc products store sync [app-id] --file catalog.csv`
- parses Khepri canonical App Store and Play Store CSV locally
- plans and polls before showing per-product diffs and warnings
- blocks apply on blocker warnings and requires interactive confirmation or `--yes`
- supports `--plan-only` for a backend dry run with no store or catalog mutation
- documents the experimental feature flag requirement and end-to-end commands

## Why

This replaces the earlier Test Store price-command work in this stack slot. It connects the new Khepri product store-state planning flow to the CLI so product metadata, localization, availability, and pricing can be tested end to end.

The Khepri endpoints are still development-only and require `PRODUCT_CATALOG_PRODUCT_PRICE_MANAGER`.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `git diff --check`
- CLI help and schema smoke tests