### PR TITLE
fix: foundation robustness (BaseURL, exit codes, pagination)

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -69,7 +69,13 @@ func NewClient(opts Options) *Client {
 	if base == "" {
 		base = DefaultBaseURL
 	}
-	u, _ := url.Parse(base)
+	u, err := url.Parse(base)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		// Never leave baseURL nil/relative — buildURL dereferences it, so a bad
+		// URL here would panic on the first request. Callers should validate
+		// user input; this is the last-resort guard.
+		u, _ = url.Parse(DefaultBaseURL)
+	}
 	hc := opts.HTTPClient
 	if hc == nil {
 		hc = &http.Client{Timeout: 30 * time.Second}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -3,19 +3,40 @@ package api
 import (
 	"context"
 	"net/http"
+	"net/url"
 )
 
 type ProjectsService struct{ c *Client }
 
 // Project type is generated in types_gen.go.
 
-// GET /projects
+// GET /projects, following next_page until the account's projects are drained.
+// next_page is a full URL; we re-request through the base-relative path using
+// its starting_after cursor. If a page reports no cursor, we stop with what we
+// have (no worse than a single-page fetch).
 func (s *ProjectsService) List(ctx context.Context) (*Page[Project], error) {
-	var out Page[Project]
-	if err := s.c.do(ctx, http.MethodGet, "/projects", nil, &out); err != nil {
-		return nil, err
+	var all []Project
+	path := "/projects"
+	for {
+		var page Page[Project]
+		if err := s.c.do(ctx, http.MethodGet, path, nil, &page); err != nil {
+			return nil, err
+		}
+		all = append(all, page.Items...)
+		if page.NextPage == "" {
+			break
+		}
+		u, err := url.Parse(page.NextPage)
+		if err != nil {
+			break
+		}
+		cursor := u.Query().Get("starting_after")
+		if cursor == "" {
+			break
+		}
+		path = "/projects?starting_after=" + url.QueryEscape(cursor)
 	}
-	return &out, nil
+	return &Page[Project]{Items: all}, nil
 }
 
 // POST /projects

--- a/internal/api/projects_test.go
+++ b/internal/api/projects_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -77,5 +78,44 @@ func TestProjectsGetWorkaround(t *testing.T) {
 	var apiErr *api.APIError
 	if !errors.As(err, &apiErr) || apiErr.Type != "resource_missing" {
 		t.Errorf("want resource_missing error, got %v", err)
+	}
+}
+
+// List must follow next_page: an account with more projects than fit on one
+// page should return them all, not just the first page.
+func TestProjectsList_Paginates(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("starting_after") == "" {
+			fmt.Fprintf(w, `{"items":[{"id":"proj_1"}],"next_page":%q}`, srv.URL+"/projects?starting_after=proj_1")
+			return
+		}
+		fmt.Fprint(w, `{"items":[{"id":"proj_2"}]}`)
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(api.Options{APIKey: "sk_test", BaseURL: srv.URL})
+	page, err := c.Projects.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("want 2 projects across 2 pages, got %d", len(page.Items))
+	}
+	if page.Items[0].ID != "proj_1" || page.Items[1].ID != "proj_2" {
+		t.Errorf("unexpected items: %+v", page.Items)
+	}
+}
+
+// An invalid BaseURL must not panic: buildURL dereferences the parsed base, so
+// a nil base would crash on the first request. The constructor falls back to a
+// valid default instead.
+func TestNewClient_InvalidBaseURLDoesNotPanic(t *testing.T) {
+	c := api.NewClient(api.Options{APIKey: "x", BaseURL: "://not-a-url"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // fail fast at the transport, after buildURL has run
+	if _, err := c.Projects.List(ctx); err == nil {
+		t.Skip("request unexpectedly succeeded; test only guards against a panic")
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -685,3 +685,17 @@ func contains(haystack []string, needle string) bool {
 	}
 	return false
 }
+
+// Usage errors (bad flags, unknown command) get the conventional exit code 2,
+// distinct from a runtime failure (1). Guards the FlagErrorFunc sentinel and
+// the cobra-message match in ExitCodeFor.
+func TestExitCode_UsageErrorsAre2(t *testing.T) {
+	_, _, err := runCmd(t, "definitely-not-a-real-command")
+	if got := cli.ExitCodeFor(err); got != 2 {
+		t.Errorf("unknown command should exit 2, got %d (err: %v)", got, err)
+	}
+	_, _, err = runCmd(t, "version", "--definitely-not-a-flag")
+	if got := cli.ExitCodeFor(err); got != 2 {
+		t.Errorf("unknown flag should exit 2, got %d (err: %v)", got, err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -151,7 +151,9 @@ Agent-friendly entrypoints:
 		newVersionCmd(),
 	)
 
-	root.SetFlagErrorFunc(suggestFlag)
+	root.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return usageError{suggestFlag(cmd, err)}
+	})
 	applySurfaceProfile(root)
 
 	// --help skips PersistentPreRunE, so re-apply the surface from the parsed

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/revenuecat/cli/internal/api"
@@ -13,8 +15,26 @@ import (
 	"github.com/revenuecat/cli/internal/output"
 )
 
-// usageError signals exit 2 — bad user input that's not the API's fault.
-// Anything matching errors.Is(err, output.ErrBadFormat) lands here too.
+// usageError marks bad user input (bad flags) so ExitCodeFor returns the
+// conventional exit 2. Flag errors are wrapped with it via the root's
+// FlagErrorFunc; cobra's own unknown-command / arg-count errors don't pass
+// through that hook, so ExitCodeFor also matches their stable messages.
+type usageError struct{ err error }
+
+func (e usageError) Error() string { return e.err.Error() }
+func (e usageError) Unwrap() error { return e.err }
+
+// cobra emits these prefixes for command/arg misuse; none pass through
+// FlagErrorFunc, so match them by message.
+func isCobraUsage(err error) bool {
+	msg := err.Error()
+	for _, p := range []string{"unknown command", "accepts ", "requires "} {
+		if strings.HasPrefix(msg, p) {
+			return true
+		}
+	}
+	return false
+}
 
 type runtimeKey struct{}
 
@@ -53,6 +73,11 @@ func (r *Runtime) API() (*api.Client, error) {
 
 	if r.Config.BearerToken() == "" {
 		return nil, ErrNotAuthenticated
+	}
+	if b := r.Config.BaseURL; b != "" {
+		if u, err := url.Parse(b); err != nil || u.Scheme == "" || u.Host == "" {
+			return nil, fmt.Errorf("invalid base URL %q (RC_BASE_URL or profile base_url): expected an absolute URL like https://api.revenuecat.com/v2", b)
+		}
 	}
 	r.client = api.NewClient(api.Options{
 		APIKey:    r.Config.BearerToken(), // works for both API keys and OAuth tokens
@@ -115,6 +140,10 @@ func ExitCodeFor(err error) int {
 		return 0
 	}
 	if errors.Is(err, output.ErrBadFormat) {
+		return 2
+	}
+	var ue usageError
+	if errors.As(err, &ue) || isCobraUsage(err) {
 		return 2
 	}
 	var apiErr *api.APIError


### PR DESCRIPTION
## What this is
The CLI talks to the RevenueCat v2 API through one HTTP client (`internal/api`). This fixes three robustness gaps in that foundation.

## How they show up for a user
```
$ RC_BASE_URL="://bad" rc projects list      # used to CRASH (nil-pointer panic); now a clear error
$ rc bogus-command                            # now exits 2 (usage error), not 1
$ rc projects list                            # now returns ALL projects, not just the first page
```

## What it does
- **Invalid BaseURL:** `NewClient` discarded the `url.Parse` error, leaving `baseURL` nil → panic in `buildURL` on the first request. Now falls back to a valid default, and `rt.API()` rejects a malformed base URL with a clear message.
- **Exit codes:** `ExitCodeFor` now returns the conventional `2` for usage errors — bad flags (via a `FlagErrorFunc` sentinel) and unknown-command/arg errors (matched on cobra's stable messages) — instead of `1`.
- **Pagination:** `Projects.List` now follows `next_page` instead of returning only the first page (also fixes `Projects.Get`, which filters over `List`).

## Why
The BaseURL case was a real latent panic; exit-code `2` is the convention scripts and agents expect for "you used it wrong"; and pagination silently truncated the project list.

## Review focus
- The pagination cursor handling in `Projects.List`.
- The exit-code detection — the flag path uses a typed sentinel, but unknown-command/arg errors are matched on cobra's message strings (the least-elegant bit; documented in code).
- Tests added for all three.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect every authenticated API call path (BaseURL validation) and global CLI exit semantics; pagination alters project list completeness but is localized to projects.
> 
> **Overview**
> Hardens the shared HTTP client and CLI exit behavior so misconfiguration and usage mistakes fail predictably instead of panicking or returning wrong exit codes.
> 
> **Invalid `BaseURL`:** `NewClient` now rejects parse failures and missing scheme/host by falling back to the default API URL (avoiding a nil `baseURL` panic in `buildURL`). `Runtime.API()` additionally returns a clear error when profile/`RC_BASE_URL` is set but not a valid absolute URL.
> 
> **Exit code 2 for usage errors:** Bad flags are wrapped in a `usageError` via `FlagErrorFunc`; `ExitCodeFor` also treats cobra’s unknown-command and arg-count messages as usage (exit **2**), not generic failure (**1**).
> 
> **Project list pagination:** `Projects.List` loops on `next_page`, extracting `starting_after` from the cursor URL and aggregating all items—so `projects list` and `Projects.Get` (list-and-filter) see the full account project set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e94b64af2c46d9fc2084c4738de327bee5f9b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->