### PR TITLE
fix(config): reject unsafe profile names

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,8 +5,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
+
+// validateProfileName rejects names that would escape the config dir when
+// joined into a file path (path separators, "..", empty). Profile names come
+// from --profile, RC_PROFILE, or the .active file, so an unchecked name like
+// "../../x" would read/write outside ~/.config/revenuecat.
+func validateProfileName(name string) error {
+	if name == "" || name == "." || name == ".." ||
+		strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		return fmt.Errorf("invalid profile name %q: must not be empty or contain path separators", name)
+	}
+	return nil
+}
 
 type Config struct {
 	// API key auth (original).
@@ -118,6 +131,9 @@ func bytesTrimSpace(b []byte) []byte {
 // SetActiveProfile writes the .active pointer file. Errors if the named
 // profile doesn't exist on disk (avoids "active" pointing at nothing).
 func SetActiveProfile(name string) error {
+	if err := validateProfileName(name); err != nil {
+		return err
+	}
 	dir, err := configDir()
 	if err != nil {
 		return err
@@ -165,6 +181,9 @@ func filepathIsJSON(name string) bool {
 // DeleteProfile removes a profile file. If it was the active one, the
 // .active pointer is cleared.
 func DeleteProfile(name string) error {
+	if err := validateProfileName(name); err != nil {
+		return err
+	}
 	dir, err := configDir()
 	if err != nil {
 		return err
@@ -197,11 +216,15 @@ func configDir() (string, error) {
 }
 
 func profilePath(profile string) (string, error) {
+	name := ProfileName(profile)
+	if err := validateProfileName(name); err != nil {
+		return "", err
+	}
 	dir, err := configDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, ProfileName(profile)+".json"), nil
+	return filepath.Join(dir, name+".json"), nil
 }
 
 // Load reads a profile from disk, layering env vars on top.
@@ -277,11 +300,15 @@ func Save(profile string, cfg *Config) error {
 // statePath returns the path of a named auxiliary state file stored beside
 // the profile files (e.g. the last Rico conversation per profile).
 func statePath(profile, name string) (string, error) {
+	pname := ProfileName(profile)
+	if err := validateProfileName(pname); err != nil {
+		return "", err
+	}
 	dir, err := configDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, ProfileName(profile)+"."+name+".json"), nil
+	return filepath.Join(dir, pname+"."+name+".json"), nil
 }
 
 // LoadState reads a named state file into out. A missing file is not an

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -258,3 +258,20 @@ func TestSave_DoesNotPersistEnvOverrides(t *testing.T) {
 		t.Errorf("explicit project change not persisted: got %q, want proj_chosen", got.ProjectID)
 	}
 }
+
+// A profile name must not escape the config dir via path separators or "..".
+func TestProfileName_RejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": dir, "RC_PROFILE": "", "RC_API_KEY": ""})
+	for _, bad := range []string{"../evil", "a/b", "..", `a\b`} {
+		if _, err := config.Load(bad); err == nil {
+			t.Errorf("Load(%q) should reject an unsafe profile name", bad)
+		}
+		if err := config.Save(bad, &config.Config{}); err == nil {
+			t.Errorf("Save(%q) should reject an unsafe profile name", bad)
+		}
+	}
+	if err := config.Save("staging", &config.Config{ProjectID: "p"}); err != nil {
+		t.Errorf("a normal profile name must still work: %v", err)
+	}
+}


### PR DESCRIPTION
## What this is
The CLI stores each auth profile in a file named after the profile — `~/.config/revenuecat/<profile>.json`. The profile name comes from `--profile`, the `RC_PROFILE` env var, or the `.active` pointer file. Those names were joined straight into a file path with no validation.

## How the bug shows up
```
$ rc projects list --profile ../../../tmp/evil
# previously read/wrote OUTSIDE ~/.config/revenuecat — a path traversal.
# now: error, "invalid profile name … must not contain path separators"
```

## What it does
Validates the profile name (rejects path separators, `..`, and empty) at every place a name becomes a path: `profilePath`, `statePath`, `SetActiveProfile`, and `DeleteProfile`. Adds a test covering the traversal cases and that normal names still work.

## Why
An unchecked name like `../../x` would read or write files outside the config directory — a config-dir path traversal.

## Review focus
- The `validateProfileName` rule and that it's applied at all four choke points.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Security-hardening with narrow scope: rejects malicious profile names at path construction without changing auth or API behavior; regression risk is low given explicit tests.
> 
> **Overview**
> Closes a **config-directory path traversal** where profile names from `--profile`, `RC_PROFILE`, or `.active` were joined into paths like `~/.config/revenuecat/<profile>.json` without checks, so names such as `../evil` or `a/b` could read or write outside the config dir.
> 
> Adds **`validateProfileName`** (rejects empty, `.`, `..`, path separators, and embedded `..`) and runs it wherever a name becomes a filesystem path: **`profilePath`** / **`statePath`** (covering **`Load`**, **`Save`**, state helpers), plus **`SetActiveProfile`** and **`DeleteProfile`**.
> 
> Adds **`TestProfileName_RejectsPathTraversal`** for bad names on **`Load`/`Save`** and confirms normal names still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c804b7adb77029c96e262aa139ba8aad813b9b23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->