### PR TITLE
refactor(paywalls): drop the "astra" codename from the Paywall AI CLI

### DIFF
--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -210,11 +210,11 @@ func stubEditorServer(t *testing.T) (*httptest.Server, *int) {
 	return server, &requests
 }
 
-// astraTestServers stubs both the v2 API (draft creation) and the Paywall AI
+// paywallAITestServers stubs both the v2 API (draft creation) and the Paywall AI
 // editor. offeringID == "" makes the v2 API stubs serve a standalone paywall.
 // The editor stream echoes offering_id as null, as the live service does
 // after a template load.
-func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string, editorInputs, createInputs *[]map[string]any) {
+func paywallAITestServers(t *testing.T, offeringID string) (apiURL, paywallAIURL string, editorInputs, createInputs *[]map[string]any) {
 	t.Helper()
 	offeringJSON := "null"
 	if offeringID != "" {
@@ -262,9 +262,9 @@ func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string,
 	t.Cleanup(apiServer.Close)
 
 	var inputs []map[string]any
-	astraServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	paywallAIServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/editor/v1/stream" {
-			t.Errorf("astra path = %s", r.URL.Path)
+			t.Errorf("paywall AI path = %s", r.URL.Path)
 			return
 		}
 		var input map[string]any
@@ -275,12 +275,12 @@ func astraTestServers(t *testing.T, offeringID string) (apiURL, astraURL string,
 		io.WriteString(w, "data: {\"type\":\"turn.snapshot\",\"session_id\":\"sess1\",\"turn_index\":0,\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}}],\"__unstable_session_items\":[{\"k\":1}]}\n\n")
 		io.WriteString(w, "data: {\"type\":\"run.completed\",\"session_id\":\"sess1\",\"trace_id\":\"tr1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero section\"}},{\"id\":\"a2\",\"type\":\"assistant_message\",\"content\":\"Done — calm annual-first layout.\"}],\"__unstable_session_items\":[{\"k\":2}],\"result_screenshots\":[{\"color_scheme\":\"light\",\"mime_type\":\"image/png\",\"data_base64\":\"UE5H\"}]}\n\n")
 	}))
-	t.Cleanup(astraServer.Close)
-	return apiServer.URL, astraServer.URL, &inputs, &created
+	t.Cleanup(paywallAIServer.Close)
+	return apiServer.URL, paywallAIServer.URL, &inputs, &created
 }
 
 // runAgentCmd is runCmd without the env reset, so RC_BASE_URL /
-// RC_ASTRA_BASE_URL stubs set by the test survive.
+// RC_PAYWALL_AI_BASE_URL stubs set by the test survive.
 func runAgentCmd(t *testing.T, args ...string) (string, string, error) {
 	t.Helper()
 	t.Setenv("RC_CONFIG_DIR", t.TempDir())
@@ -294,9 +294,9 @@ func runAgentCmd(t *testing.T, args ...string) (string, string, error) {
 }
 
 func TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession(t *testing.T) {
-	apiURL, astraURL, editorInputs, createInputs := astraTestServers(t, "ofrng_default")
+	apiURL, paywallAIURL, editorInputs, createInputs := paywallAITestServers(t, "ofrng_default")
 	t.Setenv("RC_BASE_URL", apiURL)
-	t.Setenv("RC_ASTRA_BASE_URL", astraURL)
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", paywallAIURL)
 
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.json")
@@ -398,9 +398,9 @@ func TestPaywallsGenerate_CreatesDraftStreamsAndSavesSession(t *testing.T) {
 }
 
 func TestPaywallsGenerate_Standalone(t *testing.T) {
-	apiURL, astraURL, editorInputs, createInputs := astraTestServers(t, "")
+	apiURL, paywallAIURL, editorInputs, createInputs := paywallAITestServers(t, "")
 	t.Setenv("RC_BASE_URL", apiURL)
-	t.Setenv("RC_ASTRA_BASE_URL", astraURL)
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", paywallAIURL)
 	t.Setenv("RC_OFFERING_ID", "")
 
 	sessionPath := filepath.Join(t.TempDir(), "session.json")
@@ -454,9 +454,9 @@ func TestPaywallsGenerate_Standalone(t *testing.T) {
 // reports the paywall attached even though generate ran standalone — the
 // session must pick up the server truth from the PATCH response.
 func TestPaywallsGenerate_RefreshesOfferingFromServer(t *testing.T) {
-	apiURL, astraURL, _, _ := astraTestServers(t, "ofrng_default")
+	apiURL, paywallAIURL, _, _ := paywallAITestServers(t, "ofrng_default")
 	t.Setenv("RC_BASE_URL", apiURL)
-	t.Setenv("RC_ASTRA_BASE_URL", astraURL)
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", paywallAIURL)
 	t.Setenv("RC_OFFERING_ID", "")
 
 	sessionPath := filepath.Join(t.TempDir(), "session.json")
@@ -514,9 +514,9 @@ func TestPaywallsGenerate_DraftChangedDuringRun(t *testing.T) {
 		}
 	}))
 	t.Cleanup(apiServer.Close)
-	astraServer, _ := stubEditorServer(t)
+	paywallAIServer, _ := stubEditorServer(t)
 	t.Setenv("RC_BASE_URL", apiServer.URL)
-	t.Setenv("RC_ASTRA_BASE_URL", astraServer.URL)
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", paywallAIServer.URL)
 	t.Setenv("RC_OFFERING_ID", "")
 
 	stdout, _, err := runAgentCmd(t,
@@ -591,9 +591,9 @@ func TestPaywallsEdit_StaleSessionStopsBeforeDesignTurn(t *testing.T) {
 		io.WriteString(w, paywallResponseJSON("null", 5))
 	}))
 	t.Cleanup(apiServer.Close)
-	astraServer, astraRequests := stubEditorServer(t)
+	paywallAIServer, paywallAIRequests := stubEditorServer(t)
 	t.Setenv("RC_BASE_URL", apiServer.URL)
-	t.Setenv("RC_ASTRA_BASE_URL", astraServer.URL)
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", paywallAIServer.URL)
 
 	sessionPath := filepath.Join(t.TempDir(), "session.json")
 	if err := os.WriteFile(sessionPath, []byte(staleTestSession), 0o600); err != nil {
@@ -608,8 +608,8 @@ func TestPaywallsEdit_StaleSessionStopsBeforeDesignTurn(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "pass --yes") {
 		t.Fatalf("err = %v", err)
 	}
-	if *astraRequests != 0 {
-		t.Fatalf("editor requests = %d, want 0 (no design turn on a stale session)", *astraRequests)
+	if *paywallAIRequests != 0 {
+		t.Fatalf("editor requests = %d, want 0 (no design turn on a stale session)", *paywallAIRequests)
 	}
 	payload, err := os.ReadFile(sessionPath)
 	if err != nil {
@@ -642,9 +642,9 @@ func TestPaywallsEdit_PatchCarriesSessionRevision(t *testing.T) {
 		}
 	}))
 	t.Cleanup(apiServer.Close)
-	astraServer, _ := stubEditorServer(t)
+	paywallAIServer, _ := stubEditorServer(t)
 	t.Setenv("RC_BASE_URL", apiServer.URL)
-	t.Setenv("RC_ASTRA_BASE_URL", astraServer.URL)
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", paywallAIServer.URL)
 
 	sessionPath := filepath.Join(t.TempDir(), "session.json")
 	if err := os.WriteFile(sessionPath, []byte(staleTestSession), 0o600); err != nil {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -16,27 +16,29 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/revenuecat/cli/internal/api"
-	"github.com/revenuecat/cli/internal/astra"
+	"github.com/revenuecat/cli/internal/paywallai"
 	"github.com/revenuecat/cli/internal/tui"
 )
 
-// astraSession is the state file round-tripped between editor turns. The
+// paywallAISession is the state file round-tripped between editor turns. The
 // Paywall AI editor keeps no server-side paywall state between requests: the client must resend
 // the full paywall plus the opaque session blobs every turn, so the CLI
 // persists them here (the dashboard holds the same data in builder state).
-type astraSession struct {
-	Version          int               `json:"version"`
-	ProjectID        string            `json:"project_id"`
-	PaywallID        string            `json:"paywall_id"`
-	SessionID        string            `json:"session_id,omitempty"`
-	TraceID          string            `json:"trace_id,omitempty"`
-	Revision         *int              `json:"revision"`
-	Paywall          astra.PaywallData `json:"paywall"`
-	UIConfig         json.RawMessage   `json:"ui_config"`
-	ProductVariables map[string]string `json:"product_variables"`
-	SessionItems     json.RawMessage   `json:"__unstable_session_items"`
-	AppContext       json.RawMessage   `json:"app_context,omitempty"`
+type paywallAISession struct {
+	Version          int                   `json:"version"`
+	ProjectID        string                `json:"project_id"`
+	PaywallID        string                `json:"paywall_id"`
+	SessionID        string                `json:"session_id,omitempty"`
+	TraceID          string                `json:"trace_id,omitempty"`
+	Revision         *int                  `json:"revision"`
+	Paywall          paywallai.PaywallData `json:"paywall"`
+	UIConfig         json.RawMessage       `json:"ui_config"`
+	ProductVariables map[string]string     `json:"product_variables"`
+	SessionItems     json.RawMessage       `json:"__unstable_session_items"`
+	AppContext       json.RawMessage       `json:"app_context,omitempty"`
 }
+
+const paywallSessionSuffix = ".paywall.json"
 
 // Minimal valid editor state for a brand-new paywall, mirroring the
 // dashboard's buildMinimalPaywall test helper: an empty root stack on a
@@ -76,7 +78,7 @@ func newPaywallsGenerateCmd() *cobra.Command {
 	opts := paywallAIOptions{
 		prompt:     os.Getenv("RC_PAYWALL_PROMPT"),
 		offeringID: os.Getenv("RC_OFFERING_ID"),
-		baseURL:    envOrDefault("RC_ASTRA_BASE_URL", astra.DefaultBaseURL),
+		baseURL:    envOrDefault("RC_PAYWALL_AI_BASE_URL", paywallai.DefaultBaseURL),
 		timeout:    12 * time.Minute,
 	}
 	cmd := &cobra.Command{
@@ -148,12 +150,12 @@ run rc paywalls publish.`,
 			if opts.offeringID != "" {
 				offeringID = &opts.offeringID
 			}
-			session := &astraSession{
+			session := &paywallAISession{
 				Version:   1,
 				ProjectID: projectID,
 				PaywallID: paywall.ID,
 				Revision:  &revision,
-				Paywall: astra.PaywallData{
+				Paywall: paywallai.PaywallData{
 					DefaultLocale:           "en_US",
 					OfferingID:              offeringID,
 					ComponentsConfig:        json.RawMessage(minimalComponentsConfig),
@@ -164,7 +166,7 @@ run rc paywalls publish.`,
 				SessionItems:     json.RawMessage(`{}`),
 			}
 			if opts.sessionPath == "" {
-				opts.sessionPath = paywall.ID + ".astra.json"
+				opts.sessionPath = paywall.ID + paywallSessionSuffix
 			}
 			return runPaywallAI(cmd.Context(), rt, opts, session)
 		},
@@ -178,7 +180,7 @@ run rc paywalls publish.`,
 func newPaywallsEditCmd() *cobra.Command {
 	opts := paywallAIOptions{
 		prompt:  os.Getenv("RC_PAYWALL_PROMPT"),
-		baseURL: envOrDefault("RC_ASTRA_BASE_URL", astra.DefaultBaseURL),
+		baseURL: envOrDefault("RC_PAYWALL_AI_BASE_URL", paywallai.DefaultBaseURL),
 		timeout: 10 * time.Minute,
 	}
 	cmd := &cobra.Command{
@@ -218,15 +220,15 @@ Using it well:
 		Example: `  rc paywalls edit                       # picker, then it asks what to change
   rc paywalls edit pw_abc --prompt "Background #0E1B2A, bolder CTA, keep the layout"
   rc paywalls edit pw_abc --prompt "match this" --attachment DESIGN.md --image home.png
-  rc paywalls edit --session pw_abc.astra.json --prompt "Push the gradient harder" --json --no-input`,
+  rc paywalls edit --session pw_abc.paywall.json --prompt "Push the gradient harder" --json --no-input`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
-			var session *astraSession
+			var session *paywallAISession
 			var err error
 			switch {
 			case opts.sessionPath != "":
-				session, err = loadAstraSession(rt, opts.sessionPath)
+				session, err = loadPaywallAISession(rt, opts.sessionPath)
 				if err == nil {
 					session, err = preflightSessionRevision(cmd.Context(), rt, session)
 				}
@@ -246,7 +248,7 @@ Using it well:
 					return perr
 				}
 				session, err = seedSessionFromServer(cmd.Context(), rt, projectID, paywallID)
-				opts.sessionPath = paywallID + ".astra.json"
+				opts.sessionPath = paywallID + paywallSessionSuffix
 			default:
 				return fmt.Errorf("pass a paywall ID or --session <file>")
 			}
@@ -268,7 +270,7 @@ Using it well:
 // turn is spent on it. A diverged session can't continue — the prompt targets
 // state that no longer exists — so the only way forward is consent to start
 // fresh from the server's draft, losing the conversation.
-func preflightSessionRevision(ctx context.Context, rt *Runtime, session *astraSession) (*astraSession, error) {
+func preflightSessionRevision(ctx context.Context, rt *Runtime, session *paywallAISession) (*paywallAISession, error) {
 	client, err := rt.API()
 	if err != nil {
 		return nil, err
@@ -291,7 +293,7 @@ func preflightSessionRevision(ctx context.Context, rt *Runtime, session *astraSe
 
 // seedSessionFromServer starts an editor session from the paywall's current
 // RevenueCat state (draft components, falling back to published).
-func seedSessionFromServer(ctx context.Context, rt *Runtime, projectID string, paywallID string) (*astraSession, error) {
+func seedSessionFromServer(ctx context.Context, rt *Runtime, projectID string, paywallID string) (*paywallAISession, error) {
 	client, err := rt.API()
 	if err != nil {
 		return nil, err
@@ -328,12 +330,12 @@ func seedSessionFromServer(ctx context.Context, rt *Runtime, projectID string, p
 	if version.Revision != nil {
 		revision = *version.Revision
 	}
-	return &astraSession{
+	return &paywallAISession{
 		Version:   1,
 		ProjectID: projectID,
 		PaywallID: paywall.ID,
 		Revision:  &revision,
-		Paywall: astra.PaywallData{
+		Paywall: paywallai.PaywallData{
 			DefaultLocale:           locale,
 			OfferingID:              offeringID,
 			ComponentsConfig:        version.ComponentsConfig,
@@ -347,7 +349,7 @@ func seedSessionFromServer(ctx context.Context, rt *Runtime, projectID string, p
 
 func newPaywallsRewindCmd() *cobra.Command {
 	var sessionPath string
-	baseURL := envOrDefault("RC_ASTRA_BASE_URL", astra.DefaultBaseURL)
+	baseURL := envOrDefault("RC_PAYWALL_AI_BASE_URL", paywallai.DefaultBaseURL)
 	cmd := &cobra.Command{
 		Use:   "rewind --session <file>",
 		Short: "Undo the last Paywall AI editor action",
@@ -357,14 +359,14 @@ func newPaywallsRewindCmd() *cobra.Command {
 			if sessionPath == "" {
 				return fmt.Errorf("--session is required")
 			}
-			session, err := loadAstraSession(rt, sessionPath)
+			session, err := loadPaywallAISession(rt, sessionPath)
 			if err != nil {
 				return err
 			}
 			if session.SessionID == "" || session.TraceID == "" {
 				return fmt.Errorf("session file has no completed run to rewind")
 			}
-			client, err := astraClient(rt, baseURL)
+			client, err := paywallAIClient(rt, baseURL)
 			if err != nil {
 				return err
 			}
@@ -372,7 +374,7 @@ func newPaywallsRewindCmd() *cobra.Command {
 				return err
 			}
 			// Drop saved screenshots — they show the pre-rewind design.
-			base := strings.TrimSuffix(sessionPath, ".astra.json")
+			base := strings.TrimSuffix(sessionPath, filepath.Ext(sessionPath))
 			os.Remove(base + ".light.png")
 			os.Remove(base + ".dark.png")
 			rt.Out.Success("Rewound last editor action")
@@ -380,7 +382,7 @@ func newPaywallsRewindCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&sessionPath, "session", "", "editor session file")
-	cmd.Flags().StringVar(&baseURL, "base-url", baseURL, "Paywall AI editor endpoint (or RC_ASTRA_BASE_URL)")
+	cmd.Flags().StringVar(&baseURL, "base-url", baseURL, "Paywall AI editor endpoint (or RC_PAYWALL_AI_BASE_URL)")
 	return cmd
 }
 
@@ -388,15 +390,15 @@ func addPaywallAIFlags(cmd *cobra.Command, opts *paywallAIOptions) {
 	cmd.Flags().StringVar(&opts.prompt, "prompt", opts.prompt, "natural-language direction (or RC_PAYWALL_PROMPT)")
 	cmd.Flags().StringVar(&opts.context, "context", "", "product/audience/brand context sent alongside the direction")
 	cmd.Flags().StringArrayVar(&opts.attachments, "attachment", nil, "design reference file: images (png/jpeg/webp) attach visually, text files (DESIGN.md, style guides) travel with the direction")
-	cmd.Flags().StringVar(&opts.sessionPath, "session", opts.sessionPath, "editor session file (default: <paywall-id>.astra.json)")
+	cmd.Flags().StringVar(&opts.sessionPath, "session", opts.sessionPath, "editor session file (default: <paywall-id>.paywall.json)")
 	cmd.Flags().StringArrayVar(&opts.images, "image", nil, "reference image to attach (png/jpeg/webp, max 3)")
-	cmd.Flags().StringVar(&opts.baseURL, "base-url", opts.baseURL, "Paywall AI editor endpoint (or RC_ASTRA_BASE_URL)")
+	cmd.Flags().StringVar(&opts.baseURL, "base-url", opts.baseURL, "Paywall AI editor endpoint (or RC_PAYWALL_AI_BASE_URL)")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "maximum time to wait")
 }
 
 // runPaywallAI streams one editor turn and persists the updated session file.
-func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, session *astraSession) error {
-	client, err := astraClient(rt, opts.baseURL)
+func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, session *paywallAISession) error {
+	client, err := paywallAIClient(rt, opts.baseURL)
 	if err != nil {
 		return err
 	}
@@ -409,7 +411,7 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 	defer cancel()
 
 	rt.Out.Info("Designing with the Paywall AI editor — this can take a few minutes…")
-	stream, err := client.Stream(ctx, astra.EditorRequest{
+	stream, err := client.Stream(ctx, paywallai.EditorRequest{
 		ProjectID:        session.ProjectID,
 		PaywallID:        session.PaywallID,
 		Revision:         session.Revision,
@@ -433,26 +435,26 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 	for {
 		event, err := stream.Next()
 		if err == io.EOF {
-			return fmt.Errorf("astra closed the stream without completing the run")
+			return fmt.Errorf("the Paywall AI editor closed the stream without completing the run")
 		}
 		if err != nil {
 			return err
 		}
 		switch event.Type {
-		case astra.EventRunStarted:
+		case paywallai.EventRunStarted:
 			session.SessionID = event.SessionID
-		case astra.EventTurnSnapshot:
+		case paywallai.EventTurnSnapshot:
 			reportedActivity = reportPaywallAIActivity(rt, event.Activity, reportedActivity)
-		case astra.EventRunFailed:
+		case paywallai.EventRunFailed:
 			return fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message)
-		case astra.EventRunCompleted:
+		case paywallai.EventRunCompleted:
 			reportPaywallAIActivity(rt, event.Activity, reportedActivity)
 			return finishPaywallAI(ctx, rt, opts, session, event)
 		}
 	}
 }
 
-func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, session *astraSession, event *astra.Event) error {
+func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, session *paywallAISession, event *paywallai.Event) error {
 	session.SessionID = event.SessionID
 	session.TraceID = event.TraceID
 	if event.Paywall != nil {
@@ -470,7 +472,7 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 	if len(event.AppContext) > 0 {
 		session.AppContext = event.AppContext
 	}
-	if err := saveAstraSession(opts.sessionPath, session); err != nil {
+	if err := savePaywallAISession(opts.sessionPath, session); err != nil {
 		return err
 	}
 	// Saved even when the draft PATCH below fails — the screenshot shows
@@ -490,7 +492,7 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 		saved = true
 		// Persisting refreshed the revision and offering from the server;
 		// re-save so the next turn starts from them.
-		if err := saveAstraSession(opts.sessionPath, session); err != nil {
+		if err := savePaywallAISession(opts.sessionPath, session); err != nil {
 			return err
 		}
 		rt.Out.Success("Design saved to paywall draft " + session.PaywallID)
@@ -530,9 +532,9 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 // savePaywallScreenshots writes the run's rendered previews next to the
 // session file (<base>.light.png / .dark.png) and returns the paths by color
 // scheme. Best-effort: a decode or write failure warns, never fails the turn.
-func savePaywallScreenshots(rt *Runtime, sessionPath string, shots []astra.ResultScreenshot) map[string]string {
+func savePaywallScreenshots(rt *Runtime, sessionPath string, shots []paywallai.ResultScreenshot) map[string]string {
 	paths := map[string]string{}
-	base := strings.TrimSuffix(sessionPath, ".astra.json")
+	base := strings.TrimSuffix(sessionPath, filepath.Ext(sessionPath))
 	for _, shot := range shots {
 		data, err := base64.StdEncoding.DecodeString(shot.DataBase64)
 		if err == nil {
@@ -563,7 +565,7 @@ func paywallBuilderURL(projectID, paywallID string) string {
 // persistPaywallDesign PATCHes the designed components onto the RevenueCat
 // paywall draft, guarded by the session's own revision: a draft that changed
 // outside the session comes back as a 409 instead of being overwritten.
-func persistPaywallDesign(ctx context.Context, rt *Runtime, session *astraSession) error {
+func persistPaywallDesign(ctx context.Context, rt *Runtime, session *paywallAISession) error {
 	client, err := rt.API()
 	if err != nil {
 		return err
@@ -612,7 +614,7 @@ func currentDraftRevision(ctx context.Context, client *api.Client, projectID, pa
 
 // reportPaywallAIActivity prints activity items not yet shown; snapshots carry
 // the full list each time, so it resumes from the previous count.
-func reportPaywallAIActivity(rt *Runtime, activity []astra.ToolActivity, alreadyReported int) int {
+func reportPaywallAIActivity(rt *Runtime, activity []paywallai.ToolActivity, alreadyReported int) int {
 	for _, item := range activity[min(alreadyReported, len(activity)):] {
 		switch item.Type {
 		case "assistant_message":
@@ -635,12 +637,12 @@ func reportPaywallAIActivity(rt *Runtime, activity []astra.ToolActivity, already
 	return alreadyReported
 }
 
-func loadAstraSession(rt *Runtime, path string) (*astraSession, error) {
+func loadPaywallAISession(rt *Runtime, path string) (*paywallAISession, error) {
 	payload, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading session file: %w", err)
 	}
-	var session astraSession
+	var session paywallAISession
 	if err := json.Unmarshal(payload, &session); err != nil {
 		return nil, fmt.Errorf("parsing session file %s: %w", path, err)
 	}
@@ -656,7 +658,7 @@ func loadAstraSession(rt *Runtime, path string) (*astraSession, error) {
 	return &session, nil
 }
 
-func saveAstraSession(path string, session *astraSession) error {
+func savePaywallAISession(path string, session *paywallAISession) error {
 	payload, err := json.MarshalIndent(session, "", "  ")
 	if err != nil {
 		return err
@@ -671,11 +673,11 @@ var paywallAIImageTypes = map[string]string{
 	".webp": "image/webp",
 }
 
-func loadPaywallAIImages(paths []string) ([]astra.InputAttachment, error) {
+func loadPaywallAIImages(paths []string) ([]paywallai.InputAttachment, error) {
 	if len(paths) > 3 {
 		return nil, fmt.Errorf("at most 3 images can be attached, got %d", len(paths))
 	}
-	var attachments []astra.InputAttachment
+	var attachments []paywallai.InputAttachment
 	for _, path := range paths {
 		mimeType, ok := paywallAIImageTypes[strings.ToLower(filepath.Ext(path))]
 		if !ok {
@@ -688,7 +690,7 @@ func loadPaywallAIImages(paths []string) ([]astra.InputAttachment, error) {
 		if len(data) > 10<<20 {
 			return nil, fmt.Errorf("image %s exceeds the 10MB limit", path)
 		}
-		attachments = append(attachments, astra.InputAttachment{
+		attachments = append(attachments, paywallai.InputAttachment{
 			Type:       "image",
 			Filename:   filepath.Base(path),
 			MimeType:   mimeType,
@@ -698,12 +700,12 @@ func loadPaywallAIImages(paths []string) ([]astra.InputAttachment, error) {
 	return attachments, nil
 }
 
-func astraClient(rt *Runtime, baseURL string) (*astra.Client, error) {
+func paywallAIClient(rt *Runtime, baseURL string) (*paywallai.Client, error) {
 	// rt.API() refreshes the OAuth token if needed and enforces login.
 	if _, err := rt.API(); err != nil {
 		return nil, err
 	}
-	return astra.NewClient(astra.Options{
+	return paywallai.NewClient(paywallai.Options{
 		BaseURL:   baseURL,
 		Token:     agentAuthToken(rt),
 		UserAgent: userAgent(rt.Globals.Version),
@@ -732,7 +734,7 @@ func withPaywallContext(prompt, context string) string {
 	return "Context: " + context + "\n\nDirection: " + prompt
 }
 
-func countErroredActivity(activity []astra.ToolActivity) int {
+func countErroredActivity(activity []paywallai.ToolActivity) int {
 	n := 0
 	for _, item := range activity {
 		if item.Status == "error" {
@@ -747,7 +749,7 @@ func countErroredActivity(activity []astra.ToolActivity) int {
 // png/jpeg/webp, max 3, 10MB); text design references (DESIGN.md, style
 // guides) are folded into the message, which is the only channel the editor
 // API has for them today. Anything else (fonts, binaries) errors clearly.
-func loadPaywallAIAttachments(images, attachments []string) ([]astra.InputAttachment, string, error) {
+func loadPaywallAIAttachments(images, attachments []string) ([]paywallai.InputAttachment, string, error) {
 	imagePaths := append([]string(nil), images...)
 	var textBlocks []string
 	for _, path := range attachments {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -40,6 +40,13 @@ type paywallAISession struct {
 
 const paywallSessionSuffix = ".paywall.json"
 
+func screenshotBase(sessionPath string) string {
+	if strings.HasSuffix(sessionPath, paywallSessionSuffix) {
+		return strings.TrimSuffix(sessionPath, paywallSessionSuffix)
+	}
+	return strings.TrimSuffix(sessionPath, filepath.Ext(sessionPath))
+}
+
 // Minimal valid editor state for a brand-new paywall, mirroring the
 // dashboard's buildMinimalPaywall test helper: an empty root stack on a
 // white background, no fonts or presets yet.
@@ -374,7 +381,7 @@ func newPaywallsRewindCmd() *cobra.Command {
 				return err
 			}
 			// Drop saved screenshots — they show the pre-rewind design.
-			base := strings.TrimSuffix(sessionPath, filepath.Ext(sessionPath))
+			base := screenshotBase(sessionPath)
 			os.Remove(base + ".light.png")
 			os.Remove(base + ".dark.png")
 			rt.Out.Success("Rewound last editor action")
@@ -534,7 +541,7 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 // scheme. Best-effort: a decode or write failure warns, never fails the turn.
 func savePaywallScreenshots(rt *Runtime, sessionPath string, shots []paywallai.ResultScreenshot) map[string]string {
 	paths := map[string]string{}
-	base := strings.TrimSuffix(sessionPath, filepath.Ext(sessionPath))
+	base := screenshotBase(sessionPath)
 	for _, shot := range shots {
 		data, err := base64.StdEncoding.DecodeString(shot.DataBase64)
 		if err == nil {

--- a/internal/cli/paywalls_ai_helpers_test.go
+++ b/internal/cli/paywalls_ai_helpers_test.go
@@ -46,3 +46,17 @@ func TestLoadPaywallAIAttachments(t *testing.T) {
 		t.Fatal("unsupported attachment type should error")
 	}
 }
+
+func TestScreenshotBase(t *testing.T) {
+	cases := map[string]string{
+		"pw_abc.paywall.json":      "pw_abc",
+		"/tmp/pw_abc.paywall.json": "/tmp/pw_abc",
+		"mywall.json":              "mywall",
+		"design":                   "design",
+	}
+	for in, want := range cases {
+		if got := screenshotBase(in); got != want {
+			t.Errorf("screenshotBase(%q) = %q, want %q", in, want, got)
+		}
+	}
+}

--- a/internal/paywallai/paywallai.go
+++ b/internal/paywallai/paywallai.go
@@ -1,7 +1,7 @@
-// Package astra is a client for the Paywall AI editor backend
+// Package paywallai is a client for the Paywall AI editor backend
 // (astra.revenuecat.com), speaking the same SSE contract as the dashboard
 // and mobile apps.
-package astra
+package paywallai
 
 import (
 	"bytes"

--- a/internal/paywallai/paywallai_test.go
+++ b/internal/paywallai/paywallai_test.go
@@ -1,4 +1,4 @@
-package astra
+package paywallai
 
 import (
 	"context"


### PR DESCRIPTION
## What

Rename "astra" things to "paywalls ai"

### What moved
- `internal/astra` package → `internal/paywallai`
- `astraSession` → `paywallAISession`
- `RC_ASTRA_BASE_URL` → `RC_PAYWALL_AI_BASE_URL`
- session file `.astra.json` → `.paywall.json`, now a single constant instead of a magic string in five places

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename with no behavior changes to streaming, draft persistence, or revision guards; users must switch env var and session file extension if they relied on the old names.
> 
> **Overview**
> Renames the internal **Paywall AI** integration away from the **astra** codename so CLI code, env vars, and session files match the product name.
> 
> **`internal/astra`** becomes **`internal/paywallai`**; CLI types and helpers follow (`astraSession` → `paywallAISession`, `loadAstraSession` / `saveAstraSession` → `loadPaywallAISession` / `savePaywallAISession`, `astraClient` → `paywallAIClient`). **`RC_ASTRA_BASE_URL`** is **`RC_PAYWALL_AI_BASE_URL`**.
> 
> Default session files change from **`<paywall-id>.astra.json`** to **`<paywall-id>.paywall.json`**, driven by a **`paywallSessionSuffix`** constant. **`screenshotBase`** derives preview paths from that suffix (and falls back for custom session paths); rewind and screenshot saving use it instead of hard-coded `.astra.json` trimming.
> 
> Tests and help text are updated to the new names; **`TestScreenshotBase`** covers path derivation. The editor still targets **`https://astra.revenuecat.com`** via **`paywallai.DefaultBaseURL`**—only in-repo naming changed, not the live hostname.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36bb6eb6f02b84c0cd48ffb97e31c00fcc6fbeb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->