### PR TITLE
feat: RC_CANARY env to route requests to a canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,9 @@ without raw API calls.
 | `--no-color` | Disable ANSI color (also respects `$NO_COLOR`) |
 | `--format <expr>` | jq expression applied to `--json` output |
 
+Env-only: `RC_CANARY=<name>` sends an `X-RC-Canary` header on all RevenueCat
+requests, routing them to a canary deployment.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/internal/api/canary_test.go
+++ b/internal/api/canary_test.go
@@ -1,0 +1,31 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+func TestCanaryHeader(t *testing.T) {
+	for name, canary := range map[string]string{"set": "my-canary", "unset": ""} {
+		t.Run(name, func(t *testing.T) {
+			var got string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get("X-RC-Canary")
+				w.Write([]byte(`{"items":[]}`))
+			}))
+			defer srv.Close()
+
+			c := api.NewClient(api.Options{APIKey: "sk_test", BaseURL: srv.URL, Canary: canary})
+			if _, err := c.Projects.List(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if got != canary {
+				t.Errorf("X-RC-Canary = %q, want %q", got, canary)
+			}
+		})
+	}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -29,6 +29,8 @@ type Options struct {
 	BaseURL    string
 	HTTPClient *http.Client
 	UserAgent  string
+	// Canary is sent as X-RC-Canary to route requests to a canary deployment.
+	Canary string
 }
 
 type cacheEntry struct {
@@ -41,6 +43,7 @@ type Client struct {
 	apiKey    string
 	http      *http.Client
 	userAgent string
+	canary    string
 	cache     sync.Map // url string → cacheEntry; GET-only, session-scoped
 
 	Projects        *ProjectsService
@@ -77,7 +80,7 @@ func NewClient(opts Options) *Client {
 	if ua == "" {
 		ua = "revenuecat-cli/dev"
 	}
-	c := &Client{baseURL: u, apiKey: opts.APIKey, http: hc, userAgent: ua}
+	c := &Client{baseURL: u, apiKey: opts.APIKey, http: hc, userAgent: ua, canary: opts.Canary}
 	c.Projects = &ProjectsService{c: c}
 	c.Customers = &CustomersService{c: c}
 	c.Entitlements = &EntitlementsService{c: c}
@@ -121,6 +124,9 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any) err
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", c.userAgent)
+	if c.canary != "" {
+		req.Header.Set("X-RC-Canary", c.canary)
+	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -228,6 +234,9 @@ func (c *Client) Raw(ctx context.Context, method, path string, body []byte) ([]b
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", c.userAgent)
+	if c.canary != "" {
+		req.Header.Set("X-RC-Canary", c.canary)
+	}
 	if len(body) > 0 {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/internal/astra/astra.go
+++ b/internal/astra/astra.go
@@ -96,6 +96,7 @@ type Client struct {
 	baseURL   string
 	token     string
 	userAgent string
+	canary    string
 	rest      *http.Client
 	stream    *http.Client
 }
@@ -104,6 +105,8 @@ type Options struct {
 	BaseURL   string
 	Token     string
 	UserAgent string
+	// Canary is sent as X-RC-Canary to route requests to a canary deployment.
+	Canary string
 	// HTTPClient overrides both REST and streaming transports (tests).
 	HTTPClient *http.Client
 }
@@ -125,6 +128,7 @@ func NewClient(opts Options) *Client {
 		baseURL:   baseURL,
 		token:     opts.Token,
 		userAgent: opts.UserAgent,
+		canary:    opts.Canary,
 		rest:      rest,
 		stream:    stream,
 	}
@@ -156,6 +160,9 @@ func (c *Client) newRequest(ctx context.Context, path string, body any) (*http.R
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
+	}
+	if c.canary != "" {
+		req.Header.Set("X-RC-Canary", c.canary)
 	}
 	return req, nil
 }

--- a/internal/astra/canary_test.go
+++ b/internal/astra/canary_test.go
@@ -1,0 +1,29 @@
+package astra
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCanaryHeader(t *testing.T) {
+	for name, canary := range map[string]string{"set": "my-canary", "unset": ""} {
+		t.Run(name, func(t *testing.T) {
+			var got string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get("X-RC-Canary")
+				w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+
+			client := NewClient(Options{BaseURL: server.URL, Token: "tok", Canary: canary})
+			if err := client.Feedback(context.Background(), "sess", "trace", "up"); err != nil {
+				t.Fatal(err)
+			}
+			if got != canary {
+				t.Errorf("X-RC-Canary = %q, want %q", got, canary)
+			}
+		})
+	}
+}

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -523,6 +523,7 @@ func astraClient(rt *Runtime, baseURL string) (*astra.Client, error) {
 		BaseURL:   baseURL,
 		Token:     agentAuthToken(rt),
 		UserAgent: userAgent(rt.Globals.Version),
+		Canary:    canaryName(),
 	}), nil
 }
 

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -667,6 +667,7 @@ func ricoClient(rt *Runtime, baseURL string) (*rico.Client, error) {
 		BaseURL:   baseURL,
 		Token:     agentAuthToken(rt),
 		UserAgent: userAgent(rt.Globals.Version),
+		Canary:    canaryName(),
 	}), nil
 }
 

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -58,6 +58,7 @@ func (r *Runtime) API() (*api.Client, error) {
 		APIKey:    r.Config.BearerToken(), // works for both API keys and OAuth tokens
 		BaseURL:   r.Config.BaseURL,
 		UserAgent: userAgent(r.Globals.Version),
+		Canary:    canaryName(),
 	})
 	return r.client, nil
 }
@@ -92,6 +93,12 @@ func oauthClientID() string {
 		return v
 	}
 	return api.DefaultOAuthClientID
+}
+
+// canaryName returns the X-RC-Canary routing value from RC_CANARY, so any
+// command can target a canary deployment (e.g. RC_CANARY=my-canary rc ...).
+func canaryName() string {
+	return os.Getenv("RC_CANARY")
 }
 
 func userAgent(version string) string {

--- a/internal/rico/canary_test.go
+++ b/internal/rico/canary_test.go
@@ -1,0 +1,29 @@
+package rico
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCanaryHeader(t *testing.T) {
+	for name, canary := range map[string]string{"set": "my-canary", "unset": ""} {
+		t.Run(name, func(t *testing.T) {
+			var got string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get("X-RC-Canary")
+				w.Write([]byte(`[]`))
+			}))
+			defer server.Close()
+
+			client := NewClient(Options{BaseURL: server.URL, Token: "tok", Canary: canary})
+			if _, err := client.ListConversations(context.Background(), ""); err != nil {
+				t.Fatal(err)
+			}
+			if got != canary {
+				t.Errorf("X-RC-Canary = %q, want %q", got, canary)
+			}
+		})
+	}
+}

--- a/internal/rico/client.go
+++ b/internal/rico/client.go
@@ -27,6 +27,7 @@ type Client struct {
 	baseURL   string
 	token     string
 	userAgent string
+	canary    string
 	rest      *http.Client
 	stream    *http.Client
 }
@@ -35,6 +36,8 @@ type Options struct {
 	BaseURL   string
 	Token     string
 	UserAgent string
+	// Canary is sent as X-RC-Canary to route requests to a canary deployment.
+	Canary string
 	// HTTPClient overrides both REST and streaming transports (tests).
 	HTTPClient *http.Client
 }
@@ -58,6 +61,7 @@ func NewClient(opts Options) *Client {
 		baseURL:   baseURL,
 		token:     opts.Token,
 		userAgent: opts.UserAgent,
+		canary:    opts.Canary,
 		rest:      rest,
 		stream:    stream,
 	}
@@ -114,6 +118,9 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body any) 
 	}
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
+	}
+	if c.canary != "" {
+		req.Header.Set("X-RC-Canary", c.canary)
 	}
 	return req, nil
 }


### PR DESCRIPTION
## Why

Testing server-side changes on a canary (e.g. the khepri token-exchange change in RevenueCat/khepri#22834) needs the CLI's requests routed there. RevenueCat's canary routing keys off the `X-RC-Canary` header.

## What

- `RC_CANARY=<name>` sends `X-RC-Canary: <name>` on every request from the v2 API, Rico, and Astra clients
- Unset → no header, nothing changes
- Follows the existing `RC_*` env pattern; read once in the cli layer (`canaryName()`), passed via each client's `Options`

```bash
RC_CANARY=my-canary rc rico chat "hello"
RC_CANARY=my-canary rc api get /projects
```

Based on `pr-13-astra-rico` since the Rico/Astra clients live there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)