### PR TITLE
fix login to point to the right API keys URL

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -402,7 +402,7 @@ func newAuthStatusCmd() *cobra.Command {
 }
 
 func loginWithAPIKeyInteractive(ctx context.Context, rt *Runtime) error {
-	rt.Out.Info("Generate an API key at https://app.revenuecat.com/projects — open your project, then API keys")
+	rt.Out.Info("Generate an API key at https://app.revenuecat.com/projects/-/api-keys")
 	var key string
 	if err := tui.Form(rt.Globals.NoInput).
 		Field(huh.NewInput().
@@ -432,7 +432,7 @@ func loginWithAPIKey(ctx context.Context, rt *Runtime, key string) error {
 	// Validate before clearing or saving: a bad key fails fast instead of a
 	// false "Logged in", and a failed login won't announce a project clear.
 	if _, err := client.Projects.List(ctx); err != nil {
-		rt.Out.Hint("Check your key at https://app.revenuecat.com/projects — open your project, then API keys")
+		rt.Out.Hint("Check your key at https://app.revenuecat.com/projects/-/api-keys")
 		return fmt.Errorf("that API key didn't work: %w", err)
 	}
 	clearProjectBinding(rt)

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -402,7 +402,7 @@ func newAuthStatusCmd() *cobra.Command {
 }
 
 func loginWithAPIKeyInteractive(ctx context.Context, rt *Runtime) error {
-	rt.Out.Info("Generate an API key at https://app.revenuecat.com/settings/api-keys")
+	rt.Out.Info("Generate an API key at https://app.revenuecat.com/projects — open your project, then API keys")
 	var key string
 	if err := tui.Form(rt.Globals.NoInput).
 		Field(huh.NewInput().
@@ -432,7 +432,7 @@ func loginWithAPIKey(ctx context.Context, rt *Runtime, key string) error {
 	// Validate before clearing or saving: a bad key fails fast instead of a
 	// false "Logged in", and a failed login won't announce a project clear.
 	if _, err := client.Projects.List(ctx); err != nil {
-		rt.Out.Hint("Check your key at https://app.revenuecat.com/settings/api-keys")
+		rt.Out.Hint("Check your key at https://app.revenuecat.com/projects — open your project, then API keys")
 		return fmt.Errorf("that API key didn't work: %w", err)
 	}
 	clearProjectBinding(rt)


### PR DESCRIPTION
The old /settings/api-keys URL was dead, so the login command now points users to their projects page where they can find API keys.

### 1. opens api-keys page with blank project
<img width="796" height="624" alt="Screenshot 2026-07-31 at 17 12 20" src="https://github.com/user-attachments/assets/93f4c243-d0cf-4d29-942c-8650a2bbc3c1" />

### 2. you select the project
<img width="751" height="531" alt="Screenshot 2026-07-31 at 17 12 30" src="https://github.com/user-attachments/assets/3c6f755e-b6e2-4d3f-95bc-c0b4d27c27af" />

### 3. project opens at the api-keys page
<img width="1723" height="755" alt="Screenshot 2026-07-31 at 17 12 37" src="https://github.com/user-attachments/assets/d97dee83-654b-40cc-a4ee-b0dfa00cc389" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only URL updates in CLI user messages; no auth logic or credential handling changes.
> 
> **Overview**
> Updates the **interactive API key login** help text so users are sent to the working dashboard location for keys instead of a dead `/settings/api-keys` link.
> 
> In `loginWithAPIKeyInteractive`, the info line that tells users where to generate a key now uses `https://app.revenuecat.com/projects/-/api-keys`. The same URL is used in `loginWithAPIKey` when validation fails, so the hint after a bad key matches the generate-key message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e92222428488fccb0ea7963ac4fa64d367f6ac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->