### PR TITLE
test: cover API client, keyring fallback, and exit-code matrix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 RevenueCat
+Copyright (c) 2024-2026 RevenueCat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,129 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+func TestClient_SetsAuthAndHeaders(t *testing.T) {
+	var gotAuth, gotUA, gotAccept string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth, gotUA, gotAccept = r.Header.Get("Authorization"), r.Header.Get("User-Agent"), r.Header.Get("Accept")
+		w.Write([]byte(`{"items":[{"id":"proj_1"}],"next_page":""}`))
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(api.Options{APIKey: "sk_test", BaseURL: srv.URL, UserAgent: "rc-test/1"})
+	page, err := c.Projects.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(page.Items))
+	}
+	if gotAuth != "Bearer sk_test" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+	if gotUA != "rc-test/1" {
+		t.Errorf("User-Agent = %q", gotUA)
+	}
+	if gotAccept != "application/json" {
+		t.Errorf("Accept = %q", gotAccept)
+	}
+}
+
+func TestClient_ParsesAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-Id", "req_123")
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"type":"resource_missing","message":"nope","doc_url":"https://errors.rev.cat/resource-missing","object":"error"}`))
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(api.Options{APIKey: "sk_test", BaseURL: srv.URL})
+	_, err := c.Projects.List(context.Background())
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *api.APIError, got %T: %v", err, err)
+	}
+	if apiErr.Status != 404 || apiErr.Type != "resource_missing" || apiErr.Message != "nope" {
+		t.Errorf("apiErr = %+v", apiErr)
+	}
+	if apiErr.RequestID != "req_123" {
+		t.Errorf("RequestID should come from the X-Request-Id header, got %q", apiErr.RequestID)
+	}
+	if apiErr.DocURL == "" {
+		t.Error("doc_url should propagate from the body")
+	}
+}
+
+func TestClient_NonJSONErrorBodyFallsBack(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("upstream on fire"))
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(api.Options{APIKey: "sk", BaseURL: srv.URL})
+	_, err := c.Projects.List(context.Background())
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *api.APIError, got %T", err)
+	}
+	if apiErr.Status != 500 || apiErr.Type != "http_error" {
+		t.Errorf("want 500/http_error, got %d/%s", apiErr.Status, apiErr.Type)
+	}
+	if apiErr.Message == "" {
+		t.Error("a non-JSON error body should still yield a synthetic message")
+	}
+}
+
+// A repeat GET sends If-None-Match; a 304 must be served from the cached body,
+// not surfaced as an error.
+func TestClient_ETagCachingServes304(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Header.Get("If-None-Match") == "etag-1" {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", "etag-1")
+		w.Write([]byte(`{"items":[{"id":"proj_1"}],"next_page":""}`))
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(api.Options{APIKey: "sk", BaseURL: srv.URL})
+	if _, err := c.Projects.List(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	second, err := c.Projects.List(context.Background())
+	if err != nil {
+		t.Fatalf("304 should serve from cache, not error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 server round-trips, got %d", calls)
+	}
+	if len(second.Items) != 1 {
+		t.Fatalf("cached body should decode to 1 item, got %d", len(second.Items))
+	}
+}
+
+func TestClient_RespectsContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(api.Options{APIKey: "sk", BaseURL: srv.URL})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.Projects.List(ctx); err == nil {
+		t.Fatal("expected an error from a canceled context")
+	}
+}

--- a/internal/cli/auth_login_test.go
+++ b/internal/cli/auth_login_test.go
@@ -1,0 +1,114 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/cli"
+)
+
+// runAuthCmd is runCmdInConfigDir but keeps RC_BASE_URL pointed at a test
+// server, so login can validate a key against a stub. The keyring is mocked
+// process-wide (see TestMain), so credentials never touch the real keychain.
+func runAuthCmd(t *testing.T, configDir, baseURL string, args ...string) (string, string, error) {
+	t.Helper()
+	t.Setenv("RC_CONFIG_DIR", configDir)
+	t.Setenv("RC_API_KEY", "")
+	t.Setenv("RC_PROJECT_ID", "")
+	t.Setenv("RC_PROFILE", "")
+	t.Setenv("RC_BASE_URL", baseURL)
+
+	var out, errb bytes.Buffer
+	root := cli.NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	root.SetArgs(args)
+	err := root.ExecuteContext(context.Background())
+	return out.String(), errb.String(), err
+}
+
+func statusAuthenticated(t *testing.T, dir, baseURL string) bool {
+	t.Helper()
+	stdout, _, err := runAuthCmd(t, dir, baseURL, "auth", "status", "--json", "--no-input")
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	var st struct {
+		Data struct {
+			Authenticated bool   `json:"authenticated"`
+			Method        string `json:"method"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &st); err != nil {
+		t.Fatalf("status not JSON: %v\n%s", err, stdout)
+	}
+	if st.Data.Authenticated && st.Data.Method != "api_key" {
+		t.Errorf("authenticated via api key should report method=api_key, got %q", st.Data.Method)
+	}
+	return st.Data.Authenticated
+}
+
+// A valid API key is validated against the API, then persisted so later
+// commands (here, status) see an authenticated session.
+func TestAuthLogin_APIKeyValidatesAndPersists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "projects") {
+			t.Errorf("unexpected validation path %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk_good" {
+			t.Errorf("Authorization = %q", got)
+		}
+		w.Write([]byte(`{"items":[],"next_page":""}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	if _, _, err := runAuthCmd(t, dir, srv.URL, "auth", "login", "--api-key", "sk_good", "--json", "--no-input"); err != nil {
+		t.Fatalf("login failed: %v", err)
+	}
+	if !statusAuthenticated(t, dir, srv.URL) {
+		t.Fatal("a successful login should persist credentials")
+	}
+}
+
+// A rejected key fails fast with a clear error and must not be written to the
+// profile.
+func TestAuthLogin_BadAPIKeyFailsAndDoesNotPersist(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"type":"unauthorized","message":"bad key"}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	_, _, err := runAuthCmd(t, dir, srv.URL, "auth", "login", "--api-key", "sk_bad", "--no-input")
+	if err == nil || !strings.Contains(err.Error(), "didn't work") {
+		t.Fatalf("want a rejected-key error, got %v", err)
+	}
+	if statusAuthenticated(t, dir, srv.URL) {
+		t.Fatal("a failed login must not persist credentials")
+	}
+}
+
+func TestAuthLogout_ClearsCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"items":[],"next_page":""}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	if _, _, err := runAuthCmd(t, dir, srv.URL, "auth", "login", "--api-key", "sk_good", "--json", "--no-input"); err != nil {
+		t.Fatalf("login failed: %v", err)
+	}
+	if _, _, err := runAuthCmd(t, dir, srv.URL, "auth", "logout", "--json", "--no-input"); err != nil {
+		t.Fatalf("logout failed: %v", err)
+	}
+	if statusAuthenticated(t, dir, srv.URL) {
+		t.Fatal("logout should clear the stored credentials")
+	}
+}

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+	"github.com/revenuecat/cli/internal/output"
+)
+
+// ExitCodeFor is the stable contract agents and scripts branch on. Lock the
+// whole matrix, not just the usage-error case.
+func TestExitCodeFor_Matrix(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil", nil, 0},
+		{"generic", errors.New("boom"), 1},
+		{"bad-format", output.ErrBadFormat, 2},
+		{"usage", usageError{errors.New("bad flag")}, 2},
+		{"wrapped-usage", fmt.Errorf("outer: %w", usageError{errors.New("bad flag")}), 2},
+		{"not-authenticated", ErrNotAuthenticated, 4},
+		{"api-unauthorized", &api.APIError{Type: "unauthorized"}, 4},
+		{"api-auth-error", &api.APIError{Type: "authentication_error"}, 4},
+		{"api-resource-missing", &api.APIError{Type: "resource_missing"}, 5},
+		{"api-rate-limit", &api.APIError{Type: "rate_limit_exceeded"}, 6},
+		{"api-other", &api.APIError{Type: "http_error"}, 1},
+	}
+	for _, tc := range cases {
+		if got := ExitCodeFor(tc.err); got != tc.want {
+			t.Errorf("%s: ExitCodeFor = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestSilentExitError_HasEmptyMessage(t *testing.T) {
+	if got := (&SilentExitError{Code: 7}).Error(); got != "" {
+		t.Errorf("SilentExitError.Error() = %q, want empty (Run uses the code directly)", got)
+	}
+}

--- a/internal/config/keyring_fallback_test.go
+++ b/internal/config/keyring_fallback_test.go
@@ -1,0 +1,46 @@
+package config_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+
+	"github.com/revenuecat/cli/internal/config"
+)
+
+// When the OS keyring is unavailable (headless Linux, no D-Bus, Docker, a
+// locked store), Save must keep the secrets in the 0600 profile file and Load
+// must read them back — the documented keychain-with-fallback model.
+func TestSave_FallsBackToFileWhenKeyringUnavailable(t *testing.T) {
+	keyring.MockInitWithError(errors.New("keyring unavailable"))
+	t.Cleanup(keyring.MockInit) // restore the in-memory keyring for other tests
+
+	dir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", dir)
+	t.Setenv("RC_API_KEY", "")
+
+	in := &config.Config{APIKey: "sk_secret", AccessToken: "atk_secret", ProjectID: "proj_x"}
+	if err := config.Save("default", in); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "default.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "sk_secret") || !strings.Contains(string(raw), "atk_secret") {
+		t.Fatalf("with no keyring, secrets must fall back into the file:\n%s", raw)
+	}
+
+	out, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.APIKey != "sk_secret" || out.AccessToken != "atk_secret" {
+		t.Errorf("secrets should load from the file fallback: %+v", out)
+	}
+}


### PR DESCRIPTION
The objective, no-design-call slice of the readiness scan's test gaps.

Adds tests for the foundations every command rides on but nothing covered:

- **`api/client.go`** — auth + User-Agent headers, `APIError` decoding (incl. `X-Request-Id` from the header and the non-JSON-body fallback), ETag/304 served-from-cache, and context cancellation.
- **keyring fallback** — `Save`/`Load` keep secrets in the `0600` file when the OS keyring is unavailable (the headless/Docker path), simulated with `MockInitWithError`. The happy path was already covered; this was the untested branch.
- **`ExitCodeFor`** — locks the whole matrix (bad-format→2, usage→2, unauthorized→4, resource_missing→5, rate_limit→6, generic→1), not just the usage case.

Also bumps the LICENSE copyright year.

Not stacked — off `main`, independent of the paywall stack. Leaves the auth-login/OAuth handshake tests (the fiddlier third bullet) for a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and a LICENSE date update; no production logic is modified.
>
> **Overview**
> Adds automated tests for foundational CLI behavior ahead of the 0.1.0 beta milestone, plus a **LICENSE** copyright year bump (2024–2026).
>
> **API client** (`internal/api/client_test.go`): httptest coverage for Bearer auth, `User-Agent`, and `Accept`; structured `APIError` parsing (including `X-Request-Id` and non-JSON error bodies); ETag/`If-None-Match` with **304** responses served from cache; and context cancellation.
>
> **Auth CLI** (`internal/cli/auth_login_test.go`): login with a valid API key validates against the projects endpoint and persists credentials; bad keys fail without writing the profile; logout clears stored credentials. Uses `RC_BASE_URL` against a stub server and the package `TestMain` keyring mock.
>
> **Runtime** (`internal/cli/runtime_test.go`): locks the full `ExitCodeFor` matrix (format/usage → 2, not authenticated / API auth errors → 4, `resource_missing` → 5, rate limit → 6, generic → 1) and asserts `SilentExitError` returns an empty message.
>
> **Config** (`internal/config/keyring_fallback_test.go`): when the OS keyring is unavailable (`MockInitWithError`), `Save`/`Load` keep secrets in the `0600` profile file as documented.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c348c81c3d606445c9c729b11fb815339f15c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
