### PR TITLE
feat(paywalls): store session files and screenshots in the CLI's data dir

### DIFF
--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -540,6 +540,50 @@ func TestPaywallsGenerate_DraftChangedDuringRun(t *testing.T) {
 	}
 }
 
+// With no --session, the session file and its screenshots land under the CLI
+// data dir (paywalls/<project>/<paywall>/), and every surfaced path is absolute.
+func TestPaywallsGenerate_DefaultsToDataDir(t *testing.T) {
+	apiURL, paywallAIURL, _, _ := paywallAITestServers(t, "ofrng_default")
+	t.Setenv("RC_BASE_URL", apiURL)
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", paywallAIURL)
+
+	stdout, _, err := runAgentCmd(t,
+		"paywalls", "generate", "--offering-id", "ofrng_default",
+		"--prompt", "A calm annual-first paywall",
+		"--project-id", "proj1",
+		"--json", "--no-input", "--api-key", "sk_test",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope struct {
+		Data struct {
+			SessionFile     string            `json:"session_file"`
+			ScreenshotPaths map[string]string `json:"screenshot_paths"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout)
+	}
+	sf := envelope.Data.SessionFile
+	if !filepath.IsAbs(sf) {
+		t.Fatalf("session_file must be absolute, got %q", sf)
+	}
+	if !strings.Contains(sf, filepath.Join("paywalls", "proj1", "pw_new")) || filepath.Base(sf) != "session.paywall.json" {
+		t.Fatalf("session_file not centralized per project/paywall: %q", sf)
+	}
+	if _, err := os.Stat(sf); err != nil {
+		t.Fatalf("session file not written: %v", err)
+	}
+	shot := envelope.Data.ScreenshotPaths["light"]
+	if !filepath.IsAbs(shot) || filepath.Base(shot) != "session.light.png" {
+		t.Fatalf("screenshot must be absolute and beside the session, got %q", shot)
+	}
+	if _, err := os.Stat(shot); err != nil {
+		t.Fatalf("screenshot not written: %v", err)
+	}
+}
+
 // An offering can only have one paywall, which the server enforces with a 409.
 func TestPaywallsGenerate_OfferingAlreadyHasPaywall(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -48,10 +48,6 @@ func screenshotBase(sessionPath string) string {
 	return strings.TrimSuffix(sessionPath, filepath.Ext(sessionPath))
 }
 
-// defaultPaywallSessionPath centralizes session files (and, alongside them,
-// preview screenshots) under the CLI data dir in a folder per paywall, so they
-// don't clutter — and get committed from — whatever working directory the
-// command ran in.
 func defaultPaywallSessionPath(projectID, paywallID string) (string, error) {
 	dir, err := config.Dir()
 	if err != nil {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/revenuecat/cli/internal/api"
+	"github.com/revenuecat/cli/internal/config"
 	"github.com/revenuecat/cli/internal/paywallai"
 	"github.com/revenuecat/cli/internal/tui"
 )
@@ -45,6 +46,22 @@ func screenshotBase(sessionPath string) string {
 		return strings.TrimSuffix(sessionPath, paywallSessionSuffix)
 	}
 	return strings.TrimSuffix(sessionPath, filepath.Ext(sessionPath))
+}
+
+// defaultPaywallSessionPath centralizes session files (and, alongside them,
+// preview screenshots) under the CLI data dir in a folder per paywall, so they
+// don't clutter — and get committed from — whatever working directory the
+// command ran in.
+func defaultPaywallSessionPath(projectID, paywallID string) (string, error) {
+	dir, err := config.Dir()
+	if err != nil {
+		return "", err
+	}
+	sessionDir := filepath.Join(dir, "paywalls", projectID, paywallID)
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		return "", err
+	}
+	return filepath.Join(sessionDir, "session"+paywallSessionSuffix), nil
 }
 
 // Minimal valid editor state for a brand-new paywall, mirroring the
@@ -101,9 +118,9 @@ Each completed turn saves the design onto the RevenueCat paywall draft, and
 the editor state is also kept in a session file so follow-up edits retain the
 conversation: pass the same --session to rc paywalls edit. The editor may
 answer with a clarifying question instead of a design — reply with another
-edit turn. Each completed turn also writes a preview screenshot
-(<paywall-id>.light.png, plus .dark.png when the design has dark mode) next to
-the session file — look at it after every turn and keep iterating with edit
+edit turn. Each completed turn also writes a preview screenshot next to the
+session file (plus a dark-mode one when the design has dark mode); its path is
+shown in the output — look at it after every turn and keep iterating with edit
 turns until the design is right. The draft stays unpublished; review it and
 run rc paywalls publish.`,
 		Example: `  rc paywalls generate
@@ -173,7 +190,10 @@ run rc paywalls publish.`,
 				SessionItems:     json.RawMessage(`{}`),
 			}
 			if opts.sessionPath == "" {
-				opts.sessionPath = paywall.ID + paywallSessionSuffix
+				opts.sessionPath, err = defaultPaywallSessionPath(projectID, paywall.ID)
+				if err != nil {
+					return err
+				}
 			}
 			return runPaywallAI(cmd.Context(), rt, opts, session)
 		},
@@ -217,10 +237,10 @@ Using it well:
   - The Paywall AI editor may reply with a clarifying question instead of a design (it
     appears in the streamed activity / the --json activity array). Answer it
     with another edit turn on the same session.
-  - Each completed turn writes <paywall-id>.light.png (and .dark.png when
-    the design has dark mode) next to the session file. Look at it after
-    every turn: judge the result against the direction, then follow up
-    with more edit turns until it looks right.
+  - Each completed turn writes a preview screenshot next to the session file
+    (and a dark-mode one when the design has dark mode); its path is shown in
+    the output. Look at it after every turn: judge the result against the
+    direction, then follow up with more edit turns until it looks right.
   - Turns take one to several minutes and stream progress; run with an
     extended timeout (--timeout) or in the background rather than polling.
   - Undo the last turn:  rc paywalls rewind --session <file>`,
@@ -255,7 +275,9 @@ Using it well:
 					return perr
 				}
 				session, err = seedSessionFromServer(cmd.Context(), rt, projectID, paywallID)
-				opts.sessionPath = paywallID + paywallSessionSuffix
+				if err == nil {
+					opts.sessionPath, err = defaultPaywallSessionPath(projectID, paywallID)
+				}
 			default:
 				return fmt.Errorf("pass a paywall ID or --session <file>")
 			}
@@ -397,7 +419,7 @@ func addPaywallAIFlags(cmd *cobra.Command, opts *paywallAIOptions) {
 	cmd.Flags().StringVar(&opts.prompt, "prompt", opts.prompt, "natural-language direction (or RC_PAYWALL_PROMPT)")
 	cmd.Flags().StringVar(&opts.context, "context", "", "product/audience/brand context sent alongside the direction")
 	cmd.Flags().StringArrayVar(&opts.attachments, "attachment", nil, "design reference file: images (png/jpeg/webp) attach visually, text files (DESIGN.md, style guides) travel with the direction")
-	cmd.Flags().StringVar(&opts.sessionPath, "session", opts.sessionPath, "editor session file (default: <paywall-id>.paywall.json)")
+	cmd.Flags().StringVar(&opts.sessionPath, "session", opts.sessionPath, "editor session file (default: in the CLI data dir, per project and paywall)")
 	cmd.Flags().StringArrayVar(&opts.images, "image", nil, "reference image to attach (png/jpeg/webp, max 3)")
 	cmd.Flags().StringVar(&opts.baseURL, "base-url", opts.baseURL, "Paywall AI editor endpoint (or RC_PAYWALL_AI_BASE_URL)")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "maximum time to wait")
@@ -405,6 +427,9 @@ func addPaywallAIFlags(cmd *cobra.Command, opts *paywallAIOptions) {
 
 // runPaywallAI streams one editor turn and persists the updated session file.
 func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, session *paywallAISession) error {
+	if abs, err := filepath.Abs(opts.sessionPath); err == nil {
+		opts.sessionPath = abs
+	}
 	client, err := paywallAIClient(rt, opts.baseURL)
 	if err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,6 +215,10 @@ func configDir() (string, error) {
 	return filepath.Join(home, ".config", "revenuecat"), nil
 }
 
+// Dir is the CLI's config/data directory — the single home for profiles,
+// state, and other per-account files regardless of the working directory.
+func Dir() (string, error) { return configDir() }
+
 func profilePath(profile string) (string, error) {
 	name := ProfileName(profile)
 	if err := validateProfileName(name); err != nil {


### PR DESCRIPTION
`generate`/`edit` wrote the session JSON and preview PNGs to a relative path of execution (and could be sprinkled anywhere throughout a machine 🫣)

Now they go to a folder per paywall in the CLI's data dir:

```
~/.config/revenuecat/paywalls/<project>/<paywall>/
    session.paywall.json
    session.light.png
    session.dark.png
```

Also, paths in `--json` (`session_file`, `screenshot_paths`) and the `Preview:` lines are absolute now, so they open from anywhere. `--session` still overrides 💪 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local file layout and default paths only; no auth, API, or draft-persist logic changes. Users who relied on cwd-relative session files must pass `--session` or use the new data-dir paths.
> 
> **Overview**
> **Paywall AI session files and preview screenshots** no longer default to the current working directory (`<paywall-id>.paywall.json` beside wherever you ran the command). When `--session` is omitted, `generate` and `edit` now write under the CLI data directory at `paywalls/<project-id>/<paywall-id>/` as `session.paywall.json`, with PNGs beside it (`session.light.png`, etc.).
> 
> A new `config.Dir()` exposes the same config/data root used for profiles. `runPaywallAI` normalizes the session path to an **absolute** path so `--json` fields (`session_file`, `screenshot_paths`) and **Preview** lines work from any directory. **`--session` still overrides** the default location.
> 
> Help text and long-form command docs were updated to describe centralized storage and output paths instead of paywall-id-based filenames in cwd.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b4153ba3598ca228ca2cf6a03412c021b8a2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->