### PR TITLE
fix(astra): send bearer only, no rc_auth_token cookie

### DIFF
--- a/internal/astra/astra.go
+++ b/internal/astra/astra.go
@@ -152,10 +152,7 @@ func (c *Client) newRequest(ctx context.Context, path string, body any) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	// The dashboard authenticates with the rc_auth_token cookie; send the
-	// bearer header too for token-based auth support.
 	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.AddCookie(&http.Cookie{Name: "rc_auth_token", Value: c.token})
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
 	if c.userAgent != "" {

--- a/internal/astra/astra_test.go
+++ b/internal/astra/astra_test.go
@@ -19,8 +19,8 @@ func TestStreamDecodesEvents(t *testing.T) {
 		if got := r.Header.Get("Authorization"); got != "Bearer tok_123" {
 			t.Errorf("Authorization = %q", got)
 		}
-		if cookie, err := r.Cookie("rc_auth_token"); err != nil || cookie.Value != "tok_123" {
-			t.Errorf("rc_auth_token cookie = %v, err %v", cookie, err)
+		if _, err := r.Cookie("rc_auth_token"); err == nil {
+			t.Error("rc_auth_token cookie must not be sent")
 		}
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Errorf("decode body: %v", err)


### PR DESCRIPTION
## Why

The Astra client sent the credential both as `Authorization: Bearer` and as an `rc_auth_token` cookie. A cookie takes precedence in Astra's auth middleware and forces its dashboard-session path, which can't validate the CLI's OAuth access token — so the cookie actively breaks CLI-token auth regardless of any server-side fix.

## What

- Astra requests send the bearer header only; the cookie is gone
- Test asserts the cookie is never sent
- Nothing is persisted differently: config already stores only API key / OAuth tokens, and the signup flow's temporary session token stays transient (used to authorize the OAuth code, then logged out)

Stacked on #26 (`rc-canary-env`) → #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)