### PR TITLE
feat(output): surface recovery hints to agents in --json errors

### DIFF
--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -539,8 +540,7 @@ func TestPaywallsGenerate_DraftChangedDuringRun(t *testing.T) {
 	}
 }
 
-// An offering can only have one paywall; the server's bare 409 must come back
-// as a one-line explanation, with the ways out hinted on stderr.
+// An offering can only have one paywall, which the server enforces with a 409.
 func TestPaywallsGenerate_OfferingAlreadyHasPaywall(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -550,7 +550,7 @@ func TestPaywallsGenerate_OfferingAlreadyHasPaywall(t *testing.T) {
 	t.Cleanup(server.Close)
 	t.Setenv("RC_BASE_URL", server.URL)
 
-	_, stderr, err := runAgentCmd(t,
+	_, _, err := runAgentCmd(t,
 		"paywalls", "generate", "--offering-id", "ofrng_default",
 		"--prompt", "A calm annual-first paywall",
 		"--project-id", "proj1", "--no-input", "--api-key", "sk_test",
@@ -558,8 +558,9 @@ func TestPaywallsGenerate_OfferingAlreadyHasPaywall(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "ofrng_default already has a paywall") {
 		t.Fatalf("err = %v", err)
 	}
-	if !strings.Contains(stderr, "omit --offering-id") {
-		t.Fatalf("stderr missing hint: %q", stderr)
+	var hinted interface{ Hint() string }
+	if !errors.As(err, &hinted) || !strings.Contains(hinted.Hint(), "omit --offering-id") {
+		t.Fatalf("recovery hint not attached to error: %v", err)
 	}
 }
 

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -127,9 +127,10 @@ run rc paywalls publish.`,
 				// that as a bare 409.
 				var apiErr *api.APIError
 				if opts.offeringID != "" && errors.As(err, &apiErr) && apiErr.Status == 409 {
-					rt.Out.Hint("Generate against another offering, or omit --offering-id to create a standalone draft and attach it in the dashboard later")
-					rt.Out.Hint("Or delete the existing paywall:  rc paywalls list, then rc paywalls delete <id>")
-					return fmt.Errorf("creating draft paywall: offering %s already has a paywall (an offering can only have one): %w", opts.offeringID, err)
+					return WithHint(
+						fmt.Errorf("creating draft paywall: offering %s already has a paywall (an offering can only have one): %w", opts.offeringID, err),
+						"Generate against another offering, omit --offering-id to create a standalone draft and attach it in the dashboard later, or delete the existing paywall (rc paywalls list, then rc paywalls delete <id>).",
+					)
 				}
 				return fmt.Errorf("creating draft paywall: %w", err)
 			}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -42,9 +42,30 @@ func Run(version string) int {
 	return ExitCodeFor(err)
 }
 
+type hintError struct {
+	err  error
+	hint string
+}
+
+func (e *hintError) Error() string { return e.err.Error() }
+func (e *hintError) Unwrap() error { return e.err }
+func (e *hintError) Hint() string  { return e.hint }
+
+func WithHint(err error, hint string) error {
+	if err == nil {
+		return nil
+	}
+	return &hintError{err: err, hint: hint}
+}
+
 // hintFor surfaces the actionable next-step text for an error. Pulled out so
 // both human stderr and the JSON envelope use the same source of truth.
 func hintFor(err error) string {
+	// Precedence: an attached hint wins over the fallbacks below.
+	var hinted *hintError
+	if errors.As(err, &hinted) && hinted.hint != "" {
+		return hinted.hint
+	}
 	var apiErr *api.APIError
 	if errors.As(err, &apiErr) {
 		return apiErr.Hint()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -117,8 +117,12 @@ func writeJSONError(w io.Writer, err error) {
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(map[string]any{
+	if encErr := enc.Encode(map[string]any{
 		"error":          env,
 		"schema_version": 1,
-	})
+	}); encErr != nil {
+		// Last resort: the envelope failed to encode, but the process is already
+		// exiting non-zero — emit a hand-built line so stderr isn't silent.
+		fmt.Fprintf(w, "{\"error\":{\"type\":\"cli_error\",\"message\":%q},\"schema_version\":1}\n", err.Error())
+	}
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -115,6 +116,39 @@ func TestWriteJSONError_RetryAfterPropagates(t *testing.T) {
 	}
 	if !strings.Contains(got.Error.Hint, "30 seconds") {
 		t.Errorf("hint should mention 30 seconds, got %q", got.Error.Hint)
+	}
+}
+
+func TestWriteJSONError_CarriesAttachedHint(t *testing.T) {
+	var buf bytes.Buffer
+	writeJSONError(&buf, WithHint(errors.New("offering already has a paywall"), "delete it first"))
+	var got struct {
+		Error struct {
+			Message string `json:"message"`
+			Hint    string `json:"hint"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if got.Error.Message != "offering already has a paywall" {
+		t.Errorf("message should be the underlying error, got %q", got.Error.Message)
+	}
+	if got.Error.Hint != "delete it first" {
+		t.Errorf("attached hint should surface in envelope, got %q", got.Error.Hint)
+	}
+}
+
+func TestHintFor_AttachedHintBeatsAPIFallback(t *testing.T) {
+	wrapped := fmt.Errorf("creating draft: %w", &api.APIError{Status: 409, Type: "resource_already_exists", Message: "conflict"})
+	if got := hintFor(WithHint(wrapped, "omit --offering-id")); got != "omit --offering-id" {
+		t.Errorf("attached hint should win over APIError fallback, got %q", got)
+	}
+}
+
+func TestWithHint_NilPassesThrough(t *testing.T) {
+	if WithHint(nil, "unused") != nil {
+		t.Error("WithHint(nil, …) must return nil so it composes in a return position")
 	}
 }
 


### PR DESCRIPTION
## Problem
`Renderer.Hint` is suppressed under `--json`/`--quiet` so they never reach a roboto

## Change
Recovery hints now are on the error itself.

### For humans
The hint text reaches a human on in a TTY)

### For agents
There is a `hint` field in the `--json` error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI error-path changes with tests; no auth, API transport, or data-handling logic beyond surfacing existing hint text.
> 
> **Overview**
> Recovery guidance for command failures is now **attached to the returned error** via `WithHint`, instead of being written only through `Renderer.Hint` (which agents never see under `--json`).
> 
> `hintFor` gives **attached hints precedence** over `APIError` and other fallbacks, so the same text appears in human stderr (`Hint: …`) and in the **`hint` field** of the `--json` error envelope. Paywall generate’s offering-already-has-paywall **409** is the first consumer: one consolidated hint on the error replaces separate `rt.Out.Hint` calls.
> 
> `writeJSONError` now handles JSON encode failures with a minimal fallback line so stderr is not empty on exit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb648771f3e1e4d59545f2bce823b2286b2eb89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->