### PR TITLE
feat(cli): bare `rc` shows getting-started help and the full command surface

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,7 +5,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/revenuecat/cli/internal/tui"
 	"strings"
 	"testing"
 
@@ -36,6 +35,11 @@ func NewRootCmd(version string) *cobra.Command {
 		Use:   "rc",
 		Short: "RevenueCat command line interface",
 		Long: `rc is the RevenueCat command line interface.
+
+Getting started:
+  rc auth login          log in (browser or an API key)
+  rc projects use        choose a default project
+  rc <command> --help    explore any command group
 
 Designed for humans and AI agents alike: every interactive prompt is also
 available as a flag or environment variable, and every command supports
@@ -89,7 +93,7 @@ Agent-friendly entrypoints:
 	pf.BoolVar(&g.JSON, "json", false, "emit machine-readable JSON output")
 	pf.BoolVar(&g.NoInput, "no-input", false, "disable interactive prompts; fail if input is required")
 	pf.BoolVarP(&g.Quiet, "quiet", "q", false, "suppress non-essential output")
-	pf.BoolVar(&g.ShowAll, "all", false, "show every command, not just the common ones")
+	pf.BoolVar(&g.ShowAll, "all", false, "also show experimental commands in --help")
 	pf.BoolVarP(&g.Verbose, "verbose", "v", false, "enable verbose logging")
 	_ = pf.MarkHidden("verbose")
 	pf.StringVar(&g.Profile, "profile", "", "configuration profile to use (default: active profile)")
@@ -108,14 +112,10 @@ Agent-friendly entrypoints:
 	whoamiAlias.Use = "whoami"
 	whoamiAlias.Hidden = true
 
-	// Bare `rc` (and bare `npx @revenuecat/cli`) in an interactive terminal is
-	// the acquisition path: land in the guided setup, which shows state and
-	// asks before doing anything. Everywhere else keeps cobra's help.
+	// Bare `rc` shows help, which leads with the getting-started intro. The
+	// guided setup orchestrator is still available explicitly as `rc setup`.
 	root.RunE = func(cmd *cobra.Command, args []string) error {
-		if g.JSON || g.NoInput || !tui.IsInteractive() {
-			return cmd.Help()
-		}
-		return runSetup(cmd)
+		return cmd.Help()
 	}
 
 	root.AddCommand(
@@ -164,7 +164,7 @@ Agent-friendly entrypoints:
 		applySurfaceProfile(root)
 		defaultHelp(c, args)
 		if c == root && !showAllSurface(root) && !testing.Testing() {
-			fmt.Fprintln(c.OutOrStdout(), "\nCommon commands shown. Run `rc --all` for every command, or `rc commands --schemas` for the full machine-readable surface.")
+			fmt.Fprintln(c.OutOrStdout(), "\nRun `rc --all` to include experimental commands, or `rc commands --schemas` for the full machine-readable surface.")
 		}
 	})
 	return root

--- a/internal/cli/surface.go
+++ b/internal/cli/surface.go
@@ -7,34 +7,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Command surface: humans see a short curated list; agents and --json/--schema
-// see everything. The split rides on the output channel, not an env var —
-// `rc --help` is scoped, `rc commands --schemas` is full — so agent discovery
-// never depends on a flag being set in a launch context we don't control.
+// Command surface: --help shows the full command set; only the punted tier
+// (commands not yet DX-tested) is held back, and `rc --all` reveals those too.
+// Back-compat aliases stay hidden via their own Hidden flag — curateSurface
+// never un-hides them.
 //
-// Three tiers, set via the "surface" annotation:
-//   - human (default): shown in --help and everywhere
-//   - agent-only: hidden from --help, still in commands/schema and still
-//     runnable (hidden != disabled, so skills naming it keep working)
-//   - punted: hidden everywhere including schema, until DX-tested
-//     (the one-shot `setup` orchestrator)
+// Two annotation tiers via "surface":
+//   - default: shown in --help, commands/schema, and runnable
+//   - punted: hidden from --help and schema until DX-tested (the one-shot
+//     `setup` orchestrator); `rc --all` shows it in help but never schema
 
 const (
 	annotationSurface = "surface"
 	surfacePunted     = "punted"
 )
-
-// humanSurface is the curated set shown by default; everything else is
-// agent-only. Keep it tight — it's the first thing a human sees.
-var humanSurface = map[string]bool{
-	"paywalls": true,
-	"capital":  true,
-	"auth":     true,
-	"projects": true,
-	"apps":     true,
-	"login":    true, // alias
-	"version":  true,
-}
 
 func showAllSurface(root *cobra.Command) bool {
 	if os.Getenv("RC_SURFACE") == "full" {
@@ -44,30 +30,24 @@ func showAllSurface(root *cobra.Command) bool {
 	return all
 }
 
-// applySurfaceProfile hides non-human commands from --help. Runs after flags
-// parse: --all (or RC_SURFACE=full) reveals everything; punted commands stay
-// hidden regardless. Hidden commands still execute, and commands/schema
-// include them (they gate on the punted annotation, not Hidden).
+// applySurfaceProfile hides the punted tier from --help unless --all (or
+// RC_SURFACE=full) is set. Everything else is visible. Runs after flags parse.
 func applySurfaceProfile(root *cobra.Command) {
 	if testing.Testing() {
-		return // tests assert the full surface; the rules themselves are
-		// covered directly by TestCurateSurface.
+		return // tests assert the full surface; the rule is covered directly
+		// by TestCurateSurface.
 	}
 	curateSurface(root, showAllSurface(root))
 }
 
-// curateSurface applies the visibility rules. Split out of applySurfaceProfile
-// so the rules are testable without the testing.Testing() short-circuit, which
-// would otherwise let curation regress with nothing catching it.
+// curateSurface applies the visibility rule. Split out of applySurfaceProfile
+// so it's testable without the testing.Testing() short-circuit. Only punted
+// commands are touched; aliases and every other command keep their own Hidden
+// state (so the full surface shows and aliases stay hidden).
 func curateSurface(root *cobra.Command, all bool) {
 	for _, cmd := range root.Commands() {
-		switch {
-		case cmd.Annotations[annotationSurface] == surfacePunted:
-			cmd.Hidden = true
-		case all:
-			cmd.Hidden = false
-		case !humanSurface[cmd.Name()]:
-			cmd.Hidden = true
+		if cmd.Annotations[annotationSurface] == surfacePunted {
+			cmd.Hidden = !all
 		}
 	}
 }

--- a/internal/cli/surface_test.go
+++ b/internal/cli/surface_test.go
@@ -6,21 +6,6 @@ import "testing"
 // --help, agents/JSON see everything. These guard the two invariants that
 // keep that honest.
 
-// Every name in humanSurface must be a real registered command, or the human
-// help silently curates nothing.
-func TestHumanSurface_NamesRealCommands(t *testing.T) {
-	root := NewRootCmd("test")
-	registered := map[string]bool{}
-	for _, c := range root.Commands() {
-		registered[c.Name()] = true
-	}
-	for name := range humanSurface {
-		if !registered[name] {
-			t.Errorf("humanSurface names %q, which is not a registered command", name)
-		}
-	}
-}
-
 // Agent discovery (rc commands --schemas) must include agent-only commands —
 // hidden from --help but present here — while excluding the punted tier.
 // Hiding from humans must not hide from agents.
@@ -42,8 +27,8 @@ func TestCommandSurface_SchemaIncludesAgentOnlyExcludesPunted(t *testing.T) {
 }
 
 // The human-help curation runs behind a testing.Testing() short-circuit, so
-// this drives curateSurface directly to keep the rules honest: humans see the
-// curated set, agents don't, punted stays hidden even under --all.
+// this drives curateSurface directly: the full surface shows by default, only
+// punted is held back, aliases stay hidden, and --all reveals punted too.
 func TestCurateSurface(t *testing.T) {
 	root := NewRootCmd("test")
 	hidden := func(name string) bool {
@@ -58,20 +43,20 @@ func TestCurateSurface(t *testing.T) {
 
 	curateSurface(root, false) // default help
 	if hidden("paywalls") {
-		t.Error("human command 'paywalls' should be visible in --help")
+		t.Error("'paywalls' should be visible in --help")
 	}
-	if !hidden("customer") {
-		t.Error("agent-only 'customer' should be hidden from --help")
+	if hidden("customer") {
+		t.Error("'customer' should be visible in --help (full surface)")
+	}
+	if !hidden("login") {
+		t.Error("the back-compat 'login' alias should stay hidden")
 	}
 	if !hidden("setup") {
-		t.Error("punted 'setup' should be hidden")
+		t.Error("punted 'setup' should be hidden by default")
 	}
 
 	curateSurface(root, true) // rc --all
-	if hidden("customer") {
-		t.Error("--all should reveal agent-only 'customer'")
-	}
-	if !hidden("setup") {
-		t.Error("--all must NOT reveal punted 'setup'")
+	if hidden("setup") {
+		t.Error("--all should reveal punted 'setup'")
 	}
 }


### PR DESCRIPTION
Two things, both about what a human sees first:

**Bare `rc`** printed the punted, untested `setup` orchestrator. Now it prints help, and the root help leads with a Getting started block (log in → pick a project → explore). `rc setup` still exists explicitly.

**`rc --help`** was curated down to 6 groups — `customer`, `entitlements`, `offerings`, `products`, etc. were hidden from humans. Now the full surface shows; only the punted tier is held back, and `rc --all` reveals that too. Back-compat aliases (`login`, `whoami`) stay hidden.

Follow-up: a lot of the newly-revealed groups still need `Long`/`Examples` — doing that next.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX and help/surface visibility only; no auth, API, or data-path changes. Slightly broader default help surface may expose commands still lacking docs (noted as follow-up).
>
> **Overview**
> **Bare `rc`** no longer launches the interactive `setup` orchestrator in a TTY; it always prints root help. Root **Long** now opens with a **Getting started** block (`auth login`, `projects use`, `--help`). Guided setup remains on **`rc setup`**.
>
> **Command visibility** drops the curated `humanSurface` list: default **`rc --help`** shows the full command tree except the **punted** tier (`setup`). Only punted commands are hidden via `curateSurface`; groups like `customer` and `entitlements` appear in help again. **`rc --all`** now reveals punted commands in help (not in schema). Hidden aliases (`login`, `whoami`) are unchanged.
>
> Flag/help copy updates: **`--all`** is described as experimental commands; the root help footer points to **`rc --all`** and **`rc commands --schemas`**. Tests drop the human-surface name check and assert the new visibility rules.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4a75634ec747975c359d83abc676f25e94e738e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
