### PR TITLE
fix: keep offering-id hint when paywalls ai echoes null

### DIFF
--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -187,9 +187,9 @@ func TestRicoConversations_ListJSON(t *testing.T) {
 	}
 }
 
-// astraTestServers stubs both the v2 API (draft creation) and the Astra
-// editor. offeringID == "" makes the v2 API stubs serve a standalone paywall.
-// The Astra stream always echoes offering_id as null, matching the live
+// astraTestServers stubs both the v2 API (draft creation) and the AI editor.
+// offeringID == "" makes the v2 API stubs serve a standalone paywall.
+// The editor stream always echoes offering_id as null, matching the live
 // service, which never returns it.
 func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string, editorInputs, createInputs *[]map[string]any) {
 	t.Helper()
@@ -324,7 +324,7 @@ func TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession(t *testing.T) {
 	if items["k"] != 2.0 {
 		t.Fatalf("session items = %v", session["__unstable_session_items"])
 	}
-	// Astra echoes offering_id as null; the session keeps the attached offering.
+	// The editor echoes offering_id as null; the session keeps the attached offering.
 	if v := session["paywall"].(map[string]any)["offering_id"]; v != "ofrng_default" {
 		t.Fatalf("session paywall.offering_id = %v", v)
 	}
@@ -406,6 +406,55 @@ func TestPaywallsGenerate_Standalone(t *testing.T) {
 	}
 	if v, ok := session["paywall"].(map[string]any)["offering_id"]; !ok || v != nil {
 		t.Fatalf("session paywall.offering_id = %v (present %v)", v, ok)
+	}
+}
+
+// Offering attachment can change out-of-band (dashboard). The API stub reports
+// the paywall attached even though generate ran standalone — the session must
+// pick up the server truth from the PATCH response, so the next editor turn
+// carries the offering (it drives the editor's package/price context).
+func TestPaywallsGenerate_RefreshesOfferingFromServer(t *testing.T) {
+	apiURL, astraURL, editorInputs, _ := astraTestServers(t, "ofrng_default")
+	t.Setenv("RC_BASE_URL", apiURL)
+	t.Setenv("RC_ASTRA_BASE_URL", astraURL)
+	t.Setenv("RC_OFFERING_ID", "")
+
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	_, _, err := runAgentCmd(t,
+		"paywalls", "generate", "--name", "Summer sale",
+		"--prompt", "A calm annual-first paywall",
+		"--session", sessionPath,
+		"--project-id", "proj1",
+		"--json", "--no-input", "--api-key", "sk_test",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var session map[string]any
+	if err := json.Unmarshal(payload, &session); err != nil {
+		t.Fatal(err)
+	}
+	if v := session["paywall"].(map[string]any)["offering_id"]; v != "ofrng_default" {
+		t.Fatalf("session paywall.offering_id = %v", v)
+	}
+
+	_, _, err = runAgentCmd(t,
+		"paywalls", "edit",
+		"--session", sessionPath,
+		"--prompt", "Make annual the visual default",
+		"--json", "--no-input", "--api-key", "sk_test",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paywall := (*editorInputs)[1]["paywall"].(map[string]any)
+	if paywall["offering_id"] != "ofrng_default" {
+		t.Fatalf("edit paywall.offering_id = %v", paywall["offering_id"])
 	}
 }
 

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -188,8 +188,9 @@ func TestRicoConversations_ListJSON(t *testing.T) {
 }
 
 // astraTestServers stubs both the v2 API (draft creation) and the Astra
-// editor. offeringID == "" makes the stubs serve a standalone paywall
-// (offering_id null everywhere).
+// editor. offeringID == "" makes the v2 API stubs serve a standalone paywall.
+// The Astra stream always echoes offering_id as null, matching the live
+// service, which never returns it.
 func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string, editorInputs, createInputs *[]map[string]any) {
 	t.Helper()
 	offeringJSON := "null"
@@ -244,8 +245,8 @@ func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string,
 		inputs = append(inputs, input)
 		w.Header().Set("Content-Type", "text/event-stream")
 		io.WriteString(w, "data: {\"type\":\"run.started\",\"session_id\":\"sess1\"}\n\n")
-		io.WriteString(w, "data: {\"type\":\"turn.snapshot\",\"session_id\":\"sess1\",\"turn_index\":0,\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":"+offeringJSON+",\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}}],\"__unstable_session_items\":[{\"k\":1}]}\n\n")
-		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":"+offeringJSON+",\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}},{\"id\":\"a2\",\"type\":\"assistant_message\",\"content\":\"Done — calm annual-first layout.\"}],\"__unstable_session_items\":[{\"k\":2}]}\n\n")
+		io.WriteString(w, "data: {\"type\":\"turn.snapshot\",\"session_id\":\"sess1\",\"turn_index\":0,\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}}],\"__unstable_session_items\":[{\"k\":1}]}\n\n")
+		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}},{\"id\":\"a2\",\"type\":\"assistant_message\",\"content\":\"Done — calm annual-first layout.\"}],\"__unstable_session_items\":[{\"k\":2}]}\n\n")
 	}))
 	t.Cleanup(astraServer.Close)
 	return apiServer.URL, astraServer.URL, &inputs, &created
@@ -323,6 +324,10 @@ func TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession(t *testing.T) {
 	if items["k"] != 2.0 {
 		t.Fatalf("session items = %v", session["__unstable_session_items"])
 	}
+	// Astra echoes offering_id as null; the session keeps the attached offering.
+	if v := session["paywall"].(map[string]any)["offering_id"]; v != "ofrng_default" {
+		t.Fatalf("session paywall.offering_id = %v", v)
+	}
 
 	// Editing continues the same session with its saved state.
 	stdout, _, err = runAgentCmd(t,
@@ -345,6 +350,9 @@ func TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession(t *testing.T) {
 	config := paywall["components_config"].(map[string]any)
 	if config["stack"] != true {
 		t.Fatalf("components_config not round-tripped: %v", paywall)
+	}
+	if paywall["offering_id"] != "ofrng_default" {
+		t.Fatalf("edit paywall.offering_id = %v", paywall["offering_id"])
 	}
 }
 

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -401,8 +401,8 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 	session.SessionID = event.SessionID
 	session.TraceID = event.TraceID
 	if event.Paywall != nil {
-		// Astra doesn't manage offering attachment and echoes offering_id as
-		// null — keep what the CLI established.
+		// The AI editor doesn't manage offering attachment and echoes
+		// offering_id as null — keep what the CLI established.
 		offeringID := session.Paywall.OfferingID
 		session.Paywall = *event.Paywall
 		if session.Paywall.OfferingID == nil {
@@ -424,6 +424,11 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 		rt.Out.Hint("The design is safe in " + opts.sessionPath + " — re-run rc paywalls edit to retry saving.")
 	} else {
 		saved = true
+		// Persisting refreshed the revision and offering from the server;
+		// re-save so the next turn starts from them.
+		if err := saveAstraSession(opts.sessionPath, session); err != nil {
+			return err
+		}
 		rt.Out.Success("Design saved to paywall draft " + session.PaywallID)
 		if errored := countErroredActivity(event.Activity); errored > 0 {
 			rt.Out.Info(fmt.Sprintf("%d editor step(s) errored during the run and were retried by Astra — the saved draft is the complete final state (nothing partial is ever saved).", errored))
@@ -480,6 +485,14 @@ func persistPaywallDesign(ctx context.Context, rt *Runtime, session *astraSessio
 		if err == nil {
 			if updated.Components != nil && updated.Components.Draft != nil && updated.Components.Draft.Revision != nil {
 				session.Revision = updated.Components.Draft.Revision
+			}
+			// Offering attachment can change out-of-band (dashboard); the PATCH
+			// response carries current server truth, so refresh it — it drives
+			// the attach/publish hint and the editor's product context next turn.
+			if updated.OfferingID != "" {
+				session.Paywall.OfferingID = &updated.OfferingID
+			} else {
+				session.Paywall.OfferingID = nil
 			}
 			return nil
 		}

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -401,7 +401,13 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 	session.SessionID = event.SessionID
 	session.TraceID = event.TraceID
 	if event.Paywall != nil {
+		// Astra doesn't manage offering attachment and echoes offering_id as
+		// null — keep what the CLI established.
+		offeringID := session.Paywall.OfferingID
 		session.Paywall = *event.Paywall
+		if session.Paywall.OfferingID == nil {
+			session.Paywall.OfferingID = offeringID
+		}
 	}
 	if len(event.SessionItems) > 0 {
 		session.SessionItems = event.SessionItems


### PR DESCRIPTION
When generating with `--offering-id`, the closing hint was showing "Attach it" instead of "Publish when ready" because Astra echoes `offering_id` as `null` in its `run.completed` event. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI session persistence and user hints only; no auth or payment paths; behavior aligns session state with API truth.
> 
> **Overview**
> Fixes incorrect **Attach it** hints (instead of **Publish when ready**) when generate used `--offering-id`, because the Paywall AI editor always echoes `offering_id` as null in completed runs.
> 
> In `finishPaywallAI`, the session keeps the CLI-established offering when merging the editor paywall snapshot. After a successful draft PATCH, `persistPaywallDesign` updates `offering_id` from the API response (dashboard attachment can change out-of-band), and the session file is saved again so the next edit turn sends the right offering for product context.
> 
> Tests stub the editor with null `offering_id`, assert round-trip on generate/edit with an offering, and add coverage for standalone generate picking up server attachment after save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5408c0faeadf6804183b8758157bca052042f7c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->