### PR TITLE
test(cli): cover command-surface curation

### DIFF
--- a/internal/cli/surface.go
+++ b/internal/cli/surface.go
@@ -50,9 +50,16 @@ func showAllSurface(root *cobra.Command) bool {
 // include them (they gate on the punted annotation, not Hidden).
 func applySurfaceProfile(root *cobra.Command) {
 	if testing.Testing() {
-		return // tests assert the full surface
+		return // tests assert the full surface; the rules themselves are
+		// covered directly by TestCurateSurface.
 	}
-	all := showAllSurface(root)
+	curateSurface(root, showAllSurface(root))
+}
+
+// curateSurface applies the visibility rules. Split out of applySurfaceProfile
+// so the rules are testable without the testing.Testing() short-circuit, which
+// would otherwise let curation regress with nothing catching it.
+func curateSurface(root *cobra.Command, all bool) {
 	for _, cmd := range root.Commands() {
 		switch {
 		case cmd.Annotations[annotationSurface] == surfacePunted:

--- a/internal/cli/surface_test.go
+++ b/internal/cli/surface_test.go
@@ -40,3 +40,38 @@ func TestCommandSurface_SchemaIncludesAgentOnlyExcludesPunted(t *testing.T) {
 		t.Error("punted command 'setup' should not appear in the schema surface")
 	}
 }
+
+// The human-help curation runs behind a testing.Testing() short-circuit, so
+// this drives curateSurface directly to keep the rules honest: humans see the
+// curated set, agents don't, punted stays hidden even under --all.
+func TestCurateSurface(t *testing.T) {
+	root := NewRootCmd("test")
+	hidden := func(name string) bool {
+		for _, c := range root.Commands() {
+			if c.Name() == name {
+				return c.Hidden
+			}
+		}
+		t.Fatalf("command %q not registered", name)
+		return false
+	}
+
+	curateSurface(root, false) // default help
+	if hidden("paywalls") {
+		t.Error("human command 'paywalls' should be visible in --help")
+	}
+	if !hidden("customer") {
+		t.Error("agent-only 'customer' should be hidden from --help")
+	}
+	if !hidden("setup") {
+		t.Error("punted 'setup' should be hidden")
+	}
+
+	curateSurface(root, true) // rc --all
+	if hidden("customer") {
+		t.Error("--all should reveal agent-only 'customer'")
+	}
+	if !hidden("setup") {
+		t.Error("--all must NOT reveal punted 'setup'")
+	}
+}


### PR DESCRIPTION
## What this is
The CLI deliberately shows humans a short, curated command list in `--help`, while agents and `--json`/schema output see the *full* set — "the command surface." Commands are tiered: human (shown), agent-only (hidden from `--help`, still runnable + in schema), and punted (hidden everywhere). This PR adds test coverage for those rules.

## How it's used
```
$ rc --help              # curated: paywalls, capital, auth, projects, apps, …
$ rc --all               # everything, including agent-only commands
$ rc commands --schemas  # full machine-readable surface (what agents see)
```
No user-facing change here — this is purely test coverage.

## What it does
`applySurfaceProfile` short-circuits under `testing.Testing()`, so the curation rules were never actually exercised by any test. This extracts the rules into a testable `curateSurface(root, all)` and adds a direct test for them.

## Why
Because the real code path is skipped in tests, the human/agent/punted split could regress and nothing would catch it. Splitting the rules out lets a test drive them without disturbing the ~20 tests that rely on seeing the full surface.

## Review focus
- The extraction is behavior-preserving (same switch, just callable).
- The test asserts: human commands visible, agent-only hidden from `--help`, punted hidden even under `--all`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor plus tests only; production path still uses the same visibility switch via `curateSurface`.
> 
> **Overview**
> Adds test coverage for CLI `--help` command visibility with **no user-facing behavior change**.
> 
> `applySurfaceProfile` still skips curation when `testing.Testing()` is true, so the human vs agent-only vs punted rules were never exercised in tests. The same switch logic is moved into **`curateSurface(root, all)`**, which `applySurfaceProfile` calls in production.
> 
> **`TestCurateSurface`** calls `curateSurface` directly and checks default help shows human commands (e.g. `paywalls`), hides agent-only (`customer`), and keeps punted (`setup`) hidden; with `all=true`, agent-only is revealed but punted stays hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d4e68a46f9588ae1f5ccd58619e4725410cec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->