### PR TITLE
feat(paywalls): show an offering picker on generate when omitted in a TTY

### DIFF
--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -60,6 +60,21 @@ func defaultPaywallSessionPath(projectID, paywallID string) (string, error) {
 	return filepath.Join(sessionDir, "session"+paywallSessionSuffix), nil
 }
 
+func pickOfferingOrStandalone(ctx context.Context, rt *Runtime, client *api.Client, projectID string) (string, error) {
+	if rt.Globals.NoInput || !tui.IsInteractive() {
+		return "", nil
+	}
+	offerings, err := offeringPickerItems(ctx, client, projectID)
+	if err != nil {
+		return "", err
+	}
+	items := append([]PickerItem{{ID: "", Label: "Standalone (no offering)"}}, offerings...)
+	if len(items) == 1 {
+		return "", nil
+	}
+	return selectID(rt, "offering", items, "")
+}
+
 // Minimal valid editor state for a brand-new paywall, mirroring the
 // dashboard's buildMinimalPaywall test helper: an empty root stack on a
 // white background, no fonts or presets yet.
@@ -136,6 +151,12 @@ run rc paywalls publish.`,
 			if err := requirePaywallAIPrompt(rt, &opts.prompt, "Describe the paywall you want"); err != nil {
 				return err
 			}
+			if opts.offeringID == "" {
+				opts.offeringID, err = pickOfferingOrStandalone(cmd.Context(), rt, client, projectID)
+				if err != nil {
+					return err
+				}
+			}
 
 			paywall, err := client.Paywalls.CreateFromComponents(cmd.Context(), projectID, api.PaywallComponentsCreate{
 				OfferingID:              opts.offeringID,
@@ -195,7 +216,7 @@ run rc paywalls publish.`,
 		},
 	}
 	addPaywallAIFlags(cmd, &opts)
-	cmd.Flags().StringVar(&opts.offeringID, "offering-id", opts.offeringID, "offering to attach (or RC_OFFERING_ID)")
+	cmd.Flags().StringVar(&opts.offeringID, "offering-id", opts.offeringID, "offering to attach (or RC_OFFERING_ID); prompts if omitted in a TTY")
 	cmd.Flags().StringVar(&opts.name, "name", "", "paywall name")
 	return cmd
 }

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -42,11 +42,18 @@ func requireID(rt *Runtime, arg, noun string, fetch func() ([]PickerItem, error)
 		rt.Out.Info(fmt.Sprintf("Only one %s available: %s", noun, items[0].Label))
 		return items[0].ID, nil
 	}
+	return selectID(rt, noun, items, "")
+}
+
+// selectID shows the searchable picker for a fetched list and echoes the
+// choice. defaultID pre-highlights a matching item — pass "" for none. Callers
+// own the fetch and any synthetic entries (e.g. a "no selection" row).
+func selectID(rt *Runtime, noun string, items []PickerItem, defaultID string) (string, error) {
 	opts := make([]huh.Option[string], len(items))
 	for i, item := range items {
 		opts[i] = huh.NewOption(item.Label, item.ID)
 	}
-	var chosen string
+	chosen := defaultID
 	sel := huh.NewSelect[string]().
 		Title("Select a " + noun).
 		Description("Type to filter  ·  Enter to confirm").


### PR DESCRIPTION
Stacked on #55.

`paywalls generate` was the only entity command that skipped the `requireID` picker — omit `--offering-id` in a TTY and it silently made a standalone paywall, no prompt.

Now it prompts, with **Standalone (no offering)** as the default row, so standalone stays first-class but attaching is discoverable. `--no-input` and an explicit `--offering-id` are unchanged.

The picker UI is pulled out of `requireID` into a shared `selectID` helper, so this reuses it (plus the existing `offeringPickerItems`) instead of duplicating the `huh` wiring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interactive CLI UX only; non-interactive and explicit offering ID paths are unchanged, with no API or auth changes.
> 
> **Overview**
> **`paywalls generate`** now prompts for an offering when `--offering-id` is omitted in an interactive TTY, instead of silently creating a standalone draft. The picker lists **Standalone (no offering)** first, then project offerings from `offeringPickerItems`. **`--no-input`**, an explicit **`--offering-id`**, and **`RC_OFFERING_ID`** still behave as before.
> 
> Picker UI is centralized: **`requireID`** delegates multi-choice selection to a new **`selectID`** helper (callers can add synthetic rows and optional **`defaultID`** pre-highlight). **`pickOfferingOrStandalone`** uses **`selectID`** for this flow. The **`--offering-id`** flag help notes TTY prompting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1350d4fc00f766abcbfbccae142e1b3b7fa437ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

