### PR TITLE
feat(auth): import RevenueCat credential from an agent's MCP config

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -236,16 +236,31 @@ anything on disk.`,
 				return fmt.Errorf("pass --api-key or set RC_API_KEY for non-interactive login")
 			}
 
+			// A RevenueCat credential already in an agent's MCP config is
+			// offered as a fast start (skips the browser). It's opaque, so we
+			// can't tell if it's still alive here — validation happens when
+			// it's used, and a dead one nudges to browser login.
+			found := discoverMCPCredentials()
+			options := make([]huh.Option[string], 0, len(found)+2)
+			for i, c := range found {
+				options = append(options, huh.NewOption(c.label(), fmt.Sprintf("mcp:%d", i)))
+			}
+			options = append(options,
+				huh.NewOption("Log in with RevenueCat  (opens browser)", loginMethodOAuth),
+				huh.NewOption("API key  (paste from dashboard)", loginMethodAPIKey),
+			)
+
 			var method string
-			sel := huh.NewSelect[string]().
-				Title("Login method").
-				Options(
-					huh.NewOption("Log in with RevenueCat  (opens browser)", loginMethodOAuth),
-					huh.NewOption("API key  (paste from dashboard)", loginMethodAPIKey),
-				).
-				Value(&method)
-			if err := tui.Form(false).Field(sel).Run(); err != nil {
+			if err := tui.Form(false).
+				Field(huh.NewSelect[string]().Title("Login method").Options(options...).Value(&method)).
+				Run(); err != nil {
 				return err
+			}
+			if strings.HasPrefix(method, "mcp:") {
+				var i int
+				fmt.Sscanf(method, "mcp:%d", &i)
+				rt.Out.Answer("Login method", "imported from "+found[i].Source+" MCP config")
+				return loginWithMCPCredential(cmd.Context(), rt, found[i])
 			}
 			rt.Out.Answer("Login method", map[string]string{loginMethodOAuth: "browser (RevenueCat account)", loginMethodAPIKey: "API key"}[method])
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -429,12 +429,11 @@ func loginWithAPIKey(ctx context.Context, rt *Runtime, key string) error {
 	if err != nil {
 		return err
 	}
-	// Validate the key before clearing the project binding or saving, so a bad
-	// key fails fast instead of reporting a false "Logged in" (and breaking on
-	// the first real command), and a failed login never announces a project
-	// clear that was never persisted. Account-level read, no project needed.
+	// Validate before clearing or saving: a bad key fails fast instead of a
+	// false "Logged in", and a failed login won't announce a project clear.
 	if _, err := client.Projects.List(ctx); err != nil {
-		return fmt.Errorf("that API key didn't work — check it at https://app.revenuecat.com/settings/api-keys: %w", err)
+		rt.Out.Hint("Check your key at https://app.revenuecat.com/settings/api-keys")
+		return fmt.Errorf("that API key didn't work: %w", err)
 	}
 	clearProjectBinding(rt)
 	return finishLogin(ctx, rt, client)

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -258,7 +258,12 @@ anything on disk.`,
 			}
 			if strings.HasPrefix(method, "mcp:") {
 				var i int
-				fmt.Sscanf(method, "mcp:%d", &i)
+				// method comes only from the Select above, so the index is
+				// always valid today — but validate anyway so a future flag or
+				// menu change can't turn this into an out-of-bounds panic.
+				if n, _ := fmt.Sscanf(method, "mcp:%d", &i); n != 1 || i < 0 || i >= len(found) {
+					return fmt.Errorf("invalid MCP credential selection %q", method)
+				}
 				rt.Out.Answer("Login method", "imported from "+found[i].Source+" MCP config")
 				return loginWithMCPCredential(cmd.Context(), rt, found[i])
 			}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -424,12 +424,19 @@ func loginWithAPIKey(ctx context.Context, rt *Runtime, key string) error {
 	rt.Config.TokenExpiresAt = time.Time{}
 	rt.Config.AccountEmail = ""
 	rt.Config.AccountName = ""
-	clearProjectBinding(rt)
 
 	client, err := rt.API()
 	if err != nil {
 		return err
 	}
+	// Validate the key before clearing the project binding or saving, so a bad
+	// key fails fast instead of reporting a false "Logged in" (and breaking on
+	// the first real command), and a failed login never announces a project
+	// clear that was never persisted. Account-level read, no project needed.
+	if _, err := client.Projects.List(ctx); err != nil {
+		return fmt.Errorf("that API key didn't work — check it at https://app.revenuecat.com/settings/api-keys: %w", err)
+	}
+	clearProjectBinding(rt)
 	return finishLogin(ctx, rt, client)
 }
 

--- a/internal/cli/auth_mcp_import.go
+++ b/internal/cli/auth_mcp_import.go
@@ -156,13 +156,9 @@ func loginWithMCPCredential(ctx context.Context, rt *Runtime, cred mcpCredential
 	if err != nil {
 		return err
 	}
-	// Validate the borrowed token before persisting OR clearing anything the
-	// user can see. finishLogin only saves config, so without an explicit API
-	// call a dead/expired token would look like a successful login and fail
-	// only on the first real command. Doing this before clearProjectBinding
-	// also means a failed import doesn't announce a project clear that never
-	// gets saved. A cheap account-level read (no project binding needed) proves
-	// the token works.
+	// Validate before clearing or saving: a dead token fails here instead of
+	// faking a "Logged in" that breaks on first use, and a failed import won't
+	// announce a project clear that never saved.
 	if _, err := client.Projects.List(ctx); err != nil {
 		rt.Out.Hint("Run `rc login` and choose browser login instead.")
 		return fmt.Errorf("that %s token didn't work (it may have already expired — they last about an hour): %w", cred.Source, err)

--- a/internal/cli/auth_mcp_import.go
+++ b/internal/cli/auth_mcp_import.go
@@ -157,8 +157,15 @@ func loginWithMCPCredential(ctx context.Context, rt *Runtime, cred mcpCredential
 	if err != nil {
 		return err
 	}
-	if err := finishLogin(ctx, rt, client); err != nil {
+	// Validate the borrowed token before persisting it. finishLogin only saves
+	// config, so without an explicit API call a dead/expired token would look
+	// like a successful login and fail only on the first real command. A cheap
+	// account-level read (no project binding needed) proves the token works.
+	if _, err := client.Projects.List(ctx); err != nil {
 		return fmt.Errorf("that %s token didn't work (it may have already expired — they last about an hour). Run `rc login` and choose browser login: %w", cred.Source, err)
+	}
+	if err := finishLogin(ctx, rt, client); err != nil {
+		return err
 	}
 	rt.Out.Hint("This token expires within the hour and can't refresh. Run `rc login` (browser) when you want a session that stays logged in.")
 	return nil

--- a/internal/cli/auth_mcp_import.go
+++ b/internal/cli/auth_mcp_import.go
@@ -140,7 +140,6 @@ func loginWithMCPCredential(ctx context.Context, rt *Runtime, cred mcpCredential
 	if cred.durable {
 		return loginWithAPIKey(ctx, rt, cred.Token)
 	}
-	clearProjectBinding(rt)
 	rt.Config.APIKey = ""
 	rt.Config.TokenType = "oauth"
 	rt.Config.AccessToken = cred.Token
@@ -157,13 +156,19 @@ func loginWithMCPCredential(ctx context.Context, rt *Runtime, cred mcpCredential
 	if err != nil {
 		return err
 	}
-	// Validate the borrowed token before persisting it. finishLogin only saves
-	// config, so without an explicit API call a dead/expired token would look
-	// like a successful login and fail only on the first real command. A cheap
-	// account-level read (no project binding needed) proves the token works.
+	// Validate the borrowed token before persisting OR clearing anything the
+	// user can see. finishLogin only saves config, so without an explicit API
+	// call a dead/expired token would look like a successful login and fail
+	// only on the first real command. Doing this before clearProjectBinding
+	// also means a failed import doesn't announce a project clear that never
+	// gets saved. A cheap account-level read (no project binding needed) proves
+	// the token works.
 	if _, err := client.Projects.List(ctx); err != nil {
-		return fmt.Errorf("that %s token didn't work (it may have already expired — they last about an hour). Run `rc login` and choose browser login: %w", cred.Source, err)
+		rt.Out.Hint("Run `rc login` and choose browser login instead.")
+		return fmt.Errorf("that %s token didn't work (it may have already expired — they last about an hour): %w", cred.Source, err)
 	}
+	// Token is good — now safe to clear a stale project binding and persist.
+	clearProjectBinding(rt)
 	if err := finishLogin(ctx, rt, client); err != nil {
 		return err
 	}

--- a/internal/cli/auth_mcp_import.go
+++ b/internal/cli/auth_mcp_import.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Importing an existing RevenueCat MCP credential lets a dev who already has
+// the MCP working skip the browser round-trip. The token lives in plaintext
+// in the agent's MCP config (an http MCP server carries auth in a header), so
+// we can read it. Two kinds:
+//
+//   - sk_… : a v2 secret key. Durable, no expiry. Ideal.
+//   - atk_…: an OAuth access token. khepri issues these with a 1-hour TTL
+//     (OAUTH2_TOKEN_EXPIRES_IN_SECONDS=3600) and the config carries NO refresh
+//     token — that lives in the client's private store. So an imported atk_ is
+//     a fast start, not a durable session: it works until it expires and rc
+//     can't refresh it. The token is opaque, so we can't read its remaining
+//     life; we validate by actually calling the API at import.
+
+type mcpCredential struct {
+	Source  string // "Claude Code", "Cursor"
+	Token   string
+	durable bool // sk_ key (no expiry) vs atk_ (1h, no refresh)
+}
+
+// runningViaNpx reports whether this process was launched by `npx` (the binary
+// runs out of npm's _npx cache) rather than an installed rc (brew, npm -g,
+// release tarball). Importing a borrowed 1-hour MCP token is a throwaway-session
+// convenience, so it's only offered on npx runs; an installed rc should log in
+// properly. RC_FORCE_NPX_IMPORT=1 overrides for testing.
+func runningViaNpx() bool {
+	if os.Getenv("RC_FORCE_NPX_IMPORT") == "1" {
+		return true
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(filepath.ToSlash(exe), "/_npx/")
+}
+
+func discoverMCPCredentials() []mcpCredential {
+	// Only surface MCP-imported credentials for throwaway npx sessions; an
+	// installed rc gets the durable login paths only.
+	if !runningViaNpx() {
+		return nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	var creds []mcpCredential
+	seen := map[string]bool{}
+	add := func(source, header string) {
+		token := strings.TrimSpace(header)
+		token = strings.TrimPrefix(token, "Bearer ")
+		token = strings.TrimPrefix(token, "bearer ")
+		if token == "" || seen[token] {
+			return
+		}
+		seen[token] = true
+		creds = append(creds, mcpCredential{
+			Source:  source,
+			Token:   token,
+			durable: strings.HasPrefix(token, "sk_"),
+		})
+	}
+	for _, tok := range revenueCatTokensFromJSON(filepath.Join(home, ".claude.json")) {
+		add("Claude Code", tok)
+	}
+	for _, tok := range revenueCatTokensFromJSON(filepath.Join(home, ".cursor", "mcp.json")) {
+		add("Cursor", tok)
+	}
+	return creds
+}
+
+// revenueCatTokensFromJSON walks a JSON file for mcpServers entries whose URL
+// is the RevenueCat MCP and returns their Authorization header value.
+func revenueCatTokensFromJSON(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var root any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil
+	}
+	var out []string
+	var walk func(any)
+	walk = func(node any) {
+		switch n := node.(type) {
+		case map[string]any:
+			if servers, ok := n["mcpServers"].(map[string]any); ok {
+				for _, cfg := range servers {
+					cm, ok := cfg.(map[string]any)
+					if !ok {
+						continue
+					}
+					if url, _ := cm["url"].(string); !strings.Contains(url, "mcp.revenuecat.ai") {
+						continue
+					}
+					if headers, ok := cm["headers"].(map[string]any); ok {
+						if auth, ok := headers["Authorization"].(string); ok {
+							out = append(out, auth)
+						}
+					}
+				}
+			}
+			for _, v := range n {
+				walk(v)
+			}
+		case []any:
+			for _, v := range n {
+				walk(v)
+			}
+		}
+	}
+	walk(root)
+	return out
+}
+
+func (c mcpCredential) label() string {
+	if c.durable {
+		return fmt.Sprintf("Use the RevenueCat key from your %s config  (stays logged in)", c.Source)
+	}
+	return fmt.Sprintf("Use the RevenueCat token from your %s config  (quick start; expires within the hour, no auto-refresh)", c.Source)
+}
+
+// loginWithMCPCredential stores an imported credential the same way its native
+// path would (sk_ as an API key, atk_ as an oauth access token) then validates
+// it with a real call via loginWithAPIKey/finishLogin. A dead atk_ fails that
+// call, and we translate it into a browser-login nudge.
+func loginWithMCPCredential(ctx context.Context, rt *Runtime, cred mcpCredential) error {
+	if cred.durable {
+		return loginWithAPIKey(ctx, rt, cred.Token)
+	}
+	clearProjectBinding(rt)
+	rt.Config.APIKey = ""
+	rt.Config.TokenType = "oauth"
+	rt.Config.AccessToken = cred.Token
+	// No refresh token and no expiry on purpose: this is a borrowed access
+	// token. Empty RefreshToken makes Config.NeedsRefresh() return false, so
+	// rc never tries (and never could) to refresh it — which also means it
+	// can't rotation-revoke the MCP's own session.
+	rt.Config.RefreshToken = ""
+	rt.Config.TokenExpiresAt = time.Time{}
+	rt.Config.AccountEmail = ""
+	rt.Config.AccountName = ""
+	rt.client = nil
+	client, err := rt.API()
+	if err != nil {
+		return err
+	}
+	if err := finishLogin(ctx, rt, client); err != nil {
+		return fmt.Errorf("that %s token didn't work (it may have already expired — they last about an hour). Run `rc login` and choose browser login: %w", cred.Source, err)
+	}
+	rt.Out.Hint("This token expires within the hour and can't refresh. Run `rc login` (browser) when you want a session that stays logged in.")
+	return nil
+}

--- a/internal/cli/auth_mcp_import_test.go
+++ b/internal/cli/auth_mcp_import_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/config"
+)
+
+// An imported MCP access token must never be refreshable: it has no refresh
+// token, so NeedsRefresh must stay false even though it's an oauth token.
+// This is the guarantee that keeps rc from rotation-revoking the MCP session.
+func TestImportedToken_NeverRefreshes(t *testing.T) {
+	cfg := &config.Config{}
+	// Mirror what loginWithMCPCredential stores for an atk_ token.
+	cfg.TokenType = "oauth"
+	cfg.AccessToken = "atk_borrowed"
+	cfg.RefreshToken = ""
+	if cfg.NeedsRefresh() {
+		t.Fatal("imported token with no refresh token must not report NeedsRefresh")
+	}
+	// And a durable sk_ import stays a plain API key (also never refreshes).
+	cfg2 := &config.Config{APIKey: "sk_durable"}
+	if cfg2.NeedsRefresh() {
+		t.Fatal("sk_ key must not report NeedsRefresh")
+	}
+}
+
+// discoverMCPCredentials pulls the RevenueCat bearer out of a Claude-style
+// config and classifies atk_ (borrowed) vs sk_ (durable).
+func TestDiscoverMCPCredentials_ClassifiesTokens(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("RC_FORCE_NPX_IMPORT", "1") // import is npx-only; force it on for the test
+	claude := map[string]any{
+		"mcpServers": map[string]any{
+			"RevenueCat": map[string]any{
+				"type": "http", "url": "https://mcp.revenuecat.ai/mcp",
+				"headers": map[string]any{"Authorization": "Bearer atk_abc123"},
+			},
+			"Other": map[string]any{
+				"type": "http", "url": "https://example.com/mcp",
+				"headers": map[string]any{"Authorization": "Bearer nope"},
+			},
+		},
+	}
+	data, _ := json.Marshal(claude)
+	if err := os.WriteFile(filepath.Join(dir, ".claude.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	creds := discoverMCPCredentials()
+	if len(creds) != 1 {
+		t.Fatalf("expected 1 RevenueCat credential, got %d", len(creds))
+	}
+	if creds[0].Token != "atk_abc123" || creds[0].durable {
+		t.Fatalf("atk_ should be non-durable: %+v", creds[0])
+	}
+}
+
+// Off an npx run, MCP import is suppressed entirely — installed rc gets the
+// durable login paths only.
+func TestDiscoverMCPCredentials_SuppressedWhenNotNpx(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	// no RC_FORCE_NPX_IMPORT, and the test binary isn't under /_npx/
+	claude := `{"mcpServers":{"RevenueCat":{"type":"http","url":"https://mcp.revenuecat.ai/mcp","headers":{"Authorization":"Bearer atk_abc123"}}}}`
+	if err := os.WriteFile(filepath.Join(dir, ".claude.json"), []byte(claude), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if creds := discoverMCPCredentials(); len(creds) != 0 {
+		t.Fatalf("import should be suppressed off npx, got %d creds", len(creds))
+	}
+}


### PR DESCRIPTION
## What this is
Some AI agents (Claude Code, Cursor) keep a RevenueCat auth token in their local MCP config. When you run the CLI via `npx` in that same setup, the token is already there — so `rc login` can offer it as a one-tap start and skip the browser.

## How it's used
```
$ npx @revenuecat/cli login
# in a session that already has the RevenueCat MCP configured:
? Log in with the RevenueCat token from your Claude Code MCP config?  ›
  → picked → "Logged in" (no browser)
```

## What it does
Finds a RevenueCat token in a Claude Code / Cursor MCP config and offers it:
- `sk_…` (secret API key) → stored durably, like a normal API-key login.
- `atk_…` (short-lived OAuth token) → borrowed with **no** refresh token and **no** expiry saved, so the CLI never refreshes it.
- npx runs only; an installed `rc` ignores MCP configs. The token is opaque, so validity is checked with a real API call at import — a dead one nudges you to browser login.

## Why "borrow only the access token"
RevenueCat OAuth rotates refresh tokens *with revocation* — if two clients share one, refreshing from either revokes the other. Sharing the MCP's refresh token would silently kill its session. Copying only the short-lived access token gives the fast start without touching anything that would break the MCP.

## Review focus
- The never-refresh guarantee (no refresh token / no expiry stored) — the core safety property; tests assert it.
- npx-only gating — an installed `rc` must not read MCP configs.
- Tests cover the never-refresh guarantee, token classification (`sk_` vs `atk_`), and off-npx suppression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication flows and reads local MCP auth headers, but npx gating and the no-refresh-token design limit blast radius; API validation before save reduces false success states.
> 
> **Overview**
> **Interactive `rc auth login` on `npx` runs** can now offer credentials already stored in Claude Code or Cursor MCP configs (`Authorization` headers for `mcp.revenuecat.ai`), so users can skip the browser when the agent already has RevenueCat wired up.
> 
> **`sk_` keys** are imported like a normal API-key login (durable). **`atk_` access tokens** are stored as OAuth access tokens **without** a refresh token or expiry, so the CLI never attempts refresh and avoids rotation-revoking the MCP’s session; users get a hint that the session is short-lived.
> 
> MCP discovery is **npx-only** (installed `rc` ignores MCP files unless `RC_FORCE_NPX_IMPORT=1`). Tokens are validated with a real `Projects.List` call before persisting; **`loginWithAPIKey`** now validates before clearing project binding so bad keys fail fast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c0bc6dd5448f455669b879f1bcc1f89a3bf2493. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->