### PR TITLE
make `offering-id` optional for `paywalls generate`

### DIFF
--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -209,7 +209,7 @@ rc products store discard <plan-id>                      # discard without apply
 rc paywalls list
 rc paywalls show <id>
 rc paywalls create                                       # create an offering-attached draft
-rc paywalls generate [offering-id] --prompt "..."        # AI-design a new draft via Astra (live-verified); saves the design to the draft; --standalone for no offering
+rc paywalls generate [--offering-id <id>] --prompt "..." # AI-design a new standalone draft via Astra (live-verified); optionally attach it to an offering
 rc paywalls edit <paywall-id>|--session <file> --prompt  # AI-edit any paywall (draft components fetched via v2) or continue a session
 rc paywalls rewind --session <file>                      # undo the last editor action
 rc paywalls publish [id]                                 # publish the current draft; confirmation/--yes

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -209,7 +209,7 @@ rc products store discard <plan-id>                      # discard without apply
 rc paywalls list
 rc paywalls show <id>
 rc paywalls create                                       # create an offering-attached draft
-rc paywalls generate [offering-id] --prompt "..."        # AI-design a new draft via Astra (live-verified); saves the design to the draft
+rc paywalls generate [offering-id] --prompt "..."        # AI-design a new draft via Astra (live-verified); saves the design to the draft; --standalone for no offering
 rc paywalls edit <paywall-id>|--session <file> --prompt  # AI-edit any paywall (draft components fetched via v2) or continue a session
 rc paywalls rewind --session <file>                      # undo the last editor action
 rc paywalls publish [id]                                 # publish the current draft; confirmation/--yes

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -266,14 +266,14 @@ func runAgentCmd(t *testing.T, args ...string) (string, string, error) {
 }
 
 func TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession(t *testing.T) {
-	apiURL, astraURL, editorInputs, _ := astraTestServers(t, "ofrng_default")
+	apiURL, astraURL, editorInputs, createInputs := astraTestServers(t, "ofrng_default")
 	t.Setenv("RC_BASE_URL", apiURL)
 	t.Setenv("RC_ASTRA_BASE_URL", astraURL)
 
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.json")
 	stdout, _, err := runAgentCmd(t,
-		"paywalls", "generate", "ofrng_default",
+		"paywalls", "generate", "--offering-id", "ofrng_default",
 		"--prompt", "A calm annual-first paywall",
 		"--session", sessionPath,
 		"--project-id", "proj1",
@@ -295,6 +295,9 @@ func TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession(t *testing.T) {
 	}
 	if envelope.Data.PaywallID != "pw_new" || envelope.Data.SessionID != "sess1" || envelope.Data.TraceID != "tr1" {
 		t.Fatalf("data = %+v", envelope.Data)
+	}
+	if offeringID := (*createInputs)[0]["offering_id"]; offeringID != "ofrng_default" {
+		t.Fatalf("create offering_id = %v", offeringID)
 	}
 
 	// The editor request carried the project, paywall, prompt, and state.
@@ -348,10 +351,11 @@ func TestPaywallsGenerate_Standalone(t *testing.T) {
 	apiURL, astraURL, editorInputs, createInputs := astraTestServers(t, "")
 	t.Setenv("RC_BASE_URL", apiURL)
 	t.Setenv("RC_ASTRA_BASE_URL", astraURL)
+	t.Setenv("RC_OFFERING_ID", "")
 
 	sessionPath := filepath.Join(t.TempDir(), "session.json")
 	_, _, err := runAgentCmd(t,
-		"paywalls", "generate", "--standalone", "--name", "Summer sale",
+		"paywalls", "generate", "--name", "Summer sale",
 		"--prompt", "A calm annual-first paywall",
 		"--session", sessionPath,
 		"--project-id", "proj1",
@@ -396,18 +400,10 @@ func TestPaywallsGenerate_Standalone(t *testing.T) {
 	}
 }
 
-func TestPaywallsGenerate_StandaloneConflictsWithOffering(t *testing.T) {
-	_, _, err := runCmd(t, "paywalls", "generate", "ofrng_x", "--standalone",
+func TestPaywallsGenerate_RejectsPositionalOffering(t *testing.T) {
+	_, _, err := runCmd(t, "paywalls", "generate", "ofrng_x", "--prompt", "x",
 		"--project-id", "proj1", "--no-input", "--api-key", "sk_test")
-	if err == nil || !strings.Contains(err.Error(), "--standalone cannot be combined") {
-		t.Fatalf("err = %v", err)
-	}
-}
-
-func TestPaywallsGenerate_NoInputRequiresOfferingOrStandalone(t *testing.T) {
-	_, _, err := runCmd(t, "paywalls", "generate", "--prompt", "x",
-		"--project-id", "proj1", "--no-input", "--api-key", "sk_test")
-	if err == nil || !strings.Contains(err.Error(), "--standalone") {
+	if err == nil || !strings.Contains(err.Error(), "unknown command") {
 		t.Fatalf("err = %v", err)
 	}
 }

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -187,22 +187,32 @@ func TestRicoConversations_ListJSON(t *testing.T) {
 	}
 }
 
-// astraServers stubs both the v2 API (draft creation) and the Astra editor.
-func astraTestServers(t *testing.T) (apiURL, astraURL string, editorInputs *[]map[string]any) {
+// astraTestServers stubs both the v2 API (draft creation) and the Astra
+// editor. offeringID == "" makes the stubs serve a standalone paywall
+// (offering_id null everywhere).
+func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string, editorInputs, createInputs *[]map[string]any) {
 	t.Helper()
+	offeringJSON := "null"
+	if offeringID != "" {
+		offeringJSON = `"` + offeringID + `"`
+	}
+	var created []map[string]any
 	var patched []map[string]any
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/paywalls"):
-			io.WriteString(w, `{"id":"pw_new","offering_id":"ofrng_default","created_at":1720000000000,"published_at":null}`)
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			created = append(created, body)
+			io.WriteString(w, `{"id":"pw_new","offering_id":`+offeringJSON+`,"created_at":1720000000000,"published_at":null}`)
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
-			io.WriteString(w, `{"id":"pw_new","offering_id":"ofrng_default","created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":3,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
+			io.WriteString(w, `{"id":"pw_new","offering_id":`+offeringJSON+`,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":3,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
 		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
 			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			patched = append(patched, body)
-			io.WriteString(w, `{"id":"pw_new","offering_id":"ofrng_default","created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":4,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
+			io.WriteString(w, `{"id":"pw_new","offering_id":`+offeringJSON+`,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":4,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
 		default:
 			t.Errorf("unexpected API request %s %s", r.Method, r.URL.Path)
 		}
@@ -234,11 +244,11 @@ func astraTestServers(t *testing.T) (apiURL, astraURL string, editorInputs *[]ma
 		inputs = append(inputs, input)
 		w.Header().Set("Content-Type", "text/event-stream")
 		io.WriteString(w, "data: {\"type\":\"run.started\",\"session_id\":\"sess1\"}\n\n")
-		io.WriteString(w, "data: {\"type\":\"turn.snapshot\",\"session_id\":\"sess1\",\"turn_index\":0,\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":\"ofrng_default\",\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}}],\"__unstable_session_items\":[{\"k\":1}]}\n\n")
-		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":\"ofrng_default\",\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}},{\"id\":\"a2\",\"type\":\"assistant_message\",\"content\":\"Done — calm annual-first layout.\"}],\"__unstable_session_items\":[{\"k\":2}]}\n\n")
+		io.WriteString(w, "data: {\"type\":\"turn.snapshot\",\"session_id\":\"sess1\",\"turn_index\":0,\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":"+offeringJSON+",\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}}],\"__unstable_session_items\":[{\"k\":1}]}\n\n")
+		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":"+offeringJSON+",\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}},{\"id\":\"a2\",\"type\":\"assistant_message\",\"content\":\"Done — calm annual-first layout.\"}],\"__unstable_session_items\":[{\"k\":2}]}\n\n")
 	}))
 	t.Cleanup(astraServer.Close)
-	return apiServer.URL, astraServer.URL, &inputs
+	return apiServer.URL, astraServer.URL, &inputs, &created
 }
 
 // runAgentCmd is runCmd without the env reset, so RC_BASE_URL /
@@ -256,7 +266,7 @@ func runAgentCmd(t *testing.T, args ...string) (string, string, error) {
 }
 
 func TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession(t *testing.T) {
-	apiURL, astraURL, editorInputs := astraTestServers(t)
+	apiURL, astraURL, editorInputs, _ := astraTestServers(t, "ofrng_default")
 	t.Setenv("RC_BASE_URL", apiURL)
 	t.Setenv("RC_ASTRA_BASE_URL", astraURL)
 
@@ -331,6 +341,74 @@ func TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession(t *testing.T) {
 	config := paywall["components_config"].(map[string]any)
 	if config["stack"] != true {
 		t.Fatalf("components_config not round-tripped: %v", paywall)
+	}
+}
+
+func TestPaywallsGenerate_Standalone(t *testing.T) {
+	apiURL, astraURL, editorInputs, createInputs := astraTestServers(t, "")
+	t.Setenv("RC_BASE_URL", apiURL)
+	t.Setenv("RC_ASTRA_BASE_URL", astraURL)
+
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	_, _, err := runAgentCmd(t,
+		"paywalls", "generate", "--standalone", "--name", "Summer sale",
+		"--prompt", "A calm annual-first paywall",
+		"--session", sessionPath,
+		"--project-id", "proj1",
+		"--json", "--no-input", "--api-key", "sk_test",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The draft was created from components, not attached to an offering.
+	create := (*createInputs)[0]
+	if _, ok := create["offering_id"]; ok {
+		t.Fatalf("create body should not carry offering_id: %v", create)
+	}
+	if create["name"] != "Summer sale" || create["default_locale"] != "en_US" {
+		t.Fatalf("create body = %v", create)
+	}
+	if _, ok := create["components_config"]; !ok {
+		t.Fatalf("create body missing components_config: %v", create)
+	}
+	if _, ok := create["components_localizations"]; !ok {
+		t.Fatalf("create body missing components_localizations: %v", create)
+	}
+
+	// The editor request carried a null offering.
+	paywall := (*editorInputs)[0]["paywall"].(map[string]any)
+	if v, ok := paywall["offering_id"]; !ok || v != nil {
+		t.Fatalf("editor paywall.offering_id = %v (present %v)", v, ok)
+	}
+
+	// The session file round-trips the null offering.
+	payload, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var session map[string]any
+	if err := json.Unmarshal(payload, &session); err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := session["paywall"].(map[string]any)["offering_id"]; !ok || v != nil {
+		t.Fatalf("session paywall.offering_id = %v (present %v)", v, ok)
+	}
+}
+
+func TestPaywallsGenerate_StandaloneConflictsWithOffering(t *testing.T) {
+	_, _, err := runCmd(t, "paywalls", "generate", "ofrng_x", "--standalone",
+		"--project-id", "proj1", "--no-input", "--api-key", "sk_test")
+	if err == nil || !strings.Contains(err.Error(), "--standalone cannot be combined") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestPaywallsGenerate_NoInputRequiresOfferingOrStandalone(t *testing.T) {
+	_, _, err := runCmd(t, "paywalls", "generate", "--prompt", "x",
+		"--project-id", "proj1", "--no-input", "--api-key", "sk_test")
+	if err == nil || !strings.Contains(err.Error(), "--standalone") {
+		t.Fatalf("err = %v", err)
 	}
 }
 

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -65,7 +65,6 @@ type paywallAIOptions struct {
 	attachments []string
 	prompt      string
 	offeringID  string
-	standalone  bool
 	name        string
 	sessionPath string
 	images      []string
@@ -81,14 +80,11 @@ func newPaywallsGenerateCmd() *cobra.Command {
 		timeout:    12 * time.Minute,
 	}
 	cmd := &cobra.Command{
-		Use:   "generate [offering-id]",
+		Use:   "generate",
 		Short: "Generate a paywall draft with the Paywall AI editor",
-		Long: `Creates a draft paywall for an offering and designs it from a natural-language
+		Long: `Creates a standalone draft paywall and designs it from a natural-language
 prompt using Astra, the Paywall AI editor — the same engine behind the
-dashboard's AI mode.
-
-Standalone (--standalone, or pick "Standalone (no offering)" interactively)
-creates the draft with no offering; attach it later in the dashboard.
+dashboard's AI mode. Pass --offering-id to attach the draft to an offering.
 
 Each completed turn saves the design onto the RevenueCat paywall draft, and
 the editor state is also kept in a session file so follow-up edits retain the
@@ -96,10 +92,9 @@ conversation: pass the same --session to rc paywalls edit. Astra may answer
 with a clarifying question instead of a design — reply with another edit
 turn. The draft stays unpublished; review it and run rc paywalls publish.`,
 		Example: `  rc paywalls generate
-  rc paywalls generate ofrng_default --prompt "A calm annual-first paywall"
-  rc paywalls generate --standalone --name "Summer sale" --prompt "A calm annual-first paywall"
-  rc paywalls generate ofrng_default --prompt "Match our brand" --image brand.png --json --no-input`,
-		Args: cobra.MaximumNArgs(1),
+  rc paywalls generate --name "Summer sale" --prompt "A calm annual-first paywall"
+  rc paywalls generate --offering-id ofrng_default --prompt "Match our brand" --image brand.png --json --no-input`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -110,36 +105,12 @@ turn. The draft stays unpublished; review it and run rc paywalls publish.`,
 			if err != nil {
 				return err
 			}
-			if argAt(args, 0) != "" {
-				if opts.offeringID != "" && opts.offeringID != argAt(args, 0) {
-					return fmt.Errorf("offering ID was provided both positionally and with --offering-id")
-				}
-				opts.offeringID = argAt(args, 0)
-			}
-			if opts.standalone {
-				if argAt(args, 0) != "" || cmd.Flags().Changed("offering-id") {
-					return fmt.Errorf("--standalone cannot be combined with an offering ID")
-				}
-				opts.offeringID = "" // RC_OFFERING_ID may have seeded it; --standalone wins
-			} else {
-				if opts.offeringID == "" && (rt.Globals.NoInput || !tui.IsInteractive()) {
-					return fmt.Errorf("offering ID is required; pass an offering ID or --standalone to generate a paywall without one")
-				}
-				opts.offeringID, err = requireID(rt, opts.offeringID, "offering", func() ([]PickerItem, error) {
-					items, err := offeringPickerItems(cmd.Context(), client, projectID)
-					return append([]PickerItem{{ID: "", Label: "Standalone (no offering)"}}, items...), err
-				})
-				if err != nil {
-					return err
-				}
-				opts.standalone = opts.offeringID == ""
-			}
 			if err := requirePaywallAIPrompt(rt, &opts.prompt, "Describe the paywall you want"); err != nil {
 				return err
 			}
 
 			var paywall *api.Paywall
-			if opts.standalone {
+			if opts.offeringID == "" {
 				paywall, err = client.Paywalls.CreateFromComponents(cmd.Context(), projectID, api.PaywallComponentsCreate{
 					Name:                    opts.name,
 					ComponentsConfig:        json.RawMessage(minimalComponentsConfig),
@@ -158,7 +129,7 @@ turn. The draft stays unpublished; review it and run rc paywalls publish.`,
 			rt.Out.Info("Created draft paywall " + paywall.ID)
 
 			var offeringID *string
-			if !opts.standalone {
+			if opts.offeringID != "" {
 				offeringID = &opts.offeringID
 			}
 			session := &astraSession{
@@ -183,8 +154,7 @@ turn. The draft stays unpublished; review it and run rc paywalls publish.`,
 	}
 	addPaywallAIFlags(cmd, &opts)
 	cmd.Flags().StringVar(&opts.offeringID, "offering-id", opts.offeringID, "offering to attach (or RC_OFFERING_ID)")
-	cmd.Flags().BoolVar(&opts.standalone, "standalone", false, "create without an offering; attach later")
-	cmd.Flags().StringVar(&opts.name, "name", "", "paywall name (standalone paywalls)")
+	cmd.Flags().StringVar(&opts.name, "name", "", "paywall name (standalone drafts)")
 	return cmd
 }
 

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -65,6 +65,8 @@ type paywallAIOptions struct {
 	attachments []string
 	prompt      string
 	offeringID  string
+	standalone  bool
+	name        string
 	sessionPath string
 	images      []string
 	baseURL     string
@@ -85,6 +87,9 @@ func newPaywallsGenerateCmd() *cobra.Command {
 prompt using Astra, the Paywall AI editor — the same engine behind the
 dashboard's AI mode.
 
+Standalone (--standalone, or pick "Standalone (no offering)" interactively)
+creates the draft with no offering; attach it later in the dashboard.
+
 Each completed turn saves the design onto the RevenueCat paywall draft, and
 the editor state is also kept in a session file so follow-up edits retain the
 conversation: pass the same --session to rc paywalls edit. Astra may answer
@@ -92,6 +97,7 @@ with a clarifying question instead of a design — reply with another edit
 turn. The draft stays unpublished; review it and run rc paywalls publish.`,
 		Example: `  rc paywalls generate
   rc paywalls generate ofrng_default --prompt "A calm annual-first paywall"
+  rc paywalls generate --standalone --name "Summer sale" --prompt "A calm annual-first paywall"
   rc paywalls generate ofrng_default --prompt "Match our brand" --image brand.png --json --no-input`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -110,33 +116,58 @@ turn. The draft stays unpublished; review it and run rc paywalls publish.`,
 				}
 				opts.offeringID = argAt(args, 0)
 			}
-			opts.offeringID, err = requireID(rt, opts.offeringID, "offering", func() ([]PickerItem, error) {
-				return offeringPickerItems(cmd.Context(), client, projectID)
-			})
-			if err != nil {
-				return err
+			if opts.standalone {
+				if argAt(args, 0) != "" || cmd.Flags().Changed("offering-id") {
+					return fmt.Errorf("--standalone cannot be combined with an offering ID")
+				}
+				opts.offeringID = "" // RC_OFFERING_ID may have seeded it; --standalone wins
+			} else {
+				if opts.offeringID == "" && (rt.Globals.NoInput || !tui.IsInteractive()) {
+					return fmt.Errorf("offering ID is required; pass an offering ID or --standalone to generate a paywall without one")
+				}
+				opts.offeringID, err = requireID(rt, opts.offeringID, "offering", func() ([]PickerItem, error) {
+					items, err := offeringPickerItems(cmd.Context(), client, projectID)
+					return append([]PickerItem{{ID: "", Label: "Standalone (no offering)"}}, items...), err
+				})
+				if err != nil {
+					return err
+				}
+				opts.standalone = opts.offeringID == ""
 			}
 			if err := requirePaywallAIPrompt(rt, &opts.prompt, "Describe the paywall you want"); err != nil {
 				return err
 			}
 
-			paywall, err := client.Paywalls.Create(cmd.Context(), projectID, api.PaywallCreate{
-				OfferingID:                 opts.offeringID,
-				AutomaticallyScaleFontSize: true,
-			})
+			var paywall *api.Paywall
+			if opts.standalone {
+				paywall, err = client.Paywalls.CreateFromComponents(cmd.Context(), projectID, api.PaywallComponentsCreate{
+					Name:                    opts.name,
+					ComponentsConfig:        json.RawMessage(minimalComponentsConfig),
+					ComponentsLocalizations: json.RawMessage(`{"en_US": {}}`),
+					DefaultLocale:           "en_US",
+				})
+			} else {
+				paywall, err = client.Paywalls.Create(cmd.Context(), projectID, api.PaywallCreate{
+					OfferingID:                 opts.offeringID,
+					AutomaticallyScaleFontSize: true,
+				})
+			}
 			if err != nil {
 				return fmt.Errorf("creating draft paywall: %w", err)
 			}
 			rt.Out.Info("Created draft paywall " + paywall.ID)
 
-			offeringID := opts.offeringID
+			var offeringID *string
+			if !opts.standalone {
+				offeringID = &opts.offeringID
+			}
 			session := &astraSession{
 				Version:   1,
 				ProjectID: projectID,
 				PaywallID: paywall.ID,
 				Paywall: astra.PaywallData{
 					DefaultLocale:           "en_US",
-					OfferingID:              &offeringID,
+					OfferingID:              offeringID,
 					ComponentsConfig:        json.RawMessage(minimalComponentsConfig),
 					ComponentsLocalizations: json.RawMessage(`{"en_US": {}}`),
 				},
@@ -152,6 +183,8 @@ turn. The draft stays unpublished; review it and run rc paywalls publish.`,
 	}
 	addPaywallAIFlags(cmd, &opts)
 	cmd.Flags().StringVar(&opts.offeringID, "offering-id", opts.offeringID, "offering to attach (or RC_OFFERING_ID)")
+	cmd.Flags().BoolVar(&opts.standalone, "standalone", false, "create without an offering; attach later")
+	cmd.Flags().StringVar(&opts.name, "name", "", "paywall name (standalone paywalls)")
 	return cmd
 }
 
@@ -419,7 +452,11 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 		rt.Out.Blank()
 		rt.Out.Field("View it", paywallBuilderURL(session.ProjectID, session.PaywallID))
 		rt.Out.Field("Keep designing", "rc paywalls edit --session "+opts.sessionPath)
-		rt.Out.Field("Publish when ready", "rc paywalls publish "+session.PaywallID)
+		if session.Paywall.OfferingID == nil {
+			rt.Out.Field("Attach it", "dashboard → Paywalls → "+session.PaywallID+" → attach to an offering")
+		} else {
+			rt.Out.Field("Publish when ready", "rc paywalls publish "+session.PaywallID)
+		}
 	}
 	if rt.Out.IsJSON() {
 		return rt.Out.Render(map[string]any{


### PR DESCRIPTION
Lets you generate a paywall without an offering so you can attach it later from the dashboard.