### PR TITLE
save paywall preview screenshots next to session file

### DIFF
--- a/internal/astra/astra.go
+++ b/internal/astra/astra.go
@@ -56,6 +56,10 @@ type EditorRequest struct {
 	InputAttachments []InputAttachment `json:"input_attachments,omitempty"`
 	SessionItems     json.RawMessage   `json:"__unstable_session_items"`
 	AppContext       json.RawMessage   `json:"app_context,omitempty"`
+	// IncludeResultScreenshots asks the server to render the final design
+	// and attach it to run.completed. Best-effort server-side: a render
+	// failure never fails the turn.
+	IncludeResultScreenshots bool `json:"include_result_screenshots,omitempty"`
 }
 
 type ToolActivity struct {
@@ -70,6 +74,14 @@ type ToolActivity struct {
 	Content string `json:"content,omitempty"` // assistant_message
 }
 
+// ResultScreenshot is a rendered preview of the completed design. Light is
+// always present when requested; dark only when the paywall has a dark mode.
+type ResultScreenshot struct {
+	ColorScheme string `json:"color_scheme"` // "light" | "dark"
+	MimeType    string `json:"mime_type"`
+	DataBase64  string `json:"data_base64"`
+}
+
 type StreamError struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
@@ -77,15 +89,16 @@ type StreamError struct {
 
 // Event is one editor stream event; fields are populated per Type.
 type Event struct {
-	Type         string          `json:"type"`
-	SessionID    string          `json:"session_id"`
-	TurnIndex    int             `json:"turn_index,omitempty"`
-	TraceID      string          `json:"trace_id,omitempty"`
-	Paywall      *PaywallData    `json:"paywall,omitempty"`
-	Activity     []ToolActivity  `json:"activity,omitempty"`
-	Error        *StreamError    `json:"error,omitempty"`
-	SessionItems json.RawMessage `json:"__unstable_session_items,omitempty"`
-	AppContext   json.RawMessage `json:"app_context,omitempty"`
+	Type              string             `json:"type"`
+	SessionID         string             `json:"session_id"`
+	TurnIndex         int                `json:"turn_index,omitempty"`
+	TraceID           string             `json:"trace_id,omitempty"`
+	Paywall           *PaywallData       `json:"paywall,omitempty"`
+	Activity          []ToolActivity     `json:"activity,omitempty"`
+	Error             *StreamError       `json:"error,omitempty"`
+	SessionItems      json.RawMessage    `json:"__unstable_session_items,omitempty"`
+	AppContext        json.RawMessage    `json:"app_context,omitempty"`
+	ResultScreenshots []ResultScreenshot `json:"result_screenshots,omitempty"`
 }
 
 func (e *Event) Terminal() bool {

--- a/internal/astra/astra.go
+++ b/internal/astra/astra.go
@@ -45,20 +45,18 @@ type InputAttachment struct {
 // EditorRequest is the POST /editor/v1/stream body. UIConfig, SessionItems,
 // and AppContext are opaque server round-trips.
 type EditorRequest struct {
-	ProjectID        string            `json:"project_id"`
-	PaywallID        string            `json:"paywall_id"`
-	Revision         *int              `json:"revision"`
-	SessionID        string            `json:"session_id,omitempty"`
-	Paywall          PaywallData       `json:"paywall"`
-	UIConfig         json.RawMessage   `json:"ui_config"`
-	ProductVariables map[string]string `json:"product_variables"`
-	Message          string            `json:"message"`
-	InputAttachments []InputAttachment `json:"input_attachments,omitempty"`
-	SessionItems     json.RawMessage   `json:"__unstable_session_items"`
-	AppContext       json.RawMessage   `json:"app_context,omitempty"`
-	// IncludeResultScreenshots attaches rendered previews of the final design
-	// to run.completed. Best-effort: a render failure never fails the turn.
-	IncludeResultScreenshots bool `json:"include_result_screenshots,omitempty"`
+	ProjectID                string            `json:"project_id"`
+	PaywallID                string            `json:"paywall_id"`
+	Revision                 *int              `json:"revision"`
+	SessionID                string            `json:"session_id,omitempty"`
+	Paywall                  PaywallData       `json:"paywall"`
+	UIConfig                 json.RawMessage   `json:"ui_config"`
+	ProductVariables         map[string]string `json:"product_variables"`
+	Message                  string            `json:"message"`
+	InputAttachments         []InputAttachment `json:"input_attachments,omitempty"`
+	SessionItems             json.RawMessage   `json:"__unstable_session_items"`
+	AppContext               json.RawMessage   `json:"app_context,omitempty"`
+	IncludeResultScreenshots bool              `json:"include_result_screenshots,omitempty"`
 }
 
 type ToolActivity struct {

--- a/internal/astra/astra.go
+++ b/internal/astra/astra.go
@@ -56,9 +56,8 @@ type EditorRequest struct {
 	InputAttachments []InputAttachment `json:"input_attachments,omitempty"`
 	SessionItems     json.RawMessage   `json:"__unstable_session_items"`
 	AppContext       json.RawMessage   `json:"app_context,omitempty"`
-	// IncludeResultScreenshots asks the server to render the final design
-	// and attach it to run.completed. Best-effort server-side: a render
-	// failure never fails the turn.
+	// IncludeResultScreenshots attaches rendered previews of the final design
+	// to run.completed. Best-effort: a render failure never fails the turn.
 	IncludeResultScreenshots bool `json:"include_result_screenshots,omitempty"`
 }
 

--- a/internal/astra/astra_test.go
+++ b/internal/astra/astra_test.go
@@ -28,7 +28,7 @@ func TestStreamDecodesEvents(t *testing.T) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		io.WriteString(w, "event: run.started\ndata: {\"type\":\"run.started\",\"session_id\":\"sess1\"}\n\n")
 		io.WriteString(w, "data: {\"type\":\"turn.snapshot\",\"session_id\":\"sess1\",\"turn_index\":0,\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":\"ofrng1\",\"components_config\":{\"a\":1},\"components_localizations\":{}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_call_id\":\"tc1\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Edited hero\"}}]}\n\n")
-		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{},\"components_localizations\":{}},\"activity\":[]}\n\n")
+		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{},\"components_localizations\":{}},\"activity\":[],\"result_screenshots\":[{\"color_scheme\":\"light\",\"mime_type\":\"image/png\",\"data_base64\":\"UE5H\"}]}\n\n")
 	}))
 	defer server.Close()
 
@@ -73,6 +73,9 @@ func TestStreamDecodesEvents(t *testing.T) {
 	}
 	if completed.Paywall.OfferingID != nil {
 		t.Fatalf("offering should be null, got %v", completed.Paywall.OfferingID)
+	}
+	if len(completed.ResultScreenshots) != 1 || completed.ResultScreenshots[0].ColorScheme != "light" || completed.ResultScreenshots[0].DataBase64 != "UE5H" {
+		t.Fatalf("result_screenshots = %+v", completed.ResultScreenshots)
 	}
 
 	if gotBody["project_id"] != "proj1" || gotBody["paywall_id"] != "pw1" || gotBody["revision"] != 3.0 {

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -272,7 +272,7 @@ func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string,
 		w.Header().Set("Content-Type", "text/event-stream")
 		io.WriteString(w, "data: {\"type\":\"run.started\",\"session_id\":\"sess1\"}\n\n")
 		io.WriteString(w, "data: {\"type\":\"turn.snapshot\",\"session_id\":\"sess1\",\"turn_index\":0,\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}}],\"__unstable_session_items\":[{\"k\":1}]}\n\n")
-		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}},{\"id\":\"a2\",\"type\":\"assistant_message\",\"content\":\"Done — calm annual-first layout.\"}],\"__unstable_session_items\":[{\"k\":2}]}\n\n")
+		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}},{\"id\":\"a2\",\"type\":\"assistant_message\",\"content\":\"Done — calm annual-first layout.\"}],\"__unstable_session_items\":[{\"k\":2}],\"result_screenshots\":[{\"color_scheme\":\"light\",\"mime_type\":\"image/png\",\"data_base64\":\"UE5H\"}]}\n\n")
 	}))
 	t.Cleanup(astraServer.Close)
 	return apiServer.URL, astraServer.URL, &inputs, &created
@@ -311,10 +311,11 @@ func TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession(t *testing.T) {
 	}
 	var envelope struct {
 		Data struct {
-			PaywallID   string `json:"paywall_id"`
-			SessionID   string `json:"session_id"`
-			TraceID     string `json:"trace_id"`
-			SessionFile string `json:"session_file"`
+			PaywallID       string            `json:"paywall_id"`
+			SessionID       string            `json:"session_id"`
+			TraceID         string            `json:"trace_id"`
+			SessionFile     string            `json:"session_file"`
+			ScreenshotPaths map[string]string `json:"screenshot_paths"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
@@ -328,10 +329,23 @@ func TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession(t *testing.T) {
 		t.Fatalf("create body = %v", create)
 	}
 
+	// The run's preview screenshot landed next to the session file and its
+	// path is in the envelope.
+	shotPath := envelope.Data.ScreenshotPaths["light"]
+	if shotPath == "" {
+		t.Fatalf("screenshot_paths = %v", envelope.Data.ScreenshotPaths)
+	}
+	if shot, err := os.ReadFile(shotPath); err != nil || string(shot) != "PNG" {
+		t.Fatalf("screenshot at %s = %q, err %v", shotPath, shot, err)
+	}
+
 	// The editor request carried the project, paywall, prompt, and state.
 	input := (*editorInputs)[0]
 	if input["project_id"] != "proj1" || input["paywall_id"] != "pw_new" || input["message"] != "A calm annual-first paywall" {
 		t.Fatalf("editor input = %v", input)
+	}
+	if input["include_result_screenshots"] != true {
+		t.Fatalf("include_result_screenshots = %v", input["include_result_screenshots"])
 	}
 
 	// Session file round-trips the completed paywall + opaque blobs.

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -94,8 +94,9 @@ conversation: pass the same --session to rc paywalls edit. The editor may
 answer with a clarifying question instead of a design — reply with another
 edit turn. Each completed turn also writes a preview screenshot
 (<paywall-id>.light.png, plus .dark.png when the design has dark mode) next to
-the session file — look at it to verify the design. The draft stays
-unpublished; review it and run rc paywalls publish.`,
+the session file — look at it after every turn and keep iterating with edit
+turns until the design is right. The draft stays unpublished; review it and
+run rc paywalls publish.`,
 		Example: `  rc paywalls generate
   rc paywalls generate --name "Summer sale" --prompt "A calm annual-first paywall"
   rc paywalls generate --offering-id ofrng_default --prompt "Match our brand" --image brand.png --json --no-input`,
@@ -207,8 +208,9 @@ Using it well:
     appears in the streamed activity / the --json activity array). Answer it
     with another edit turn on the same session.
   - Each completed turn writes <paywall-id>.light.png (and .dark.png when
-    the design has dark mode) next to the session file — look at it to
-    verify the design before publishing.
+    the design has dark mode) next to the session file. Look at it after
+    every turn: judge the result against the direction, then follow up
+    with more edit turns until it looks right.
   - Turns take one to several minutes and stream progress; run with an
     extended timeout (--timeout) or in the background rather than polling.
   - Undo the last turn:  rc paywalls rewind --session <file>`,

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -368,8 +368,7 @@ func newPaywallsRewindCmd() *cobra.Command {
 			if err := client.Rewind(cmd.Context(), session.SessionID, session.TraceID, true); err != nil {
 				return err
 			}
-			// The saved screenshots show the pre-rewind design; drop them so
-			// they don't lie about the rewound state.
+			// Drop saved screenshots — they show the pre-rewind design.
 			base := strings.TrimSuffix(sessionPath, ".astra.json")
 			os.Remove(base + ".light.png")
 			os.Remove(base + ".dark.png")
@@ -420,7 +419,7 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 		SessionItems:     session.SessionItems,
 		AppContext:       session.AppContext,
 
-		IncludeResultScreenshots: true, // rendered previews land on run.completed
+		IncludeResultScreenshots: true,
 	})
 	if err != nil {
 		return err
@@ -471,8 +470,8 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 	if err := saveAstraSession(opts.sessionPath, session); err != nil {
 		return err
 	}
-	// Always, not only when the draft PATCH succeeds: the screenshot shows
-	// what the session file holds even when the draft changed elsewhere.
+	// Saved even when the draft PATCH below fails — the screenshot shows
+	// what the session file holds.
 	screenshots := savePaywallScreenshots(rt, opts.sessionPath, event.ResultScreenshots)
 	saved := false
 	if err := persistPaywallDesign(ctx, rt, session); err != nil {
@@ -526,9 +525,8 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 }
 
 // savePaywallScreenshots writes the run's rendered previews next to the
-// session file (<session base>.light.png, and .dark.png when the design has
-// dark mode) and returns the paths by color scheme. Best-effort, matching the
-// server's stance: a decode or write failure warns, never fails the turn.
+// session file (<base>.light.png / .dark.png) and returns the paths by color
+// scheme. Best-effort: a decode or write failure warns, never fails the turn.
 func savePaywallScreenshots(rt *Runtime, sessionPath string, shots []astra.ResultScreenshot) map[string]string {
 	paths := map[string]string{}
 	base := strings.TrimSuffix(sessionPath, ".astra.json")

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -92,7 +92,10 @@ Each completed turn saves the design onto the RevenueCat paywall draft, and
 the editor state is also kept in a session file so follow-up edits retain the
 conversation: pass the same --session to rc paywalls edit. The editor may
 answer with a clarifying question instead of a design — reply with another
-edit turn. The draft stays unpublished; review it and run rc paywalls publish.`,
+edit turn. Each completed turn also writes a preview screenshot
+(<paywall-id>.light.png, plus .dark.png when the design has dark mode) next to
+the session file — look at it to verify the design. The draft stays
+unpublished; review it and run rc paywalls publish.`,
 		Example: `  rc paywalls generate
   rc paywalls generate --name "Summer sale" --prompt "A calm annual-first paywall"
   rc paywalls generate --offering-id ofrng_default --prompt "Match our brand" --image brand.png --json --no-input`,
@@ -203,6 +206,9 @@ Using it well:
   - The Paywall AI editor may reply with a clarifying question instead of a design (it
     appears in the streamed activity / the --json activity array). Answer it
     with another edit turn on the same session.
+  - Each completed turn writes <paywall-id>.light.png (and .dark.png when
+    the design has dark mode) next to the session file — look at it to
+    verify the design before publishing.
   - Turns take one to several minutes and stream progress; run with an
     extended timeout (--timeout) or in the background rather than polling.
   - Undo the last turn:  rc paywalls rewind --session <file>`,
@@ -362,6 +368,11 @@ func newPaywallsRewindCmd() *cobra.Command {
 			if err := client.Rewind(cmd.Context(), session.SessionID, session.TraceID, true); err != nil {
 				return err
 			}
+			// The saved screenshots show the pre-rewind design; drop them so
+			// they don't lie about the rewound state.
+			base := strings.TrimSuffix(sessionPath, ".astra.json")
+			os.Remove(base + ".light.png")
+			os.Remove(base + ".dark.png")
 			rt.Out.Success("Rewound last editor action")
 			return rt.Out.Render(map[string]any{"ok": true, "session_id": session.SessionID})
 		},
@@ -408,6 +419,8 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 		InputAttachments: attachments,
 		SessionItems:     session.SessionItems,
 		AppContext:       session.AppContext,
+
+		IncludeResultScreenshots: true, // rendered previews land on run.completed
 	})
 	if err != nil {
 		return err
@@ -458,6 +471,9 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 	if err := saveAstraSession(opts.sessionPath, session); err != nil {
 		return err
 	}
+	// Always, not only when the draft PATCH succeeds: the screenshot shows
+	// what the session file holds even when the draft changed elsewhere.
+	screenshots := savePaywallScreenshots(rt, opts.sessionPath, event.ResultScreenshots)
 	saved := false
 	if err := persistPaywallDesign(ctx, rt, session); err != nil {
 		var apiErr *api.APIError
@@ -480,6 +496,12 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 			rt.Out.Info(fmt.Sprintf("%d editor step(s) errored during the run and were retried by the Paywall AI editor — the saved draft is the complete final state (nothing partial is ever saved).", errored))
 		}
 		rt.Out.Blank()
+		if path, ok := screenshots["light"]; ok {
+			rt.Out.Field("Preview", path)
+		}
+		if path, ok := screenshots["dark"]; ok {
+			rt.Out.Field("Preview (dark)", path)
+		}
 		rt.Out.Field("View it", paywallBuilderURL(session.ProjectID, session.PaywallID))
 		rt.Out.Field("Keep designing", "rc paywalls edit --session "+opts.sessionPath)
 		if session.Paywall.OfferingID == nil {
@@ -490,16 +512,45 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 	}
 	if rt.Out.IsJSON() {
 		return rt.Out.Render(map[string]any{
-			"paywall_id":     session.PaywallID,
-			"dashboard_url":  paywallBuilderURL(session.ProjectID, session.PaywallID),
-			"session_id":     session.SessionID,
-			"trace_id":       session.TraceID,
-			"session_file":   opts.sessionPath,
-			"saved_to_draft": saved,
-			"activity":       event.Activity,
+			"paywall_id":       session.PaywallID,
+			"dashboard_url":    paywallBuilderURL(session.ProjectID, session.PaywallID),
+			"session_id":       session.SessionID,
+			"trace_id":         session.TraceID,
+			"session_file":     opts.sessionPath,
+			"saved_to_draft":   saved,
+			"screenshot_paths": screenshots,
+			"activity":         event.Activity,
 		})
 	}
 	return nil
+}
+
+// savePaywallScreenshots writes the run's rendered previews next to the
+// session file (<session base>.light.png, and .dark.png when the design has
+// dark mode) and returns the paths by color scheme. Best-effort, matching the
+// server's stance: a decode or write failure warns, never fails the turn.
+func savePaywallScreenshots(rt *Runtime, sessionPath string, shots []astra.ResultScreenshot) map[string]string {
+	paths := map[string]string{}
+	base := strings.TrimSuffix(sessionPath, ".astra.json")
+	for _, shot := range shots {
+		data, err := base64.StdEncoding.DecodeString(shot.DataBase64)
+		if err == nil {
+			path := base + "." + shot.ColorScheme + ".png"
+			if err = os.WriteFile(path, data, 0o600); err == nil {
+				paths[shot.ColorScheme] = path
+				continue
+			}
+		}
+		rt.Out.Warn("Could not save the " + shot.ColorScheme + " preview screenshot: " + err.Error())
+	}
+	// A light screenshot without a dark one means the design has no dark
+	// mode; drop a stale dark.png from an earlier turn so it doesn't lie.
+	if _, ok := paths["light"]; ok {
+		if _, ok := paths["dark"]; !ok {
+			os.Remove(base + ".dark.png")
+		}
+	}
+	return paths
 }
 
 // paywallBuilderURL is the dashboard's visual editor for a components


### PR DESCRIPTION
Implements PWAI-283

After each completed turn, writes <paywall-id>.light.png (and .dark.png when the design has dark mode) next to the session file so you can verify the design without opening the dashboard. Rewind cleans them up automatically.

Tested locally, works nicely!


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive CLI/Astra client behavior with best-effort file writes; no auth or draft-persist logic changes beyond requesting and saving optional preview images.
> 
> **Overview**
> Adds **local preview screenshots** for Paywall AI `generate`/`edit` turns so you can judge designs without opening the dashboard.
> 
> The Astra client now requests **`include_result_screenshots`** and decodes **`result_screenshots`** on completed runs. After each turn, the CLI writes **`<session-base>.light.png`** (and **`.dark.png`** when the editor returns dark mode) beside the session file, surfaces paths in interactive output and **`screenshot_paths`** in `--json`, and removes stale **`.dark.png`** when a design no longer has dark mode. **`rc paywalls rewind`** deletes those PNGs so previews match the rewound state. Help text for generate/edit documents the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af59ad4636a882da8b59b0f1baf9f036cf5d1e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->