### PR TITLE
docs: drop the "Astra" codename from user-facing wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or download a binary directly from the [releases page](../../releases).
 
 The two focused flows don't require installing anything:
 ```bash
-npx @revenuecat/cli paywalls generate   # design a paywall with Astra
+npx @revenuecat/cli paywalls generate   # AI-design a paywall
 npx @revenuecat/cli capital setup        # connect App Store Connect for RevenueCat Capital
 ```
 

--- a/docs/khepri-localizations-prompt.md
+++ b/docs/khepri-localizations-prompt.md
@@ -73,7 +73,7 @@ localization write).
 ## Verification
 
 From the RevenueCat CLI once deployed (paywall pw505aa79911c94808 in project
-proj9d48bef3 has real Astra-generated localizations to read):
+proj9d48bef3 has real Paywall AI-generated localizations to read):
 
 ```bash
 rc api get "/projects/proj9d48bef3/paywalls/pw505aa79911c94808/localizations"

--- a/internal/astra/astra.go
+++ b/internal/astra/astra.go
@@ -1,4 +1,4 @@
-// Package astra is a client for the Astra paywall AI editor backend
+// Package astra is a client for the Paywall AI editor backend
 // (astra.revenuecat.com), speaking the same SSE contract as the dashboard
 // and mobile apps.
 package astra
@@ -136,7 +136,7 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("Astra returned HTTP %d: %s", e.StatusCode, e.Message)
+	return fmt.Sprintf("the Paywall AI editor returned HTTP %d: %s", e.StatusCode, e.Message)
 }
 
 func (c *Client) newRequest(ctx context.Context, path string, body any) (*http.Request, error) {
@@ -148,7 +148,7 @@ func (c *Client) newRequest(ctx context.Context, path string, body any) (*http.R
 	if err != nil {
 		return nil, err
 	}
-	// Bearer only: Astra accepts CLI OAuth tokens in the Authorization
+	// Bearer only: the Paywall AI editor accepts CLI OAuth tokens in the Authorization
 	// header. Do not also send an rc_auth_token cookie — an invalid cookie
 	// shadows a valid bearer token and fails the whole request.
 	req.Header.Set("Authorization", "Bearer "+c.token)
@@ -196,7 +196,7 @@ func (c *Client) Stream(ctx context.Context, request EditorRequest) (*Stream, er
 	req.Header.Set("Accept", "text/event-stream")
 	resp, err := c.stream.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("calling Astra: %w", err)
+		return nil, fmt.Errorf("calling the Paywall AI editor: %w", err)
 	}
 	if err := checkStatus(resp); err != nil {
 		resp.Body.Close()
@@ -212,7 +212,7 @@ func (c *Client) doJSON(ctx context.Context, path string, body any) error {
 	}
 	resp, err := c.rest.Do(req)
 	if err != nil {
-		return fmt.Errorf("calling Astra: %w", err)
+		return fmt.Errorf("calling the Paywall AI editor: %w", err)
 	}
 	defer resp.Body.Close()
 	return checkStatus(resp)
@@ -254,7 +254,7 @@ func (s *Stream) Next() (*Event, error) {
 		}
 		var event Event
 		if err := json.Unmarshal([]byte(frame.Data), &event); err != nil {
-			return nil, fmt.Errorf("decoding Astra event: %w", err)
+			return nil, fmt.Errorf("decoding Paywall AI editor event: %w", err)
 		}
 		return &event, nil
 	}

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -187,7 +187,7 @@ func TestRicoConversations_ListJSON(t *testing.T) {
 	}
 }
 
-// astraTestServers stubs both the v2 API (draft creation) and the Astra
+// astraTestServers stubs both the v2 API (draft creation) and the Paywall AI
 // editor. offeringID == "" makes the stubs serve a standalone paywall
 // (offering_id null everywhere).
 func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string, editorInputs, createInputs *[]map[string]any) {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -20,8 +20,8 @@ import (
 	"github.com/revenuecat/cli/internal/tui"
 )
 
-// astraSession is the state file round-tripped between editor turns. Astra
-// keeps no server-side paywall state between requests: the client must resend
+// astraSession is the state file round-tripped between editor turns. The
+// Paywall AI editor keeps no server-side paywall state between requests: the client must resend
 // the full paywall plus the opaque session blobs every turn, so the CLI
 // persists them here (the dashboard holds the same data in builder state).
 type astraSession struct {
@@ -191,7 +191,7 @@ Using it well:
     visually, up to 3 images total.
   - Keep the SAME --session file across turns — it is the conversation
     memory. A lost session file starts the design conversation over.
-  - Astra may reply with a clarifying question instead of a design (it
+  - The Paywall AI editor may reply with a clarifying question instead of a design (it
     appears in the streamed activity / the --json activity array). Answer it
     with another edit turn on the same session.
   - Turns take one to several minutes and stream progress; run with an
@@ -327,7 +327,7 @@ func newPaywallsRewindCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&sessionPath, "session", "", "editor session file")
-	cmd.Flags().StringVar(&baseURL, "base-url", baseURL, "Astra endpoint (or RC_ASTRA_BASE_URL)")
+	cmd.Flags().StringVar(&baseURL, "base-url", baseURL, "Paywall AI editor endpoint (or RC_ASTRA_BASE_URL)")
 	return cmd
 }
 
@@ -337,7 +337,7 @@ func addPaywallAIFlags(cmd *cobra.Command, opts *paywallAIOptions) {
 	cmd.Flags().StringArrayVar(&opts.attachments, "attachment", nil, "design reference file: images (png/jpeg/webp) attach visually, text files (DESIGN.md, style guides) travel with the direction")
 	cmd.Flags().StringVar(&opts.sessionPath, "session", opts.sessionPath, "editor session file (default: <paywall-id>.astra.json)")
 	cmd.Flags().StringArrayVar(&opts.images, "image", nil, "reference image to attach (png/jpeg/webp, max 3)")
-	cmd.Flags().StringVar(&opts.baseURL, "base-url", opts.baseURL, "Astra endpoint (or RC_ASTRA_BASE_URL)")
+	cmd.Flags().StringVar(&opts.baseURL, "base-url", opts.baseURL, "Paywall AI editor endpoint (or RC_ASTRA_BASE_URL)")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "maximum time to wait")
 }
 
@@ -355,7 +355,7 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 	ctx, cancel := context.WithTimeout(ctx, opts.timeout)
 	defer cancel()
 
-	rt.Out.Info("Designing with Astra — this can take a few minutes…")
+	rt.Out.Info("Designing with the Paywall AI editor — this can take a few minutes…")
 	stream, err := client.Stream(ctx, astra.EditorRequest{
 		ProjectID:        session.ProjectID,
 		PaywallID:        session.PaywallID,
@@ -420,7 +420,7 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 		saved = true
 		rt.Out.Success("Design saved to paywall draft " + session.PaywallID)
 		if errored := countErroredActivity(event.Activity); errored > 0 {
-			rt.Out.Info(fmt.Sprintf("%d editor step(s) errored during the run and were retried by Astra — the saved draft is the complete final state (nothing partial is ever saved).", errored))
+			rt.Out.Info(fmt.Sprintf("%d editor step(s) errored during the run and were retried by the Paywall AI editor — the saved draft is the complete final state (nothing partial is ever saved).", errored))
 		}
 		rt.Out.Blank()
 		rt.Out.Field("View it", paywallBuilderURL(session.ProjectID, session.PaywallID))
@@ -507,14 +507,14 @@ func reportPaywallAIActivity(rt *Runtime, activity []astra.ToolActivity, already
 	for _, item := range activity[min(alreadyReported, len(activity)):] {
 		switch item.Type {
 		case "assistant_message":
-			rt.Out.Info("Astra: " + item.Content)
+			rt.Out.Info("Paywall AI: " + item.Content)
 		default:
 			text := item.Display.Text
 			if text == "" {
 				text = item.ToolName
 			}
 			if item.Status == "error" {
-				rt.Out.Warn("⚙ " + text + "  (errored — Astra retries these itself)")
+				rt.Out.Warn("⚙ " + text + "  (errored — the Paywall AI editor retries these itself)")
 			} else {
 				rt.Out.Info("⚙ " + text)
 			}
@@ -607,7 +607,7 @@ func requirePaywallAIPrompt(rt *Runtime, prompt *string, title string) error {
 		Run()
 }
 
-// withPaywallContext folds --context into the direction sent to Astra: the
+// withPaywallContext folds --context into the direction sent to the Paywall AI editor: the
 // skills document the flag (product/audience/brand context) and agents were
 // burning generation attempts on unknown-flag errors before hand-merging it.
 func withPaywallContext(prompt, context string) string {
@@ -628,7 +628,7 @@ func countErroredActivity(activity []astra.ToolActivity) int {
 }
 
 // loadPaywallAIAttachments routes --image and --attachment by type: image
-// files become real Astra attachments (the server accepts only
+// files become real Paywall AI editor attachments (the server accepts only
 // png/jpeg/webp, max 3, 10MB); text design references (DESIGN.md, style
 // guides) are folded into the message, which is the only channel the editor
 // API has for them today. Anything else (fonts, binaries) errors clearly.
@@ -651,7 +651,7 @@ func loadPaywallAIAttachments(images, attachments []string) ([]astra.InputAttach
 			}
 			textBlocks = append(textBlocks, "Design reference ("+filepath.Base(path)+"):\n```\n"+string(data)+"\n```")
 		default:
-			return nil, "", fmt.Errorf("unsupported attachment %q: Astra accepts images (png/jpeg/webp) and text design references (md/txt/json/yaml/css) — fonts and other binaries are not supported by the editor API yet", path)
+			return nil, "", fmt.Errorf("unsupported attachment %q: the Paywall AI editor accepts images (png/jpeg/webp) and text design references (md/txt/json/yaml/css) — fonts and other binaries are not supported by the editor API yet", path)
 		}
 	}
 	loaded, err := loadPaywallAIImages(imagePaths)

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -665,7 +665,7 @@ func ricoClient(rt *Runtime, baseURL string) (*rico.Client, error) {
 	}), nil
 }
 
-// agentAuthToken returns the credential sent to the Rico/Astra backends —
+// agentAuthToken returns the credential sent to the Rico/Paywall AI backends —
 // the CLI's own bearer token; both backends accept CLI OAuth tokens
 // (verified live 2026-07-17).
 func agentAuthToken(rt *Runtime) string {

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -1,5 +1,5 @@
 // Package sse implements a streaming Server-Sent Events reader shared by the
-// Rico and Astra agent clients.
+// Rico and Paywall AI agent clients.
 package sse
 
 import (


### PR DESCRIPTION
## What this is
Astra is the internal codename for the Paywall AI editor; the user-facing surface is `rc paywalls generate` / `rc paywalls edit`. This removes the codename from everywhere a user or agent can see it.

## What it does
Replaces "Astra" with "the Paywall AI editor" in: help text, flag descriptions, runtime `rt.Out` output, error messages (incl. the `internal/astra` client error strings), code comments, and the README.

## Out of scope (tracked in DX-859)
Leaves the things that need the agreed replacement name or are real infra:
- Go identifiers: the `internal/astra` package, `astraSession`, `loadAstraSession`, `RC_ASTRA_BASE_URL`, `.astra.json`
- Real infra names: `astra.revenuecat.com`, the `RevenueCat/astra` repo, git branch names

## Notes
- Stacked on #44. Pure wording/comment change — no behavior change; build/vet/tests green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and user-facing string renames only; no logic, config defaults, or wire protocol changes.
> 
> **Overview**
> Replaces the internal **Astra** codename with **Paywall AI** / **the Paywall AI editor** everywhere users and agents see it: README install hint, `rc paywalls` help and flag descriptions, streamed CLI output (`Paywall AI:` messages, progress lines), and error strings from `internal/astra`.
> 
> Docs and comments in `paywalls_ai.go`, `rico.go`, `agents_test.go`, and `internal/sse` are updated to match. **No runtime or API behavior changes.**
> 
> Identifiers and infra names stay as-is (per DX-859): `internal/astra`, `astraSession`, `RC_ASTRA_BASE_URL`, `.astra.json`, `astra.revenuecat.com`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fee9c341c847933dfe77d2cda404b2d686d1f646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->