### PR TITLE
fix: preflight revision check on stale edit sessions

### DIFF
--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -521,63 +521,6 @@ func TestPaywallsGenerate_DraftChangedDuringRun(t *testing.T) {
 	}
 }
 
-// Session files written before the revision guard carry "revision": null —
-// out-of-band changes can't be detected against them, so continuing needs
-// explicit consent, and consenting adopts the server's revision so the rest
-// of the turn is guarded.
-func TestPaywallsEdit_NullRevisionSessionNeedsConsent(t *testing.T) {
-	nullSession := strings.Replace(staleTestSession, `"revision": 3`, `"revision": null`, 1)
-	var patched []map[string]any
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
-			io.WriteString(w, paywallResponseJSON(5))
-		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
-			var body map[string]any
-			json.NewDecoder(r.Body).Decode(&body)
-			patched = append(patched, body)
-			io.WriteString(w, paywallResponseJSON(6))
-		default:
-			t.Errorf("unexpected API request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	t.Cleanup(apiServer.Close)
-	astraServer, astraRequests := stubEditorServer(t)
-	t.Setenv("RC_BASE_URL", apiServer.URL)
-	t.Setenv("RC_ASTRA_BASE_URL", astraServer.URL)
-
-	sessionPath := filepath.Join(t.TempDir(), "session.json")
-	if err := os.WriteFile(sessionPath, []byte(nullSession), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	_, _, err := runAgentCmd(t,
-		"paywalls", "edit",
-		"--session", sessionPath,
-		"--prompt", "Push the gradient harder",
-		"--no-input", "--api-key", "sk_test",
-	)
-	if err == nil || !strings.Contains(err.Error(), "pass --yes") {
-		t.Fatalf("err = %v", err)
-	}
-	if *astraRequests != 0 {
-		t.Fatalf("astra requests = %d, want 0 (no design turn without consent)", *astraRequests)
-	}
-
-	_, _, err = runAgentCmd(t,
-		"paywalls", "edit",
-		"--session", sessionPath,
-		"--prompt", "Push the gradient harder",
-		"--yes", "--json", "--no-input", "--api-key", "sk_test",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(patched) != 1 || patched[0]["revision"] != 5.0 {
-		t.Fatalf("patched = %v, want the adopted server revision 5", patched)
-	}
-}
-
 // An offering can only have one paywall; the server's bare 409 must come back
 // as a one-line explanation, with the ways out hinted on stderr.
 func TestPaywallsGenerate_OfferingAlreadyHasPaywall(t *testing.T) {

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -465,6 +465,119 @@ func TestPaywallsGenerate_RefreshesOfferingFromServer(t *testing.T) {
 	}
 }
 
+// A dashboard edit that lands during generate's multi-minute design turn must
+// surface as a conflict, not be clobbered: the PATCH carries the revision
+// fetched once at create time — refetching at persist would sail past
+// khepri's conflict guard.
+func TestPaywallsGenerate_DraftChangedDuringRun(t *testing.T) {
+	gets := 0
+	var patched []map[string]any
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/paywalls"):
+			io.WriteString(w, `{"id":"pw_new","offering_id":null,"created_at":1720000000000,"published_at":null}`)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
+			gets++
+			revision := 3 // at create time; 7 after the dashboard edit lands
+			if gets > 1 {
+				revision = 7
+			}
+			io.WriteString(w, paywallResponseJSON(revision))
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			patched = append(patched, body)
+			w.WriteHeader(http.StatusConflict)
+			io.WriteString(w, `{"object":"error","type":"resource_conflict","message":"draft revision is stale"}`)
+		default:
+			t.Errorf("unexpected API request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(apiServer.Close)
+	astraServer, _ := stubEditorServer(t)
+	t.Setenv("RC_BASE_URL", apiServer.URL)
+	t.Setenv("RC_ASTRA_BASE_URL", astraServer.URL)
+	t.Setenv("RC_OFFERING_ID", "")
+
+	stdout, _, err := runAgentCmd(t,
+		"paywalls", "generate", "--name", "Summer sale",
+		"--prompt", "A calm annual-first paywall",
+		"--session", filepath.Join(t.TempDir(), "session.json"),
+		"--project-id", "proj1",
+		"--json", "--no-input", "--api-key", "sk_test",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gets != 1 {
+		t.Fatalf("GETs = %d, want 1 (create-time only; persist must not refetch)", gets)
+	}
+	if len(patched) != 1 || patched[0]["revision"] != 3.0 {
+		t.Fatalf("patched = %v, want one PATCH carrying the create-time revision 3", patched)
+	}
+	if !strings.Contains(stdout, `"saved_to_draft": false`) {
+		t.Fatalf("stdout = %s", stdout)
+	}
+}
+
+// Session files written before the revision guard carry "revision": null —
+// out-of-band changes can't be detected against them, so continuing needs
+// explicit consent, and consenting adopts the server's revision so the rest
+// of the turn is guarded.
+func TestPaywallsEdit_NullRevisionSessionNeedsConsent(t *testing.T) {
+	nullSession := strings.Replace(staleTestSession, `"revision": 3`, `"revision": null`, 1)
+	var patched []map[string]any
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
+			io.WriteString(w, paywallResponseJSON(5))
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			patched = append(patched, body)
+			io.WriteString(w, paywallResponseJSON(6))
+		default:
+			t.Errorf("unexpected API request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(apiServer.Close)
+	astraServer, astraRequests := stubEditorServer(t)
+	t.Setenv("RC_BASE_URL", apiServer.URL)
+	t.Setenv("RC_ASTRA_BASE_URL", astraServer.URL)
+
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(sessionPath, []byte(nullSession), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := runAgentCmd(t,
+		"paywalls", "edit",
+		"--session", sessionPath,
+		"--prompt", "Push the gradient harder",
+		"--no-input", "--api-key", "sk_test",
+	)
+	if err == nil || !strings.Contains(err.Error(), "pass --yes") {
+		t.Fatalf("err = %v", err)
+	}
+	if *astraRequests != 0 {
+		t.Fatalf("astra requests = %d, want 0 (no design turn without consent)", *astraRequests)
+	}
+
+	_, _, err = runAgentCmd(t,
+		"paywalls", "edit",
+		"--session", sessionPath,
+		"--prompt", "Push the gradient harder",
+		"--yes", "--json", "--no-input", "--api-key", "sk_test",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(patched) != 1 || patched[0]["revision"] != 5.0 {
+		t.Fatalf("patched = %v, want the adopted server revision 5", patched)
+	}
+}
+
 // An offering can only have one paywall; the server's bare 409 must come back
 // as a one-line explanation, with the ways out hinted on stderr.
 func TestPaywallsGenerate_OfferingAlreadyHasPaywall(t *testing.T) {
@@ -487,6 +600,27 @@ func TestPaywallsGenerate_OfferingAlreadyHasPaywall(t *testing.T) {
 	if !strings.Contains(stderr, "omit --offering-id") {
 		t.Fatalf("stderr missing hint: %q", stderr)
 	}
+}
+
+// paywallResponseJSON is the v2 API paywall body for pw_new at a given draft
+// revision, shared by the stubs that pit stored revisions against the server.
+func paywallResponseJSON(revision int) string {
+	return fmt.Sprintf(`{"id":"pw_new","offering_id":null,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":%d,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`, revision)
+}
+
+// stubEditorServer serves one minimal completed design turn and counts the
+// requests it received.
+func stubEditorServer(t *testing.T) (*httptest.Server, *int) {
+	t.Helper()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "data: {\"type\":\"run.started\",\"session_id\":\"sess1\"}\n\n")
+		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[],\"__unstable_session_items\":[{\"k\":3}]}\n\n")
+	}))
+	t.Cleanup(server.Close)
+	return server, &requests
 }
 
 // staleTestSession is a session file whose stored revision the tests pit
@@ -513,14 +647,10 @@ func TestPaywallsEdit_StaleSessionStopsBeforeAstra(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, `{"id":"pw_new","offering_id":null,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":5,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
+		io.WriteString(w, paywallResponseJSON(5))
 	}))
 	t.Cleanup(apiServer.Close)
-	astraRequests := 0
-	astraServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		astraRequests++
-	}))
-	t.Cleanup(astraServer.Close)
+	astraServer, astraRequests := stubEditorServer(t)
 	t.Setenv("RC_BASE_URL", apiServer.URL)
 	t.Setenv("RC_ASTRA_BASE_URL", astraServer.URL)
 
@@ -537,8 +667,8 @@ func TestPaywallsEdit_StaleSessionStopsBeforeAstra(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "pass --yes") {
 		t.Fatalf("err = %v", err)
 	}
-	if astraRequests != 0 {
-		t.Fatalf("astra requests = %d, want 0 (no design turn on a stale session)", astraRequests)
+	if *astraRequests != 0 {
+		t.Fatalf("astra requests = %d, want 0 (no design turn on a stale session)", *astraRequests)
 	}
 	payload, err := os.ReadFile(sessionPath)
 	if err != nil {
@@ -560,23 +690,18 @@ func TestPaywallsEdit_PatchCarriesSessionRevision(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
 			gets++
-			io.WriteString(w, `{"id":"pw_new","offering_id":null,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":3,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
+			io.WriteString(w, paywallResponseJSON(3))
 		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
 			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			patched = append(patched, body)
-			io.WriteString(w, `{"id":"pw_new","offering_id":null,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":4,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
+			io.WriteString(w, paywallResponseJSON(4))
 		default:
 			t.Errorf("unexpected API request %s %s", r.Method, r.URL.Path)
 		}
 	}))
 	t.Cleanup(apiServer.Close)
-	astraServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		io.WriteString(w, "data: {\"type\":\"run.started\",\"session_id\":\"sess1\"}\n\n")
-		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[],\"__unstable_session_items\":[{\"k\":3}]}\n\n")
-	}))
-	t.Cleanup(astraServer.Close)
+	astraServer, _ := stubEditorServer(t)
 	t.Setenv("RC_BASE_URL", apiServer.URL)
 	t.Setenv("RC_ASTRA_BASE_URL", astraServer.URL)
 

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -188,9 +188,8 @@ func TestRicoConversations_ListJSON(t *testing.T) {
 	}
 }
 
-// paywallResponseJSON is the v2 API paywall body for pw_new — the one
-// template for every stub that serves it, whatever offering and draft
-// revision the test needs.
+// paywallResponseJSON is the v2 API paywall body for pw_new at a given
+// offering and draft revision.
 func paywallResponseJSON(offeringJSON string, revision int) string {
 	return fmt.Sprintf(`{"id":"pw_new","offering_id":%s,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":%d,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`, offeringJSON, revision)
 }
@@ -212,8 +211,8 @@ func stubEditorServer(t *testing.T) (*httptest.Server, *int) {
 
 // astraTestServers stubs both the v2 API (draft creation) and the Paywall AI
 // editor. offeringID == "" makes the v2 API stubs serve a standalone paywall.
-// The editor stream always echoes offering_id as null, matching the live
-// service, which never returns it.
+// The editor stream echoes offering_id as null, as the live service does
+// after a template load.
 func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string, editorInputs, createInputs *[]map[string]any) {
 	t.Helper()
 	offeringJSON := "null"
@@ -436,11 +435,9 @@ func TestPaywallsGenerate_Standalone(t *testing.T) {
 	}
 }
 
-// Offering attachment can change out-of-band (dashboard). The API stub reports
-// the paywall attached even though generate ran standalone — the session must
-// pick up the server truth from the PATCH response so the next editor turn
-// carries it (session-to-editor propagation itself is covered by
-// TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession).
+// Offering attachment can change out-of-band (dashboard). The API stub
+// reports the paywall attached even though generate ran standalone — the
+// session must pick up the server truth from the PATCH response.
 func TestPaywallsGenerate_RefreshesOfferingFromServer(t *testing.T) {
 	apiURL, astraURL, _, _ := astraTestServers(t, "ofrng_default")
 	t.Setenv("RC_BASE_URL", apiURL)

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -438,10 +438,11 @@ func TestPaywallsGenerate_Standalone(t *testing.T) {
 
 // Offering attachment can change out-of-band (dashboard). The API stub reports
 // the paywall attached even though generate ran standalone — the session must
-// pick up the server truth from the PATCH response, so the next editor turn
-// carries the offering (it drives the editor's package/price context).
+// pick up the server truth from the PATCH response so the next editor turn
+// carries it (session-to-editor propagation itself is covered by
+// TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession).
 func TestPaywallsGenerate_RefreshesOfferingFromServer(t *testing.T) {
-	apiURL, astraURL, editorInputs, _ := astraTestServers(t, "ofrng_default")
+	apiURL, astraURL, _, _ := astraTestServers(t, "ofrng_default")
 	t.Setenv("RC_BASE_URL", apiURL)
 	t.Setenv("RC_ASTRA_BASE_URL", astraURL)
 	t.Setenv("RC_OFFERING_ID", "")
@@ -468,20 +469,6 @@ func TestPaywallsGenerate_RefreshesOfferingFromServer(t *testing.T) {
 	}
 	if v := session["paywall"].(map[string]any)["offering_id"]; v != "ofrng_default" {
 		t.Fatalf("session paywall.offering_id = %v", v)
-	}
-
-	_, _, err = runAgentCmd(t,
-		"paywalls", "edit",
-		"--session", sessionPath,
-		"--prompt", "Make annual the visual default",
-		"--json", "--no-input", "--api-key", "sk_test",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	paywall := (*editorInputs)[1]["paywall"].(map[string]any)
-	if paywall["offering_id"] != "ofrng_default" {
-		t.Fatalf("edit paywall.offering_id = %v", paywall["offering_id"])
 	}
 }
 

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -199,6 +200,12 @@ func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string,
 	}
 	var created []map[string]any
 	var patched []map[string]any
+	// The draft revision is stateful like khepri's: GET serves the current
+	// one, a PATCH must carry it (the conflict guard) and bumps it.
+	revision := 3
+	paywallJSON := func() string {
+		return fmt.Sprintf(`{"id":"pw_new","offering_id":%s,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":%d,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`, offeringJSON, revision)
+	}
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -208,12 +215,16 @@ func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string,
 			created = append(created, body)
 			io.WriteString(w, `{"id":"pw_new","offering_id":`+offeringJSON+`,"created_at":1720000000000,"published_at":null}`)
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
-			io.WriteString(w, `{"id":"pw_new","offering_id":`+offeringJSON+`,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":3,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
+			io.WriteString(w, paywallJSON())
 		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
 			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
+			if body["revision"] != float64(revision) {
+				t.Errorf("PATCH revision = %v, server draft is at %d", body["revision"], revision)
+			}
 			patched = append(patched, body)
-			io.WriteString(w, `{"id":"pw_new","offering_id":`+offeringJSON+`,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":4,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
+			revision++
+			io.WriteString(w, paywallJSON())
 		default:
 			t.Errorf("unexpected API request %s %s", r.Method, r.URL.Path)
 		}
@@ -223,13 +234,9 @@ func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string,
 			t.Error("design was never PATCHed onto the RevenueCat draft")
 			return
 		}
-		last := patched[len(patched)-1]
-		if last["revision"] != 3.0 {
-			t.Errorf("PATCH revision = %v", last["revision"])
-		}
-		config, _ := last["components_config"].(map[string]any)
+		config, _ := patched[len(patched)-1]["components_config"].(map[string]any)
 		if config["stack"] != true {
-			t.Errorf("PATCH components_config = %v", last["components_config"])
+			t.Errorf("PATCH components_config = %v", patched[len(patched)-1]["components_config"])
 		}
 	})
 	t.Cleanup(apiServer.Close)
@@ -479,6 +486,118 @@ func TestPaywallsGenerate_OfferingAlreadyHasPaywall(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "omit --offering-id") {
 		t.Fatalf("stderr missing hint: %q", stderr)
+	}
+}
+
+// staleTestSession is a session file whose stored revision the tests pit
+// against the API stub's current draft revision.
+const staleTestSession = `{
+  "version": 1,
+  "project_id": "proj1",
+  "paywall_id": "pw_new",
+  "session_id": "sess1",
+  "revision": 3,
+  "paywall": {"default_locale": "en_US", "offering_id": null, "components_config": {"stack": true}, "components_localizations": {"en_US": {}}},
+  "ui_config": {"fonts": {}, "presets": {"saved_colors": []}},
+  "product_variables": {},
+  "__unstable_session_items": [{"k": 2}]
+}`
+
+// A session whose revision diverged from the server must stop at preflight:
+// no design turn is spent, and without --yes the command errors instead of
+// silently starting over from the server's draft.
+func TestPaywallsEdit_StaleSessionStopsBeforeAstra(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/paywalls/pw_new") {
+			t.Errorf("unexpected API request %s %s", r.Method, r.URL.Path)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"id":"pw_new","offering_id":null,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":5,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
+	}))
+	t.Cleanup(apiServer.Close)
+	astraRequests := 0
+	astraServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		astraRequests++
+	}))
+	t.Cleanup(astraServer.Close)
+	t.Setenv("RC_BASE_URL", apiServer.URL)
+	t.Setenv("RC_ASTRA_BASE_URL", astraServer.URL)
+
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(sessionPath, []byte(staleTestSession), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := runAgentCmd(t,
+		"paywalls", "edit",
+		"--session", sessionPath,
+		"--prompt", "Push the gradient harder",
+		"--no-input", "--api-key", "sk_test",
+	)
+	if err == nil || !strings.Contains(err.Error(), "pass --yes") {
+		t.Fatalf("err = %v", err)
+	}
+	if astraRequests != 0 {
+		t.Fatalf("astra requests = %d, want 0 (no design turn on a stale session)", astraRequests)
+	}
+	payload, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(payload) != staleTestSession {
+		t.Fatalf("session file was modified:\n%s", payload)
+	}
+}
+
+// The PATCH must carry the session's own revision — not a freshly fetched
+// one — or khepri's conflict guard can never fire for a stale session. The
+// single GET is the preflight; persist itself must not refetch.
+func TestPaywallsEdit_PatchCarriesSessionRevision(t *testing.T) {
+	gets := 0
+	var patched []map[string]any
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
+			gets++
+			io.WriteString(w, `{"id":"pw_new","offering_id":null,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":3,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			patched = append(patched, body)
+			io.WriteString(w, `{"id":"pw_new","offering_id":null,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":4,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`)
+		default:
+			t.Errorf("unexpected API request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(apiServer.Close)
+	astraServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "data: {\"type\":\"run.started\",\"session_id\":\"sess1\"}\n\n")
+		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[],\"__unstable_session_items\":[{\"k\":3}]}\n\n")
+	}))
+	t.Cleanup(astraServer.Close)
+	t.Setenv("RC_BASE_URL", apiServer.URL)
+	t.Setenv("RC_ASTRA_BASE_URL", astraServer.URL)
+
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(sessionPath, []byte(staleTestSession), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := runAgentCmd(t,
+		"paywalls", "edit",
+		"--session", sessionPath,
+		"--prompt", "Push the gradient harder",
+		"--json", "--no-input", "--api-key", "sk_test",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gets != 1 {
+		t.Fatalf("GETs = %d, want 1 (preflight only; persist must not refetch)", gets)
+	}
+	if len(patched) != 1 || patched[0]["revision"] != 3.0 {
+		t.Fatalf("patched = %v", patched)
 	}
 }
 

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -188,6 +188,28 @@ func TestRicoConversations_ListJSON(t *testing.T) {
 	}
 }
 
+// paywallResponseJSON is the v2 API paywall body for pw_new — the one
+// template for every stub that serves it, whatever offering and draft
+// revision the test needs.
+func paywallResponseJSON(offeringJSON string, revision int) string {
+	return fmt.Sprintf(`{"id":"pw_new","offering_id":%s,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":%d,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`, offeringJSON, revision)
+}
+
+// stubEditorServer serves one minimal completed design turn and counts the
+// requests it received.
+func stubEditorServer(t *testing.T) (*httptest.Server, *int) {
+	t.Helper()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "data: {\"type\":\"run.started\",\"session_id\":\"sess1\"}\n\n")
+		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[],\"__unstable_session_items\":[{\"k\":3}]}\n\n")
+	}))
+	t.Cleanup(server.Close)
+	return server, &requests
+}
+
 // astraTestServers stubs both the v2 API (draft creation) and the Paywall AI
 // editor. offeringID == "" makes the v2 API stubs serve a standalone paywall.
 // The editor stream always echoes offering_id as null, matching the live
@@ -203,9 +225,7 @@ func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string,
 	// The draft revision is stateful like khepri's: GET serves the current
 	// one, a PATCH must carry it (the conflict guard) and bumps it.
 	revision := 3
-	paywallJSON := func() string {
-		return fmt.Sprintf(`{"id":"pw_new","offering_id":%s,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":%d,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`, offeringJSON, revision)
-	}
+	paywallJSON := func() string { return paywallResponseJSON(offeringJSON, revision) }
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -483,7 +503,7 @@ func TestPaywallsGenerate_DraftChangedDuringRun(t *testing.T) {
 			if gets > 1 {
 				revision = 7
 			}
-			io.WriteString(w, paywallResponseJSON(revision))
+			io.WriteString(w, paywallResponseJSON("null", revision))
 		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
 			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
@@ -545,27 +565,6 @@ func TestPaywallsGenerate_OfferingAlreadyHasPaywall(t *testing.T) {
 	}
 }
 
-// paywallResponseJSON is the v2 API paywall body for pw_new at a given draft
-// revision, shared by the stubs that pit stored revisions against the server.
-func paywallResponseJSON(revision int) string {
-	return fmt.Sprintf(`{"id":"pw_new","offering_id":null,"created_at":1720000000000,"published_at":null,"components":{"published":null,"draft":{"revision":%d,"components_config":{},"components_localizations":{},"default_locale":"en_US","automatically_scale_font_size":true}}}`, revision)
-}
-
-// stubEditorServer serves one minimal completed design turn and counts the
-// requests it received.
-func stubEditorServer(t *testing.T) (*httptest.Server, *int) {
-	t.Helper()
-	requests := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requests++
-		w.Header().Set("Content-Type", "text/event-stream")
-		io.WriteString(w, "data: {\"type\":\"run.started\",\"session_id\":\"sess1\"}\n\n")
-		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[],\"__unstable_session_items\":[{\"k\":3}]}\n\n")
-	}))
-	t.Cleanup(server.Close)
-	return server, &requests
-}
-
 // staleTestSession is a session file whose stored revision the tests pit
 // against the API stub's current draft revision.
 const staleTestSession = `{
@@ -590,7 +589,7 @@ func TestPaywallsEdit_StaleSessionStopsBeforeAstra(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, paywallResponseJSON(5))
+		io.WriteString(w, paywallResponseJSON("null", 5))
 	}))
 	t.Cleanup(apiServer.Close)
 	astraServer, astraRequests := stubEditorServer(t)
@@ -633,12 +632,12 @@ func TestPaywallsEdit_PatchCarriesSessionRevision(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
 			gets++
-			io.WriteString(w, paywallResponseJSON(3))
+			io.WriteString(w, paywallResponseJSON("null", 3))
 		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
 			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			patched = append(patched, body)
-			io.WriteString(w, paywallResponseJSON(4))
+			io.WriteString(w, paywallResponseJSON("null", 4))
 		default:
 			t.Errorf("unexpected API request %s %s", r.Method, r.URL.Path)
 		}

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -566,7 +566,7 @@ const staleTestSession = `{
 // A session whose revision diverged from the server must stop at preflight:
 // no design turn is spent, and without --yes the command errors instead of
 // silently starting over from the server's draft.
-func TestPaywallsEdit_StaleSessionStopsBeforeAstra(t *testing.T) {
+func TestPaywallsEdit_StaleSessionStopsBeforeDesignTurn(t *testing.T) {
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/paywalls/pw_new") {
 			t.Errorf("unexpected API request %s %s", r.Method, r.URL.Path)

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -594,7 +594,7 @@ func TestPaywallsEdit_StaleSessionStopsBeforeDesignTurn(t *testing.T) {
 		t.Fatalf("err = %v", err)
 	}
 	if *astraRequests != 0 {
-		t.Fatalf("astra requests = %d, want 0 (no design turn on a stale session)", *astraRequests)
+		t.Fatalf("editor requests = %d, want 0 (no design turn on a stale session)", *astraRequests)
 	}
 	payload, err := os.ReadFile(sessionPath)
 	if err != nil {

--- a/internal/cli/confirm.go
+++ b/internal/cli/confirm.go
@@ -21,7 +21,7 @@ func confirmOrAbort(rt *Runtime, msg string, declineDetail ...string) error {
 	}
 	if !ok {
 		if len(declineDetail) > 0 && declineDetail[0] != "" {
-			return fmt.Errorf("aborted; %s", declineDetail[0])
+			rt.Out.Hint(declineDetail[0])
 		}
 		return fmt.Errorf("aborted")
 	}

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -131,10 +131,9 @@ edit turn. The draft stays unpublished; review it and run rc paywalls publish.`,
 			}
 			rt.Out.Info("Created draft paywall " + paywall.ID)
 
-			// The create response doesn't include the draft revision; fetch
-			// it now so the first persist is guarded by it — a draft edited
-			// elsewhere during the multi-minute turn 409s instead of being
-			// silently overwritten.
+			// The create response never carries the draft revision; fetch it
+			// so a draft edited elsewhere during the minutes-long turn 409s
+			// at persist instead of being overwritten.
 			revision, err := currentDraftRevision(cmd.Context(), client, projectID, paywall.ID)
 			if err != nil {
 				return err
@@ -256,11 +255,10 @@ Using it well:
 }
 
 // preflightSessionRevision guards a file-loaded session against a draft that
-// changed elsewhere (dashboard, its AI editor, API) since the file was
-// written. Turns take minutes, so the revisions are compared before anything
-// is streamed. A diverged session can't be continued — the prompt was written
-// against state that no longer exists — so the only way forward is consent to
-// start fresh from the server's current draft, losing the conversation.
+// changed elsewhere (dashboard, its AI editor, API), before a minutes-long
+// turn is spent on it. A diverged session can't continue — the prompt targets
+// state that no longer exists — so the only way forward is consent to start
+// fresh from the server's draft, losing the conversation.
 func preflightSessionRevision(ctx context.Context, rt *Runtime, session *astraSession) (*astraSession, error) {
 	client, err := rt.API()
 	if err != nil {
@@ -272,9 +270,8 @@ func preflightSessionRevision(ctx context.Context, rt *Runtime, session *astraSe
 	}
 	if session.Revision == nil {
 		// Files written by older CLIs carry no revision, so out-of-band
-		// changes since then are undetectable — overwriting the draft needs
-		// consent, not silence. Adopting the server's revision keeps the
-		// conversation and guards the rest of this turn.
+		// changes are undetectable — overwriting needs consent. Adopting the
+		// server's revision keeps the conversation and guards this turn.
 		rt.Out.Warn(fmt.Sprintf("This session file has no draft revision, so changes made to %s outside this session can't be detected.", session.PaywallID))
 		if err := confirmOrAbort(rt, "Continue and overwrite the current draft?",
 			"run rc paywalls edit "+session.PaywallID+" to start fresh from the server's draft"); err != nil {
@@ -332,9 +329,8 @@ func seedSessionFromServer(ctx context.Context, rt *Runtime, paywallID string) (
 	if paywall.OfferingID != "" {
 		offeringID = &paywall.OfferingID
 	}
-	// Sessions always carry a revision (persist relies on it to guard the
-	// PATCH); normalize a server response without one the same way
-	// currentDraftRevision does.
+	// Persist guards the PATCH with the session revision; normalize a server
+	// response without one, like currentDraftRevision does.
 	revision := 0
 	if version.Revision != nil {
 		revision = *version.Revision
@@ -461,7 +457,7 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 	session.SessionID = event.SessionID
 	session.TraceID = event.TraceID
 	if event.Paywall != nil {
-		// The AI editor doesn't manage offering attachment and echoes
+		// The AI editor doesn't manage offering attachment and may echo
 		// offering_id as null — keep what the CLI established.
 		offeringID := session.Paywall.OfferingID
 		session.Paywall = *event.Paywall
@@ -541,10 +537,8 @@ func persistPaywallDesign(ctx context.Context, rt *Runtime, session *astraSessio
 		ComponentsLocalizations: session.Paywall.ComponentsLocalizations,
 		DefaultLocale:           session.Paywall.DefaultLocale,
 	}
-	// Every path that builds a session seeds the revision (generate fetches
-	// it after create; edit preflights or reseeds from the server) — fetching
-	// a fresh one here instead would let the PATCH sail past the conflict
-	// guard and clobber out-of-band changes.
+	// Always the session's own revision — refetching a fresh one here would
+	// sail past the conflict guard and clobber out-of-band changes.
 	update.Revision = *session.Revision
 	updated, err := client.Paywalls.UpdateDraft(ctx, session.ProjectID, session.PaywallID, update)
 	if err != nil {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -236,7 +236,7 @@ Using it well:
 				if perr != nil {
 					return perr
 				}
-				session, err = seedSessionFromServer(cmd.Context(), rt, paywallID)
+				session, err = seedSessionFromServer(cmd.Context(), rt, projectID, paywallID)
 				opts.sessionPath = paywallID + ".astra.json"
 			default:
 				return fmt.Errorf("pass a paywall ID or --session <file>")
@@ -277,16 +277,12 @@ func preflightSessionRevision(ctx context.Context, rt *Runtime, session *astraSe
 		"run rc paywalls edit "+session.PaywallID+" to start fresh deliberately"); err != nil {
 		return nil, err
 	}
-	return seedSessionFromServer(ctx, rt, session.PaywallID)
+	return seedSessionFromServer(ctx, rt, session.ProjectID, session.PaywallID)
 }
 
 // seedSessionFromServer starts an editor session from the paywall's current
 // RevenueCat state (draft components, falling back to published).
-func seedSessionFromServer(ctx context.Context, rt *Runtime, paywallID string) (*astraSession, error) {
-	projectID, err := requireProject(rt)
-	if err != nil {
-		return nil, err
-	}
+func seedSessionFromServer(ctx context.Context, rt *Runtime, projectID string, paywallID string) (*astraSession, error) {
 	client, err := rt.API()
 	if err != nil {
 		return nil, err

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -131,6 +131,15 @@ edit turn. The draft stays unpublished; review it and run rc paywalls publish.`,
 			}
 			rt.Out.Info("Created draft paywall " + paywall.ID)
 
+			// The create response doesn't include the draft revision; fetch
+			// it now so the first persist is guarded by it — a draft edited
+			// elsewhere during the multi-minute turn 409s instead of being
+			// silently overwritten.
+			revision, err := currentDraftRevision(cmd.Context(), client, projectID, paywall.ID)
+			if err != nil {
+				return err
+			}
+
 			var offeringID *string
 			if opts.offeringID != "" {
 				offeringID = &opts.offeringID
@@ -139,6 +148,7 @@ edit turn. The draft stays unpublished; review it and run rc paywalls publish.`,
 				Version:   1,
 				ProjectID: projectID,
 				PaywallID: paywall.ID,
+				Revision:  &revision,
 				Paywall: astra.PaywallData{
 					DefaultLocale:           "en_US",
 					OfferingID:              offeringID,
@@ -252,9 +262,6 @@ Using it well:
 // against state that no longer exists — so the only way forward is consent to
 // start fresh from the server's current draft, losing the conversation.
 func preflightSessionRevision(ctx context.Context, rt *Runtime, session *astraSession) (*astraSession, error) {
-	if session.Revision == nil {
-		return session, nil
-	}
 	client, err := rt.API()
 	if err != nil {
 		return nil, err
@@ -262,6 +269,19 @@ func preflightSessionRevision(ctx context.Context, rt *Runtime, session *astraSe
 	revision, err := currentDraftRevision(ctx, client, session.ProjectID, session.PaywallID)
 	if err != nil {
 		return nil, err
+	}
+	if session.Revision == nil {
+		// Files written by older CLIs carry no revision, so out-of-band
+		// changes since then are undetectable — overwriting the draft needs
+		// consent, not silence. Adopting the server's revision keeps the
+		// conversation and guards the rest of this turn.
+		rt.Out.Warn(fmt.Sprintf("This session file has no draft revision, so changes made to %s outside this session can't be detected.", session.PaywallID))
+		if err := confirmOrAbort(rt, "Continue and overwrite the current draft?",
+			"run rc paywalls edit "+session.PaywallID+" to start fresh from the server's draft"); err != nil {
+			return nil, err
+		}
+		session.Revision = &revision
+		return session, nil
 	}
 	if revision == *session.Revision {
 		return session, nil
@@ -514,17 +534,14 @@ func persistPaywallDesign(ctx context.Context, rt *Runtime, session *astraSessio
 		ComponentsLocalizations: session.Paywall.ComponentsLocalizations,
 		DefaultLocale:           session.Paywall.DefaultLocale,
 	}
-	if session.Revision != nil {
-		update.Revision = *session.Revision
-	} else {
-		// First turn from rc paywalls generate: the session exists before any
-		// PATCH, and the paywall was created moments ago.
-		revision, err := currentDraftRevision(ctx, client, session.ProjectID, session.PaywallID)
-		if err != nil {
-			return err
-		}
-		update.Revision = revision
+	// Every path that builds a session seeds the revision (generate fetches
+	// it after create; edit preflights or reseeds from the server) — fetching
+	// a fresh one here instead would let the PATCH sail past the conflict
+	// guard and clobber out-of-band changes.
+	if session.Revision == nil {
+		return fmt.Errorf("session has no draft revision; run rc paywalls edit %s to start fresh from the server's draft", session.PaywallID)
 	}
+	update.Revision = *session.Revision
 	updated, err := client.Paywalls.UpdateDraft(ctx, session.ProjectID, session.PaywallID, update)
 	if err != nil {
 		return err

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -209,6 +209,9 @@ Using it well:
 			switch {
 			case opts.sessionPath != "":
 				session, err = loadAstraSession(opts.sessionPath)
+				if err == nil {
+					session, err = preflightSessionRevision(cmd.Context(), rt, session)
+				}
 			case argAt(args, 0) != "" || (!rt.Globals.NoInput && tui.IsInteractive()):
 				client, cerr := rt.API()
 				if cerr != nil {
@@ -240,6 +243,36 @@ Using it well:
 	}
 	addPaywallAIFlags(cmd, &opts)
 	return cmd
+}
+
+// preflightSessionRevision guards a file-loaded session against a draft that
+// changed elsewhere (dashboard, its AI editor, API) since the file was
+// written. Turns take minutes, so the revisions are compared before anything
+// is streamed. A diverged session can't be continued — the prompt was written
+// against state that no longer exists — so the only way forward is consent to
+// start fresh from the server's current draft, losing the conversation.
+func preflightSessionRevision(ctx context.Context, rt *Runtime, session *astraSession) (*astraSession, error) {
+	if session.Revision == nil {
+		return session, nil
+	}
+	client, err := rt.API()
+	if err != nil {
+		return nil, err
+	}
+	revision, err := currentDraftRevision(ctx, client, session.ProjectID, session.PaywallID)
+	if err != nil {
+		return nil, err
+	}
+	if revision == *session.Revision {
+		return session, nil
+	}
+	rt.Out.Warn(fmt.Sprintf("The draft for %s changed outside this session — the dashboard, its AI editor, or the API wrote revision %d, the session has %d.", session.PaywallID, revision, *session.Revision))
+	rt.Out.Info("A session can't continue against diverged state. Continuing starts fresh from the server's current draft; the conversation context in this session file is lost.")
+	if err := confirmOrAbort(rt, "Start fresh from the server's current draft?",
+		"run rc paywalls edit "+session.PaywallID+" to start fresh deliberately"); err != nil {
+		return nil, err
+	}
+	return seedSessionFromServer(ctx, rt, session.PaywallID)
 }
 
 // seedSessionFromServer starts an editor session from the paywall's current
@@ -420,8 +453,14 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 	}
 	saved := false
 	if err := persistPaywallDesign(ctx, rt, session); err != nil {
-		rt.Out.Warn("Could not save the design to RevenueCat: " + err.Error())
-		rt.Out.Hint("The design is safe in " + opts.sessionPath + " — re-run rc paywalls edit to retry saving.")
+		var apiErr *api.APIError
+		if errors.As(err, &apiErr) && apiErr.Status == 409 {
+			rt.Out.Warn("Could not save the design: the draft changed during the run (dashboard, its AI editor, or API), and this session can't be saved over it.")
+			rt.Out.Hint("Start fresh from the current draft:  rc paywalls edit " + session.PaywallID)
+		} else {
+			rt.Out.Warn("Could not save the design to RevenueCat: " + err.Error())
+			rt.Out.Hint("The design is safe in " + opts.sessionPath + " — re-run rc paywalls edit to retry saving.")
+		}
 	} else {
 		saved = true
 		// Persisting refreshed the revision and offering from the server;
@@ -463,8 +502,8 @@ func paywallBuilderURL(projectID, paywallID string) string {
 }
 
 // persistPaywallDesign PATCHes the designed components onto the RevenueCat
-// paywall draft, using the server's current draft revision to avoid stale
-// writes (retried once on a revision conflict).
+// paywall draft, guarded by the session's own revision: a draft that changed
+// outside the session comes back as a 409 instead of being overwritten.
 func persistPaywallDesign(ctx context.Context, rt *Runtime, session *astraSession) error {
 	client, err := rt.API()
 	if err != nil {
@@ -475,33 +514,33 @@ func persistPaywallDesign(ctx context.Context, rt *Runtime, session *astraSessio
 		ComponentsLocalizations: session.Paywall.ComponentsLocalizations,
 		DefaultLocale:           session.Paywall.DefaultLocale,
 	}
-	for attempt := 0; ; attempt++ {
+	if session.Revision != nil {
+		update.Revision = *session.Revision
+	} else {
+		// First turn from rc paywalls generate: the session exists before any
+		// PATCH, and the paywall was created moments ago.
 		revision, err := currentDraftRevision(ctx, client, session.ProjectID, session.PaywallID)
 		if err != nil {
 			return err
 		}
 		update.Revision = revision
-		updated, err := client.Paywalls.UpdateDraft(ctx, session.ProjectID, session.PaywallID, update)
-		if err == nil {
-			if updated.Components != nil && updated.Components.Draft != nil && updated.Components.Draft.Revision != nil {
-				session.Revision = updated.Components.Draft.Revision
-			}
-			// Offering attachment can change out-of-band (dashboard); the PATCH
-			// response carries current server truth, so refresh it — it drives
-			// the attach/publish hint and the editor's product context next turn.
-			if updated.OfferingID != "" {
-				session.Paywall.OfferingID = &updated.OfferingID
-			} else {
-				session.Paywall.OfferingID = nil
-			}
-			return nil
-		}
-		var apiErr *api.APIError
-		if attempt == 0 && errors.As(err, &apiErr) && apiErr.Status == 409 {
-			continue // stale revision: refetch and retry once
-		}
+	}
+	updated, err := client.Paywalls.UpdateDraft(ctx, session.ProjectID, session.PaywallID, update)
+	if err != nil {
 		return err
 	}
+	if updated.Components != nil && updated.Components.Draft != nil && updated.Components.Draft.Revision != nil {
+		session.Revision = updated.Components.Draft.Revision
+	}
+	// Offering attachment can change out-of-band (dashboard); the PATCH
+	// response carries current server truth, so refresh it — it drives
+	// the attach/publish hint and the editor's product context next turn.
+	if updated.OfferingID != "" {
+		session.Paywall.OfferingID = &updated.OfferingID
+	} else {
+		session.Paywall.OfferingID = nil
+	}
+	return nil
 }
 
 func currentDraftRevision(ctx context.Context, client *api.Client, projectID, paywallID string) (int, error) {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -217,7 +217,7 @@ Using it well:
 			var err error
 			switch {
 			case opts.sessionPath != "":
-				session, err = loadAstraSession(opts.sessionPath)
+				session, err = loadAstraSession(rt, opts.sessionPath)
 				if err == nil {
 					session, err = preflightSessionRevision(cmd.Context(), rt, session)
 				}
@@ -348,7 +348,7 @@ func newPaywallsRewindCmd() *cobra.Command {
 			if sessionPath == "" {
 				return fmt.Errorf("--session is required")
 			}
-			session, err := loadAstraSession(sessionPath)
+			session, err := loadAstraSession(rt, sessionPath)
 			if err != nil {
 				return err
 			}
@@ -583,7 +583,7 @@ func reportPaywallAIActivity(rt *Runtime, activity []astra.ToolActivity, already
 	return alreadyReported
 }
 
-func loadAstraSession(path string) (*astraSession, error) {
+func loadAstraSession(rt *Runtime, path string) (*astraSession, error) {
 	payload, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading session file: %w", err)
@@ -598,7 +598,8 @@ func loadAstraSession(path string) (*astraSession, error) {
 	// The revision is what guards the draft against out-of-band changes;
 	// without one the session can't be continued safely.
 	if session.Revision == nil {
-		return nil, fmt.Errorf("session file %s has no draft revision; start fresh with rc paywalls edit %s", path, session.PaywallID)
+		rt.Out.Hint("Start fresh session with rc paywalls edit " + session.PaywallID)
+		return nil, fmt.Errorf("session file %s has no draft revision", path)
 	}
 	return &session, nil
 }

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -332,11 +332,18 @@ func seedSessionFromServer(ctx context.Context, rt *Runtime, paywallID string) (
 	if paywall.OfferingID != "" {
 		offeringID = &paywall.OfferingID
 	}
+	// Sessions always carry a revision (persist relies on it to guard the
+	// PATCH); normalize a server response without one the same way
+	// currentDraftRevision does.
+	revision := 0
+	if version.Revision != nil {
+		revision = *version.Revision
+	}
 	return &astraSession{
 		Version:   1,
 		ProjectID: projectID,
 		PaywallID: paywall.ID,
-		Revision:  version.Revision,
+		Revision:  &revision,
 		Paywall: astra.PaywallData{
 			DefaultLocale:           locale,
 			OfferingID:              offeringID,
@@ -538,9 +545,6 @@ func persistPaywallDesign(ctx context.Context, rt *Runtime, session *astraSessio
 	// it after create; edit preflights or reseeds from the server) — fetching
 	// a fresh one here instead would let the PATCH sail past the conflict
 	// guard and clobber out-of-band changes.
-	if session.Revision == nil {
-		return fmt.Errorf("session has no draft revision; run rc paywalls edit %s to start fresh from the server's draft", session.PaywallID)
-	}
 	update.Revision = *session.Revision
 	updated, err := client.Paywalls.UpdateDraft(ctx, session.ProjectID, session.PaywallID, update)
 	if err != nil {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -268,18 +268,6 @@ func preflightSessionRevision(ctx context.Context, rt *Runtime, session *astraSe
 	if err != nil {
 		return nil, err
 	}
-	if session.Revision == nil {
-		// Files written by older CLIs carry no revision, so out-of-band
-		// changes are undetectable — overwriting needs consent. Adopting the
-		// server's revision keeps the conversation and guards this turn.
-		rt.Out.Warn(fmt.Sprintf("This session file has no draft revision, so changes made to %s outside this session can't be detected.", session.PaywallID))
-		if err := confirmOrAbort(rt, "Continue and overwrite the current draft?",
-			"run rc paywalls edit "+session.PaywallID+" to start fresh from the server's draft"); err != nil {
-			return nil, err
-		}
-		session.Revision = &revision
-		return session, nil
-	}
 	if revision == *session.Revision {
 		return session, nil
 	}
@@ -610,6 +598,11 @@ func loadAstraSession(path string) (*astraSession, error) {
 	}
 	if session.ProjectID == "" || session.PaywallID == "" {
 		return nil, fmt.Errorf("session file %s is missing project_id or paywall_id", path)
+	}
+	// The revision is what guards the draft against out-of-band changes;
+	// without one the session can't be continued safely.
+	if session.Revision == nil {
+		return nil, fmt.Errorf("session file %s has no draft revision; start fresh with rc paywalls edit %s", path, session.PaywallID)
 	}
 	return &session, nil
 }


### PR DESCRIPTION
Checks the server's current draft revision before starting an edit turn from a file session, and asks user to continue with a new session, or fails in `--json` mode so agents can decide what to do.

### Note
Error message that agents will see is not that descriptive. But @joshdholtz is working on a solution to pass hints and warnings to results when the CLI is called with `--json`. I'll open a linear ticket and improve the `--json` messaging in the follow up once @joshdholtz's fix has been shipped.

### Conflict in interactive mode
```
> ./rc-local paywalls edit --session pw246295f656104c6b.astra.json --prompt 'make it better'
! The draft for pw246295f656104c6b changed outside this session — the dashboard, its AI editor, or the API wrote revision 5, the session has 2.
· A session can't continue against diverged state. Continuing starts fresh from the server's current draft; the conversation context in this session file is lost.

┃ Start fresh from the server's current draft?
┃
┃                 Yes     No
```

### After aborting
```
> ./rc-local paywalls edit --session pw246295f656104c6b.astra.json --prompt 'make it better'
! The draft for pw246295f656104c6b changed outside this session — the dashboard, its AI editor, or the API wrote revision 5, the session has 2.
· A session can't continue against diverged state. Continuing starts fresh from the server's current draft; the conversation context in this session file is lost.

  run rc paywalls edit pw246295f656104c6b to start fresh deliberately
✗ aborted
```

### Conflict with `--json --no-input`
```
> ./rc-local paywalls edit --session pw246295f656104c6b.astra.json --prompt 'make it better' --json --no-input
{
  "error": {
    "type": "cli_error",
    "message": "Start fresh from the server's current draft? (pass --yes to confirm non-interactively)",
    "exit_code": 1
  },
  "schema_version": 1
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall draft persistence and session continuity semantics; incorrect revision handling could still block saves or confuse agents, but the change intentionally tightens conflict safety on a critical write path.
> 
> **Overview**
> Fixes **silent overwrite** of paywall drafts when the dashboard, API, or another editor changes the draft while a Paywall AI session is in flight or stale.
> 
> **Edit from `--session`:** Before a long design turn, the CLI compares the session file’s `revision` to the server draft. If they diverge, it warns and requires confirmation to **start fresh** from the server (conversation context in the file is lost); with `--no-input` and without `--yes`, it errors instead of continuing or clobbering.
> 
> **Persist behavior:** `persistPaywallDesign` PATCHes using the **session’s stored revision** only—no refetch-and-retry on conflict—so out-of-band edits during a run return **409** and `saved_to_draft: false` instead of overwriting khepri’s guarded draft.
> 
> **Generate:** After create, the CLI fetches the initial draft revision into the session so the same conflict rules apply if the draft changes during the first turn.
> 
> Session files **without** a `revision` are rejected on load. Declining a confirm prompt now surfaces recovery hints via `Out.Hint` rather than only in the abort error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2f10f76bb2c511fc897432c6ea579a942f345ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->