### PR TITLE
docs(cli): normalize all command help to RevenueCat's product voice

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -31,7 +31,13 @@ func newAppsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "apps",
 		Aliases: []string{"app"},
-		Short:   "Manage apps in a project",
+		Short:   "Manage apps in a Project",
+		Long: `An App is a per-platform connection in a Project — one App Store, Play Store,
+Amazon, Stripe, Web Billing, Roku, or Paddle app each. Apps hold the store
+credentials RevenueCat uses to validate purchases and the public SDK keys your
+client apps configure with.`,
+		Example: `  rc apps list
+  rc apps create --name "Acme iOS" --type app_store --bundle-id com.acme.app`,
 	}
 	cmd.AddCommand(
 		newAppsListCmd(),
@@ -50,6 +56,10 @@ func newAppsListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List apps",
+		Long: `Lists the apps in the active Project with their platform type and store-credential
+status. App Store apps show whether Apple credentials are configured.`,
+		Example: `  rc apps list
+  rc apps list --json | jq '.data.items[].id'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -94,9 +104,11 @@ func newAppsListCmd() *cobra.Command {
 
 func newAppsShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show [id]",
-		Short: "Show an app",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "show [id]",
+		Short:   "Show an app",
+		Long:    `Shows an app's platform type, store configuration, and credential status. Omit the ID in a terminal to pick from a list.`,
+		Example: "  rc apps show app_x\n  rc apps show                 # pick interactively",
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -149,6 +161,14 @@ func newAppsCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an app",
+		Long: `Creates an app of a given platform type in the active Project. Prompts for the
+name, type, and the platform's required identifier (bundle ID, package name, or
+app name) when run interactively.
+
+App Store apps still need Apple credentials before purchases validate — finish
+with rc apps apple setup.`,
+		Example: `  rc apps create --name "Acme iOS" --type app_store --bundle-id com.acme.app
+  rc apps create --name "Acme Android" --type play_store --package-name com.acme.app`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -277,9 +297,11 @@ func validAppType(appType string) bool {
 func newAppsUpdateCmd() *cobra.Command {
 	var name string
 	cmd := &cobra.Command{
-		Use:   "update [id]",
-		Short: "Update an app",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "update [id]",
+		Short:   "Update an app",
+		Long:    `Updates an app's name. Only the flags you pass change; omit the ID in a terminal to pick from a list.`,
+		Example: `  rc apps update app_x --name "Acme iOS (prod)"`,
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -512,8 +534,14 @@ func newAppsStoreKitConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "storekit-config [app-id]",
 		Aliases: []string{"storekit"},
-		Short:   "Export the StoreKit configuration for an app",
-		Args:    cobra.MaximumNArgs(1),
+		Short:   "Export an app's StoreKit configuration",
+		Long: `Exports the StoreKit configuration file for an App Store app — the Products,
+prices, and subscription groups Xcode uses to run StoreKit testing without the
+sandbox. Prints JSON to stdout, or writes it with --output. Omit the app ID in a
+terminal to pick from a list.`,
+		Example: `  rc apps storekit-config app_x
+  rc apps storekit-config app_x --output Products.storekit`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)

--- a/internal/cli/apps_apple.go
+++ b/internal/cli/apps_apple.go
@@ -189,7 +189,16 @@ func newAppsAppleCmd() *cobra.Command {
 func newAppsAppleCmdWithFactory(factory appleConnectFactory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apple",
-		Short: "Configure Apple credentials for an App Store app",
+		Short: "Set up Apple credentials for an App Store app",
+		Long: `Signs in to App Store Connect and configures the Apple credentials RevenueCat
+needs for an App Store app — the in-app purchase key (validates purchases), the
+App Store Connect API key (manages Products and prices), and your vendor number.
+
+Requires an interactive terminal and Apple 2FA: a human must run it. Apple
+credentials go straight to Apple and are never saved or sent to RevenueCat. Use
+check for a read-only dry run before setup.`,
+		Example: `  rc apps apple check app_x     # read-only: verify sign-in and key access
+  rc apps apple setup app_x     # create keys and configure the app`,
 	}
 	cmd.AddCommand(
 		newAppsAppleWorkflowCmd(true, factory),
@@ -204,16 +213,19 @@ func newAppsAppleWorkflowCmd(checkOnly bool, factory appleConnectFactory) *cobra
 	var sms, skipInAppKey, skipAPIKey, force bool
 	use, short, long := "setup [app-id]", "Create Apple keys and configure an App Store app", appleSetupInstructions
 	privacy := applePrivacyNotice
+	example := "  rc apps apple setup app_x\n  rc apps apple setup app_x --sms --phone-number +15551234567"
 	if checkOnly {
 		use, short, long = "check [app-id]", "Check Apple authentication and key access", appleCheckInstructions
 		privacy = appleCheckPrivacyNotice
+		example = "  rc apps apple check app_x"
 	}
 
 	cmd := &cobra.Command{
-		Use:   use,
-		Short: short,
-		Long:  short + ".\n\n" + long + "\n\n" + privacy,
-		Args:  cobra.MaximumNArgs(1),
+		Use:     use,
+		Short:   short,
+		Long:    short + ".\n\n" + long + "\n\n" + privacy,
+		Example: example,
+		Args:    cobra.MaximumNArgs(1),
 		Annotations: map[string]string{
 			"requires_human":        "true",
 			"requires_human_reason": "Signs in to Apple with an Apple ID, password, and two-factor code; the user must run it in a local interactive terminal. Never collect Apple credentials in chat.",

--- a/internal/cli/browse.go
+++ b/internal/cli/browse.go
@@ -14,11 +14,12 @@ import (
 func newBrowseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "browse",
-		Short: "Interactive project browser hub",
-		Long: `Opens a full-screen interactive hub for the active project.
-Navigate to customers, entitlements, offerings, apps, webhooks, and more.
+		Short: "Browse the active project in an interactive hub",
+		Long: `Opens a full-screen interactive hub for the active Project. Navigate Customers,
+Entitlements, Offerings, Products, apps, webhooks, and charts, and drill into
+records without leaving the terminal.
 
-Requires a TTY. Pass --json or --no-input to disable.`,
+Requires an interactive terminal. Pass --json or --no-input to disable.`,
 		Example: `  rc browse`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())

--- a/internal/cli/charts.go
+++ b/internal/cli/charts.go
@@ -16,8 +16,15 @@ func newChartsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "charts",
 		Aliases: []string{"chart"},
-		Short:   "Inspect project charts",
-		RunE:    runChartsList,
+		Short:   "Explore subscription metric charts",
+		Long: `Explore subscription metric charts — Active Subscriptions, MRR, Revenue, Churn,
+Trial Conversion, and more — each sliceable with filters and segments. Run
+without arguments to list the available charts, then 'show' one or inspect its
+'options'.`,
+		Example: `  rc charts list
+  rc charts show mrr
+  rc charts show actives --filter store=app_store`,
+		RunE: runChartsList,
 	}
 	cmd.AddCommand(
 		newChartsListCmd(),
@@ -33,9 +40,11 @@ func newChartsCmd() *cobra.Command {
 // without making a request that 400s.
 func newChartsListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
-		Short: "List valid chart names",
-		RunE:  runChartsList,
+		Use:     "list",
+		Short:   "List available chart names",
+		Long:    `Lists the chart names accepted by 'rc charts show'. The set is a fixed enum, so this works without a request. In a terminal it opens the interactive chart browser.`,
+		Example: "  rc charts list\n  rc charts list --json | jq -r '.names[]'",
+		RunE:    runChartsList,
 	}
 }
 
@@ -71,7 +80,7 @@ func newChartsShowCmd() *cobra.Command {
 	var filterFlags []string
 	cmd := &cobra.Command{
 		Use:   "show <chart-name>",
-		Short: "Show chart data for a named chart",
+		Short: "Show data for a named chart",
 		Long: fmt.Sprintf(`Show data for a named chart. The chart name is validated client-side
 against a fixed enum (the API enforces the same enum server-side; we validate
 locally to avoid a 400 round-trip and to provide shell completion).
@@ -135,7 +144,9 @@ Valid names:
 func newChartsOptionsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:               "options <chart-name>",
-		Short:             "Show available filters/segments for a chart",
+		Short:             "Show a chart's filters and segments",
+		Long:              `Lists the filters and segments a chart accepts, so you know what to pass to 'rc charts show --filter'.`,
+		Example:           "  rc charts options mrr\n  rc charts options actives --json",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: cobra.FixedCompletions(api.ValidChartNames, cobra.ShellCompDirectiveNoFileComp),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/customers.go
+++ b/internal/cli/customers.go
@@ -60,7 +60,14 @@ func newCustomersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "customer",
 		Aliases: []string{"customers"},
-		Short:   "Inspect and manage customers",
+		Short:   "Inspect and manage Customers",
+		Long: `Inspect and manage Customers in the active project. A Customer Profile
+gathers a Customer's subscriptions, Non-Subscription Purchases, active
+Entitlements, and Customer Attributes. Multiple App User IDs that resolve to
+one Customer are aliases.`,
+		Example: `  rc customer list
+  rc customer show cus_abc
+  rc customer grant cus_abc entl_pro --duration monthly`,
 	}
 	cmd.AddCommand(
 		newCustomerListCmd(),
@@ -84,10 +91,10 @@ func newCustomerSimulatePurchaseCmd() *cobra.Command {
 	var appID, productRef, appUserID, publicAPIKey string
 	cmd := &cobra.Command{
 		Use:   "simulate-purchase",
-		Short: "Simulate a Test Store purchase for a customer",
+		Short: "Simulate a Test Store purchase for a Customer",
 		Long: `Creates a real RevenueCat Test Store transaction through the same receipt
 endpoint used by the SDK. The selected app must have a test_ public SDK key.
-The product may be given by RevenueCat product ID or store identifier.
+The Product may be given by RevenueCat Product ID or store identifier.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
 		Example: `  rc customer simulate-purchase --app-id app_test --product premium_monthly --app-user-id demo-user
@@ -214,8 +221,13 @@ func simulatedStoreFetchToken() (string, error) {
 func newCustomerAliasesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "aliases <customer-id>",
-		Short: "List a customer's aliases",
-		Args:  cobra.ExactArgs(1),
+		Short: "List a Customer's aliases",
+		Long: `Lists the App User IDs that resolve to one Customer. Aliases accumulate
+when the same person is identified under different App User IDs (anonymous
+then logged-in, across devices, after a transfer).`,
+		Example: `  rc customer aliases cus_abc
+  rc customer aliases cus_abc --json | jq '.data.items[].id'`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -238,8 +250,12 @@ func newCustomerAliasesCmd() *cobra.Command {
 func newCustomerAttributesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "attributes <customer-id>",
-		Short: "List a customer's attributes",
-		Args:  cobra.ExactArgs(1),
+		Short: "List a Customer's attributes",
+		Long: `Lists the Customer Attributes (metadata) stored on a Customer, including
+reserved keys like $email and any custom keys you set.`,
+		Example: `  rc customer attributes cus_abc
+  rc customer attributes cus_abc --json | jq '.data'`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -263,10 +279,10 @@ func newCustomerSetAttributeCmd() *cobra.Command {
 	var sets []string
 	cmd := &cobra.Command{
 		Use:   "set-attribute <customer-id>",
-		Short: "Set one or more attributes on a customer (--set key=value, repeatable)",
-		Long: `Sets custom attributes on a customer. Pass --set key=value once per
-attribute. Existing attributes with the same key are overwritten; others
-are preserved.`,
+		Short: "Set Customer Attributes",
+		Long: `Sets Customer Attributes (metadata) on a Customer. Pass --set key=value
+once per attribute. Existing attributes with the same key are overwritten;
+others are preserved.`,
 		Example: `  rc customer set-attribute cus_abc --set email=user@example.com
   rc customer set-attribute cus_abc --set $segment=premium --set $churnRisk=low`,
 		Args: cobra.ExactArgs(1),
@@ -315,12 +331,15 @@ func newCustomerTransferCmd() *cobra.Command {
 	var to string
 	cmd := &cobra.Command{
 		Use:   "transfer <source-customer-id> --to <dest-customer-id>",
-		Short: "Transfer subscriptions and purchases from one customer to another",
-		Long: `Transfers all subscriptions and purchases from a source customer to a
-destination customer. Useful for merging duplicate customer records.
+		Short: "Transfer subscriptions and purchases between Customers",
+		Long: `Transfers all subscriptions and Non-Subscription Purchases from a source
+Customer to a destination Customer. Useful for merging duplicate Customer
+Profiles.
 
-This is destructive on the source customer's purchase history; pass --yes
-to skip the confirmation prompt.`,
+Reversibility: destructive on the source Customer's purchase history — the
+transfer is not automatically reversed.
+
+Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
 		Example: `  rc customer transfer cus_old --to cus_new
   rc customer transfer cus_old --to cus_new --yes --json`,
 		Args: cobra.ExactArgs(1),
@@ -355,9 +374,9 @@ func newCustomerOverrideOfferingCmd() *cobra.Command {
 	var offering string
 	cmd := &cobra.Command{
 		Use:   "override-offering <customer-id> --offering <id>",
-		Short: "Assign an offering override to a customer",
-		Long: `Forces a specific offering to be shown to one customer regardless of
-which offering is currently the project default. Common for A/B tests or
+		Short: "Assign an Offering override to a Customer",
+		Long: `Forces a specific Offering to be shown to one Customer regardless of
+which Offering is currently the project default. Common for A/B tests or
 support overrides. Use 'rc customer clear-override' to remove.`,
 		Example: `  rc customer override-offering cus_abc --offering ofrng_promo_2026
   rc customer clear-override cus_abc`,
@@ -389,9 +408,9 @@ support overrides. Use 'rc customer clear-override' to remove.`,
 func newCustomerClearOverrideCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "clear-override <customer-id>",
-		Short: "Clear a customer's offering override",
-		Long: `Removes any offering override set via ` + "`rc customer override-offering`" + `.
-The customer will see whichever offering is the project default.
+		Short: "Clear a Customer's Offering override",
+		Long: `Removes any Offering override set via ` + "`rc customer override-offering`" + `.
+The Customer will see whichever Offering is the project default.
 
 Reversibility: re-apply with ` + "`rc customer override-offering`" + `.
 
@@ -421,8 +440,8 @@ func newCustomerRestoreGoogleCmd() *cobra.Command {
 	var token string
 	cmd := &cobra.Command{
 		Use:   "restore-google <customer-id> --token <purchase-token>",
-		Short: "Restore a Google Play purchase for a customer",
-		Long: `Re-syncs a Google Play purchase to a customer using a Google Play
+		Short: "Restore a Google Play purchase for a Customer",
+		Long: `Re-syncs a Google Play purchase to a Customer using a Google Play
 purchase token. Useful when a purchase was made on-device but didn't reach
 RevenueCat (network failure, app uninstall mid-purchase, etc.).
 
@@ -459,8 +478,12 @@ Confirmation: no prompt — idempotent (re-running with the same token is safe).
 func newCustomerWalletCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "wallet <customer-id>",
-		Short: "Show a customer's virtual currency balances",
-		Args:  cobra.ExactArgs(1),
+		Short: "Show a Customer's virtual currency balances",
+		Long: `Shows the Customer's wallet: per-currency virtual currency balances for
+the project.`,
+		Example: `  rc customer wallet cus_abc
+  rc customer wallet cus_abc --json | jq '.data.items[]'`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -560,8 +583,8 @@ func newCustomerListCmd() *cobra.Command {
 	var cursor string
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List customers in the active project",
-		Long: `Lists customers, paginated. In TTY mode launches an interactive browser;
+		Short: "List Customers in the active project",
+		Long: `Lists Customers, paginated. In TTY mode launches an interactive browser;
 pass --json for machine-readable output or --no-input to disable the browser.`,
 		Example: `  rc customer list
   rc customer list --json --limit 100 | jq '.data.items[].id'
@@ -627,10 +650,13 @@ func lastID(items []api.Customer) string {
 func newCustomerShowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show <customer-id>",
-		Short: "Show a complete view of a customer",
-		Long: `Composes the customer record (which already embeds active entitlements),
-subscriptions, and purchases into one envelope. In TTY mode launches an
-interactive detail view with drill-down. Use --json for the raw merged document.`,
+		Short: "Show a complete view of a Customer",
+		Long: `Composes the Customer record (which already embeds active Entitlements),
+subscriptions, and Non-Subscription Purchases into one envelope — the CLI's
+take on the Customer Profile. In TTY mode launches an interactive detail view
+with drill-down. Use --json for the raw merged document.`,
+		Example: `  rc customer show cus_abc
+  rc customer show cus_abc --json | jq '.data.customer.active_entitlements'`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -685,11 +711,11 @@ func newCustomerGrantCmd() *cobra.Command {
 	var duration string
 	cmd := &cobra.Command{
 		Use:   "grant <customer-id> [entitlement-id]",
-		Short: "Grant a promotional entitlement to a customer",
-		Long: `Grants a promotional entitlement to a customer for a fixed duration.
+		Short: "Grant a promotional Entitlement to a Customer",
+		Long: `Grants a promotional Entitlement to a Customer for a fixed duration.
 
 customer-id is required. entitlement-id is optional under a TTY — omit it
-to pick from the project's entitlement catalog interactively.
+to pick from the project's Entitlements interactively.
 
 Duration must be one of: daily, three_day, weekly, monthly, two_month,
 three_month, six_month, yearly, lifetime. Omit --duration under a TTY to
@@ -758,13 +784,13 @@ pick from the list interactively.`,
 func newCustomerRevokeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "revoke <customer-id> [entitlement-id]",
-		Short: "Revoke a promotional entitlement from a customer",
-		Long: `Revokes a previously-granted promotional entitlement. Only affects
+		Short: "Revoke a promotional Entitlement from a Customer",
+		Long: `Revokes a previously-granted promotional Entitlement. Only affects
 promotional grants made through ` + "`rc customer grant`" + ` — store
 purchases are not affected.
 
 customer-id is required. entitlement-id is optional under a TTY — omit it
-to pick from the project's entitlement catalog interactively.
+to pick from the project's Entitlements interactively.
 
 Reversibility: re-grant with ` + "`rc customer grant`" + ` if needed.
 

--- a/internal/cli/entitlements.go
+++ b/internal/cli/entitlements.go
@@ -20,7 +20,12 @@ func newEntitlementsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "entitlements",
 		Aliases: []string{"entitlement", "ent"},
-		Short:   "Manage entitlements in the project catalog",
+		Short:   "Manage Entitlements in the project catalog",
+		Long: `An Entitlement is a level of access a Customer is entitled to — unlocked
+when they purchase a Product attached to it. Attach Products to an Entitlement,
+then reference the Entitlement in your app to gate premium features.`,
+		Example: `  rc entitlements list
+  rc entitlements attach entl_pro prod_x`,
 	}
 	cmd.AddCommand(
 		newEntitlementsListCmd(),
@@ -40,14 +45,15 @@ func newEntitlementsCmd() *cobra.Command {
 func newEntitlementsArchiveCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "archive [id]",
-		Short: "Archive an entitlement",
-		Long: `Archives an entitlement, removing it from new offerings while preserving
-historical access for existing subscribers.
+		Short: "Archive an Entitlement",
+		Long: `Archives an Entitlement, removing it from new Offerings while preserving
+historical access for existing subscribers. Omit the ID in a terminal to pick
+from a list.
 
 Reversibility: use ` + "`rc entitlements restore <id>`" + ` to undo.
 
 Confirmation: no prompt — this is a soft, reversible state change.`,
-		Example: `  rc entitlements archive entl_legacy`,
+		Example: `  rc entitlements archive entl_pro`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -78,14 +84,15 @@ Confirmation: no prompt — this is a soft, reversible state change.`,
 func newEntitlementsRestoreCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "restore [id]",
-		Short: "Restore an archived entitlement (= unarchive)",
-		Long: `Restores a previously-archived entitlement so it can be added to new
-offerings again. Inverse of ` + "`rc entitlements archive`" + `.
+		Short: "Restore an archived Entitlement",
+		Long: `Restores a previously-archived Entitlement so it can be added to new
+Offerings again. Inverse of ` + "`rc entitlements archive`" + `. Omit the ID in a
+terminal to pick from a list.
 
 Reversibility: re-archive with ` + "`rc entitlements archive <id>`" + `.
 
 Confirmation: no prompt.`,
-		Example: `  rc entitlements restore entl_legacy`,
+		Example: `  rc entitlements restore entl_pro`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -116,8 +123,12 @@ Confirmation: no prompt.`,
 func newEntitlementsProductsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "products [id]",
-		Short: "List products attached to an entitlement",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "List Products attached to an Entitlement",
+		Long: `Lists the Products whose purchase grants this Entitlement. Omit the ID in
+a terminal to pick from a list.`,
+		Example: `  rc entitlements products entl_pro
+  rc entitlements products entl_pro --json | jq '.data.items[].store_identifier'`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -154,11 +165,12 @@ func newEntitlementsProductsCmd() *cobra.Command {
 func newEntitlementsAttachCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "attach <id> <product-id> [product-id...]",
-		Short: "Attach products to an entitlement",
-		Long: `Attaches one or more products to an entitlement. The entitlement will
-then grant access to anyone who purchases any of the listed products.`,
-		Example: `  rc entitlements attach pro prod_monthly prod_yearly
-  rc entitlements attach pro prod_monthly --json`,
+		Short: "Attach Products to an Entitlement",
+		Long: `Attaches one or more Products to an Entitlement. The Entitlement then
+grants access to any Customer who purchases any of the listed Products. The
+first argument accepts an Entitlement ID or lookup key.`,
+		Example: `  rc entitlements attach entl_pro prod_monthly prod_yearly
+  rc entitlements attach entl_pro prod_monthly --json`,
 		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -186,8 +198,11 @@ then grant access to anyone who purchases any of the listed products.`,
 func newEntitlementsDetachCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "detach <id> <product-id> [product-id...]",
-		Short: "Detach products from an entitlement",
-		Args:  cobra.MinimumNArgs(2),
+		Short: "Detach Products from an Entitlement",
+		Long: `Detaches one or more Products from an Entitlement so their purchase no
+longer grants it. The first argument accepts an Entitlement ID or lookup key.`,
+		Example: `  rc entitlements detach entl_pro prod_legacy --json`,
+		Args:    cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -214,7 +229,10 @@ func newEntitlementsDetachCmd() *cobra.Command {
 func newEntitlementsListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "List entitlements",
+		Short: "List Entitlements",
+		Long:  `Lists the Entitlements in the active project, with each lookup key and display name.`,
+		Example: `  rc entitlements list
+  rc entitlements list --json | jq '.data.items[].lookup_key'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -254,9 +272,11 @@ func newEntitlementsListCmd() *cobra.Command {
 
 func newEntitlementsShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show [id]",
-		Short: "Show an entitlement",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "show [id]",
+		Short:   "Show an Entitlement",
+		Long:    `Shows an Entitlement's lookup key, display name, and state. Omit the ID in a terminal to pick from a list.`,
+		Example: "  rc entitlements show entl_pro\n  rc entitlements show                 # pick interactively",
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -290,7 +310,11 @@ func newEntitlementsCreateCmd() *cobra.Command {
 	var lookupKey, displayName string
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create an entitlement",
+		Short: "Create an Entitlement",
+		Long: `Creates an Entitlement in the project catalog. Attach Products afterward
+with ` + "`rc entitlements attach`" + `. Prompts for the lookup key and display name
+when run interactively.`,
+		Example: `  rc entitlements create --lookup-key pro --display-name "Pro"`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -326,9 +350,11 @@ func newEntitlementsCreateCmd() *cobra.Command {
 func newEntitlementsUpdateCmd() *cobra.Command {
 	var displayName string
 	cmd := &cobra.Command{
-		Use:   "update [id]",
-		Short: "Update an entitlement",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "update [id]",
+		Short:   "Update an Entitlement",
+		Long:    `Updates an Entitlement's display name. Omit the ID in a terminal to pick from a list.`,
+		Example: `  rc entitlements update entl_pro --display-name "Pro Access"`,
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -364,15 +390,16 @@ func newEntitlementsUpdateCmd() *cobra.Command {
 func newEntitlementsDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete [id]",
-		Short: "Delete an entitlement",
-		Long: `Permanently deletes an entitlement from the project catalog.
+		Short: "Delete an Entitlement",
+		Long: `Permanently deletes an Entitlement from the project catalog. Omit the ID
+in a terminal to pick from a list.
 
 Reversibility: irreversible. If you only need to hide it from current
-offerings, prefer ` + "`rc entitlements archive`" + ` which can be undone with
+Offerings, prefer ` + "`rc entitlements archive`" + ` which can be undone with
 ` + "`rc entitlements restore`" + `.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc entitlements delete entl_old --yes`,
+		Example: `  rc entitlements delete entl_pro --yes`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())

--- a/internal/cli/invoices.go
+++ b/internal/cli/invoices.go
@@ -10,7 +10,12 @@ func newInvoicesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "invoices",
 		Aliases: []string{"invoice"},
-		Short:   "Inspect invoices",
+		Short:   "Inspect Web Billing invoices",
+		Long: `Inspect RevenueCat Billing (Web Billing) invoices — the billing records for
+web purchases, with payment status and a downloadable PDF. These are
+RevenueCat Billing records, not App Store or Play Store purchases.`,
+		Example: `  rc invoices for cus_abc
+  rc invoices show inv_abc`,
 	}
 	cmd.AddCommand(
 		newInvoicesShowCmd(),
@@ -21,9 +26,11 @@ func newInvoicesCmd() *cobra.Command {
 
 func newInvoicesShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show <id>",
-		Short: "Show an invoice",
-		Args:  cobra.ExactArgs(1),
+		Use:     "show <id>",
+		Short:   "Show a Web Billing invoice",
+		Long:    `Shows a RevenueCat Billing invoice: its payment status, amount, issue date, and the URL to the downloadable PDF.`,
+		Example: "  rc invoices show inv_abc\n  rc invoices show inv_abc --json | jq -r '.pdf_url'",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -48,9 +55,11 @@ func newInvoicesShowCmd() *cobra.Command {
 // first and only narrow by customer if needed.
 func newInvoicesForCustomerCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "for <customer-id>",
-		Short: "List invoices for a customer",
-		Args:  cobra.ExactArgs(1),
+		Use:     "for <customer-id>",
+		Short:   "List a Customer's Web Billing invoices",
+		Long:    `Lists the RevenueCat Billing invoices for a Customer by App User ID, with each invoice's payment status and issue date.`,
+		Example: "  rc invoices for cus_abc\n  rc invoices for cus_abc --json | jq '.data.items[] | select(.status==\"paid\")'",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)

--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -10,8 +10,10 @@ import (
 
 func newMetricsCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "metrics",
-		Short: "Show the project metrics overview",
+		Use:     "metrics",
+		Short:   "Show the project Overview metrics",
+		Long:    `Shows the project Overview: the headline metrics — Active Trials, Active Subscriptions, MRR, and Revenue — each with its current value and period. For time series with filters and segments, use 'rc charts'.`,
+		Example: "  rc metrics\n  rc metrics --json | jq '.metrics[] | {id, value}'",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)

--- a/internal/cli/offerings.go
+++ b/internal/cli/offerings.go
@@ -18,7 +18,12 @@ func newOfferingsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "offerings",
 		Aliases: []string{"offering", "offer"},
-		Short:   "Manage offerings (and their packages)",
+		Short:   "Manage Offerings and their Packages",
+		Long: `An Offering groups the Packages shown on a paywall. Each project has one
+"current" Offering that SDKs fetch by default. Use these commands to build
+Offerings, arrange their Packages, and set which one is current.`,
+		Example: `  rc offerings list
+  rc offerings set-current ofrng_default`,
 	}
 	cmd.AddCommand(
 		newOfferingsListCmd(),
@@ -64,12 +69,14 @@ type verifiedEntitlement struct {
 func newOfferingsVerifyCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "verify [id]",
-		Short: "Verify the complete configuration served by an offering",
-		Long: `Builds one read-only graph containing the offering, its packages, attached
-products and prices, matching entitlements, and attached paywall publication state.
-The issues array calls out missing links that would prevent a working purchase flow.`,
-		Example: `  rc offerings verify ofrng_default --json --no-input`,
-		Args:    cobra.MaximumNArgs(1),
+		Short: "Verify the full configuration served by an Offering",
+		Long: `Builds one read-only graph of an Offering: its Packages, attached Products
+and prices, matching Entitlements, and attached paywall publication state. The
+issues array calls out missing links that would break a purchase flow. Omit the
+ID in a terminal to pick from a list.`,
+		Example: `  rc offerings verify ofrng_default --json --no-input
+  rc offerings verify ofrng_default --json | jq '.data.issues'`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -186,11 +193,12 @@ func newOfferingsPreviewCmd() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "preview [app-id]",
-		Short: "Fetch the offerings payload exactly as an SDK sees it",
+		Short: "Fetch the Offerings payload exactly as an SDK sees it",
 		Long: `Calls the RevenueCat v1 SDK offerings endpoint with an app's public SDK key.
-Use this to verify the current offering, package-product mapping, and published
-paywall components. A null paywall_components value means the SDK is receiving
-the fallback rather than a published dashboard paywall.`,
+Use this to verify the current Offering, Package-to-Product mapping, and
+published paywall components. A null paywall_components value means the SDK is
+receiving the fallback rather than a published dashboard paywall. Omit the app
+ID in a terminal to pick from a list.`,
 		Example: `  rc offerings preview app_test --json --no-input
   rc offerings preview app_ios --public-api-key appl_... --app-user-id preview-user --json --no-input`,
 		Args: cobra.MaximumNArgs(1),
@@ -248,13 +256,15 @@ the fallback rather than a published dashboard paywall.`,
 func newOfferingsSetCurrentCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set-current [id]",
-		Short: "Make an offering the current SDK offering",
-		Long: `Makes this offering the project's current offering. Apps that request the
-current offering from a RevenueCat SDK will receive this offering.
+		Short: "Make an Offering the current Offering",
+		Long: `Makes this the project's current Offering. Apps that request the current
+Offering from a RevenueCat SDK receive it. Omit the ID in a terminal to pick
+from a list.
 
-Confirmation is required because this changes the catalog served to customers.
-Pass --yes for agents and non-interactive use. The change can be reversed by
-setting a different offering as current.`,
+Confirmation: required because this changes the catalog served to Customers.
+Pass --yes for agents and non-interactive use.
+
+Reversibility: set a different Offering as current to change it back.`,
 		Example: `  rc offerings set-current ofrng_default
   rc offerings set-current ofrng_default --yes --json --no-input`,
 		Args: cobra.MaximumNArgs(1),
@@ -291,14 +301,15 @@ setting a different offering as current.`,
 func newOfferingsArchiveCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "archive [id]",
-		Short: "Archive an offering",
-		Long: `Archives an offering so it stops being served to new customers while
-existing subscribers keep their access.
+		Short: "Archive an Offering",
+		Long: `Archives an Offering so it stops being served to new Customers while
+existing subscribers keep their access. Omit the ID in a terminal to pick from
+a list.
 
 Reversibility: use ` + "`rc offerings restore <id>`" + ` to undo.
 
 Confirmation: no prompt — soft, reversible state change.`,
-		Example: `  rc offerings archive ofrng_q1_promo`,
+		Example: `  rc offerings archive ofrng_default`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -329,14 +340,14 @@ Confirmation: no prompt — soft, reversible state change.`,
 func newOfferingsRestoreCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "restore [id]",
-		Short: "Restore an archived offering (= unarchive)",
-		Long: `Restores a previously-archived offering. Inverse of
-` + "`rc offerings archive`" + `.
+		Short: "Restore an archived Offering",
+		Long: `Restores a previously-archived Offering. Inverse of
+` + "`rc offerings archive`" + `. Omit the ID in a terminal to pick from a list.
 
 Reversibility: re-archive with ` + "`rc offerings archive <id>`" + `.
 
 Confirmation: no prompt.`,
-		Example: `  rc offerings restore ofrng_q1_promo`,
+		Example: `  rc offerings restore ofrng_default`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -367,7 +378,10 @@ Confirmation: no prompt.`,
 func newOfferingsListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "List offerings",
+		Short: "List Offerings",
+		Long:  `Lists the Offerings in the active project. The current Offering is marked with an asterisk.`,
+		Example: `  rc offerings list
+  rc offerings list --json | jq '.data.items[] | select(.is_current)'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -411,9 +425,11 @@ func newOfferingsListCmd() *cobra.Command {
 
 func newOfferingsShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show [id]",
-		Short: "Show an offering",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "show [id]",
+		Short:   "Show an Offering",
+		Long:    `Shows an Offering's lookup key, display name, state, and whether it is current. Omit the ID in a terminal to pick from a list.`,
+		Example: "  rc offerings show ofrng_default\n  rc offerings show                  # pick interactively",
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -447,7 +463,11 @@ func newOfferingsCreateCmd() *cobra.Command {
 	var lookupKey, displayName string
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create an offering",
+		Short: "Create an Offering",
+		Long: `Creates an Offering in the active project. Add Packages afterward with
+` + "`rc packages create`" + `. Prompts for the lookup key and display name when run
+interactively.`,
+		Example: `  rc offerings create --lookup-key default --display-name "Default"`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -482,9 +502,11 @@ func newOfferingsCreateCmd() *cobra.Command {
 func newOfferingsUpdateCmd() *cobra.Command {
 	var displayName string
 	cmd := &cobra.Command{
-		Use:   "update [id]",
-		Short: "Update an offering",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "update [id]",
+		Short:   "Update an Offering",
+		Long:    `Updates an Offering's display name. Omit the ID in a terminal to pick from a list. To make an Offering current, use ` + "`rc offerings set-current`" + `.`,
+		Example: `  rc offerings update ofrng_default --display-name "Default"`,
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -520,14 +542,15 @@ func newOfferingsUpdateCmd() *cobra.Command {
 func newOfferingsDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete [id]",
-		Short: "Delete an offering",
-		Long: `Permanently deletes an offering from the project.
+		Short: "Delete an Offering",
+		Long: `Permanently deletes an Offering from the project. Omit the ID in a
+terminal to pick from a list.
 
 Reversibility: irreversible. Prefer ` + "`rc offerings archive`" + ` for
 reversible removal.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc offerings delete ofrng_old --yes`,
+		Example: `  rc offerings delete ofrng_default --yes`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -697,8 +720,12 @@ func paywallToItem(projectID string, pw api.Paywall) tui.BrowserItem {
 func newOfferingsPackagesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "packages [offering-id]",
-		Short: "List packages in an offering",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "List Packages in an Offering",
+		Long: `Lists the Packages that belong to an Offering. Omit the Offering ID in a
+terminal to pick from a list.`,
+		Example: `  rc offerings packages ofrng_default
+  rc offerings packages ofrng_default --json | jq '.data.items[].lookup_key'`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)

--- a/internal/cli/packages.go
+++ b/internal/cli/packages.go
@@ -18,7 +18,13 @@ func newPackagesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "packages",
 		Aliases: []string{"package", "pkg"},
-		Short:   "Manage packages within offerings",
+		Short:   "Manage Packages within Offerings",
+		Long: `A Package groups equivalent Products across platforms under one identifier
+(such as $rc_monthly or $rc_annual) so a paywall can offer the right Product on
+each store. Packages live inside an Offering. Run bare to list every Package in
+the project.`,
+		Example: `  rc packages list
+  rc packages create ofrng_default --lookup-key '$rc_monthly' --display-name "Monthly"`,
 		// Bare `rc packages` runs list for discovery.
 		RunE: runPackagesList,
 	}
@@ -38,12 +44,12 @@ func newPackagesCmd() *cobra.Command {
 func newPackagesListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "List all packages across all offerings",
-		Long: `Lists every package in the active project, grouped across all offerings.
-Each row includes the offering ID so you know where to find the package.
+		Short: "List all Packages across all Offerings",
+		Long: `Lists every Package in the active project, grouped across all Offerings.
+Each row includes the Offering ID so you know where the Package lives.
 
-To create, update, or delete a package you need both the offering ID and
-the package ID. This command is the fastest way to discover them.`,
+To create, update, or delete a Package you need both the Offering ID and
+the Package ID. This command is the fastest way to discover them.`,
 		Example: `  rc packages list
   rc packages list --json | jq '.data.items[] | select(.lookup_key == "$rc_monthly")'`,
 		RunE: runPackagesList,
@@ -132,11 +138,11 @@ func runPackagesList(cmd *cobra.Command, _ []string) error {
 func newPackagesShowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show [package-id]",
-		Short: "Show a package",
-		Long: `Show details for a specific package. Omit the ID under a TTY to pick
-interactively.`,
-		Example: `  rc packages show          # TTY: pick a package
-  rc packages show pkg_xyz  # explicit`,
+		Short: "Show a Package",
+		Long: `Shows a Package's lookup key and display name. Omit the ID in a terminal
+to pick from a list.`,
+		Example: `  rc packages show pkg_x
+  rc packages show          # pick interactively`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -167,8 +173,13 @@ func newPackagesCreateCmd() *cobra.Command {
 	var lookupKey, displayName string
 	cmd := &cobra.Command{
 		Use:   "create [offering-id]",
-		Short: "Create a package in an offering",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "Create a Package in an Offering",
+		Long: `Creates a Package inside an Offering. Use a standard lookup key such as
+$rc_monthly or $rc_annual so SDKs and paywalls resolve it automatically. Omit
+the Offering ID in a terminal to pick from a list. Attach Products afterward
+with ` + "`rc packages attach`" + `.`,
+		Example: `  rc packages create ofrng_default --lookup-key '$rc_monthly' --display-name "Monthly"`,
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -209,9 +220,11 @@ func newPackagesCreateCmd() *cobra.Command {
 func newPackagesUpdateCmd() *cobra.Command {
 	var displayName string
 	cmd := &cobra.Command{
-		Use:   "update [package-id]",
-		Short: "Update a package",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "update [package-id]",
+		Short:   "Update a Package",
+		Long:    `Updates a Package's display name. Omit the ID in a terminal to pick from a list.`,
+		Example: `  rc packages update pkg_x --display-name "Monthly"`,
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -247,13 +260,14 @@ func newPackagesUpdateCmd() *cobra.Command {
 func newPackagesDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete [package-id]",
-		Short: "Delete a package",
-		Long: `Permanently deletes a package from its offering.
+		Short: "Delete a Package",
+		Long: `Permanently deletes a Package from its Offering. Omit the ID in a terminal
+to pick from a list.
 
 Reversibility: irreversible.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc packages delete pkg_legacy --yes`,
+		Example: `  rc packages delete pkg_x --yes`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -286,8 +300,12 @@ Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`
 func newPackagesProductsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "products [package-id]",
-		Short: "List products attached to a package",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "List Products attached to a Package",
+		Long: `Lists the Products attached to a Package, with each store identifier and
+eligibility criteria. Omit the ID in a terminal to pick from a list.`,
+		Example: `  rc packages products pkg_x
+  rc packages products pkg_x --json | jq '.data.items[].store_identifier'`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -353,12 +371,12 @@ func allPackagePickerItems(ctx context.Context, client *api.Client, projectID st
 func newPackagesAttachCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "attach <package-id> <product-id> [product-id...]",
-		Short: "Attach products to a package",
-		Long: `Attach one or more products to a package. Positional arguments are the
-package ID followed by every product ID to attach. Products default to the
+		Short: "Attach Products to a Package",
+		Long: `Attaches one or more Products to a Package. Positional arguments are the
+Package ID followed by every Product ID to attach. Products default to the
 "all" eligibility criteria, which applies to every supported SDK version.`,
-		Example: `  rc packages attach pkg_monthly prod_test_monthly
-  rc packages attach pkg_monthly prod_ios_monthly prod_android_monthly --json --no-input`,
+		Example: `  rc packages attach pkg_x prod_monthly
+  rc packages attach pkg_x prod_ios_monthly prod_android_monthly --json --no-input`,
 		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -382,10 +400,10 @@ package ID followed by every product ID to attach. Products default to the
 func newPackagesDetachCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "detach <package-id> <product-id> [product-id...]",
-		Short: "Detach products from a package",
-		Long: `Detach one or more products from a package. Positional arguments are the
-package ID followed by every product ID to detach.`,
-		Example: `  rc packages detach pkg_monthly prod_legacy --json --no-input`,
+		Short: "Detach Products from a Package",
+		Long: `Detaches one or more Products from a Package. Positional arguments are the
+Package ID followed by every Product ID to detach.`,
+		Example: `  rc packages detach pkg_x prod_legacy --json --no-input`,
 		Args:    cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -20,7 +20,13 @@ func newProductsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "products",
 		Aliases: []string{"product"},
-		Short:   "Inspect products in the project catalog",
+		Short:   "Manage Products in the project catalog",
+		Long: `A Product is a store SKU a Customer buys — its identifier must match the
+store (App Store, Play, Stripe, Test Store). Attach Products to Packages and
+Entitlements so a purchase grants access. These commands inspect, create,
+price, and push Products.`,
+		Example: `  rc products list
+  rc products show prod_x`,
 	}
 	cmd.AddCommand(
 		newProductsListCmd(),
@@ -40,14 +46,14 @@ func newProductsCmd() *cobra.Command {
 func newProductsArchiveCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "archive [id]",
-		Short: "Archive a product",
-		Long: `Archives a product. Existing subscribers keep their access; new
-attaches are blocked.
+		Short: "Archive a Product",
+		Long: `Archives a Product. Existing subscribers keep their access; new attaches
+are blocked. Omit the ID in a terminal to pick from a list.
 
 Reversibility: use ` + "`rc products restore <id>`" + ` to undo.
 
 Confirmation: no prompt — soft, reversible state change.`,
-		Example: `  rc products archive prod_legacy`,
+		Example: `  rc products archive prod_x`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -78,14 +84,14 @@ Confirmation: no prompt — soft, reversible state change.`,
 func newProductsRestoreCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "restore [id]",
-		Short: "Restore an archived product",
-		Long: `Restores a previously-archived product. Inverse of
-` + "`rc products archive`" + `.
+		Short: "Restore an archived Product",
+		Long: `Restores a previously-archived Product. Inverse of
+` + "`rc products archive`" + `. Omit the ID in a terminal to pick from a list.
 
 Reversibility: re-archive with ` + "`rc products archive <id>`" + `.
 
 Confirmation: no prompt.`,
-		Example: `  rc products restore prod_legacy`,
+		Example: `  rc products restore prod_x`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -116,16 +122,17 @@ Confirmation: no prompt.`,
 func newProductsPushCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "push [id]",
-		Short: "Push a product configuration to its underlying store",
-		Long: `Pushes a product's current configuration up to the underlying store
+		Short: "Push a Product's configuration to its store",
+		Long: `Pushes a Product's current configuration up to the underlying store
 (App Store, Play Store, Stripe, etc.). Required after editing pricing or
-metadata on platforms where RC manages the store-side config.
+metadata on platforms where RevenueCat manages the store-side config. Omit the
+ID in a terminal to pick from a list.
 
 Reversibility: external side effect — once written to the store, undoing
 requires a follow-up push with the previous configuration.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc products push prod_abc --yes`,
+		Example: `  rc products push prod_x --yes`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -159,9 +166,10 @@ func newProductsListCmd() *cobra.Command {
 	var appID string
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List products",
+		Short: "List Products",
+		Long:  `Lists the Products in the active project, with each store identifier, type, and state. Filter to one app with --app-id.`,
 		Example: `  rc products list
-  rc products list --app-id app_abc
+  rc products list --app-id app_x
   rc products list --json | jq '.data.items[] | select(.type == "subscription")'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -213,16 +221,18 @@ func newProductsCreateCmd() *cobra.Command {
 	var storeID, productType, appID, displayName, title, duration string
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a product",
-		Long: `Create a new product in the project catalog.
+		Short: "Create a Product",
+		Long: `Creates a Product in the project catalog.
 
---store-id is the product identifier on the platform store (required).
---type must be "subscription" or "one_time" (required; picker shown in TTY).
---app-id is the RevenueCat app ID (required; picker shown in TTY).
---title is the user-facing product title required by Test Store products.
---duration (optional, subscriptions only) is an ISO 8601 duration, e.g. P1M, P1Y.`,
-		Example: `  rc products create --store-id premium_monthly --type subscription --app-id app_test --title "Premium Monthly" --duration P1M
-  rc products create --store-id com.example.once --type one_time --app-id app_abc --display-name "Unlock Everything"`,
+--store-id is the Product identifier on the platform store; it must match the
+store exactly (required).
+--type must be "subscription" or "one_time" (Non-Subscription Purchases)
+(required; picker shown in a terminal).
+--app-id is the RevenueCat app ID (required; picker shown in a terminal).
+--title is the Customer-facing Product title required by Test Store Products.
+--duration (subscriptions only) is an ISO 8601 duration, e.g. P1M, P1Y.`,
+		Example: `  rc products create --store-id premium_monthly --type subscription --app-id app_x --title "Premium Monthly" --duration P1M
+  rc products create --store-id com.example.once --type one_time --app-id app_x --display-name "Unlock Everything"`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -295,13 +305,14 @@ func newProductsCreateCmd() *cobra.Command {
 func newProductsPricesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "prices [product-id]",
-		Short: "List Test Store or Web Billing product prices",
-		Long: `Lists configured prices for a Test Store or Web Billing product.
+		Short: "List Test Store or Web Billing Product prices",
+		Long: `Lists configured prices for a Test Store or Web Billing Product. Omit the
+ID in a terminal to pick from a list.
 
-Use prices set to idempotently create missing currencies or update existing
-Test Store prices. Amounts are entered as decimal major units, not micros.`,
-		Example: `  rc products prices prod_abc --json --no-input
-  rc products prices set prod_abc --price USD=9.99 --price EUR=8.99 --json --no-input`,
+Use ` + "`rc products prices set`" + ` to idempotently create missing currencies or
+update existing Test Store prices. Amounts are decimal major units, not micros.`,
+		Example: `  rc products prices prod_x --json --no-input
+  rc products prices set prod_x --price USD=9.99 --price EUR=8.99 --json --no-input`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -324,14 +335,15 @@ func newProductsPricesSetCmd() *cobra.Command {
 	var rawPrices []string
 	cmd := &cobra.Command{
 		Use:   "set [product-id]",
-		Short: "Create or update Test Store product prices",
-		Long: `Sets exact Test Store product prices by currency. Missing currencies are
+		Short: "Create or update Test Store Product prices",
+		Long: `Sets exact Test Store Product prices by currency. Missing currencies are
 created through the Test Store price API; existing currencies are updated.
-Running the same command again is safe and makes no unnecessary writes.
+Running the same command again is safe and makes no unnecessary writes. Omit the
+ID in a terminal to pick from a list.
 
 Values use ISO 4217 currency and decimal major units: --price USD=9.99.`,
-		Example: `  rc products prices set prod_abc --price USD=9.99
-  rc products prices set prod_abc --price USD=9.99 --price EUR=8.99 --json --no-input`,
+		Example: `  rc products prices set prod_x --price USD=9.99
+  rc products prices set prod_x --price USD=9.99 --price EUR=8.99 --json --no-input`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -447,17 +459,17 @@ func newProductsShowCmd() *cobra.Command {
 	var withStoreState bool
 	cmd := &cobra.Command{
 		Use:   "show [id]",
-		Short: "Show a product",
-		Long: `Shows a RevenueCat product.
+		Short: "Show a Product",
+		Long: `Shows a RevenueCat Product. Omit the ID in a terminal to pick from a list.
 
-Pass --store-state to also read the product's live state from its store:
+Pass --store-state to also read the Product's live state from its store:
 next effective territory prices (scheduled changes include a start date),
 availability, localizations, and App Review metadata. The live read requires
 configured store credentials and reaches the store directly, so it takes a
 few seconds.`,
-		Example: `  rc products show prod_abc
-  rc products show prod_abc --store-state
-  rc products show prod_abc --store-state --json --no-input`,
+		Example: `  rc products show prod_x
+  rc products show prod_x --store-state
+  rc products show prod_x --store-state --json --no-input`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -508,9 +520,11 @@ few seconds.`,
 func newProductsUpdateCmd() *cobra.Command {
 	var displayName string
 	cmd := &cobra.Command{
-		Use:   "update [id]",
-		Short: "Update a product",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "update [id]",
+		Short:   "Update a Product",
+		Long:    `Updates a Product's display name. Omit the ID in a terminal to pick from a list.`,
+		Example: `  rc products update prod_x --display-name "Premium Monthly"`,
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -546,14 +560,15 @@ func newProductsUpdateCmd() *cobra.Command {
 func newProductsDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete [id]",
-		Short: "Delete a product",
-		Long: `Permanently deletes a product from the project.
+		Short: "Delete a Product",
+		Long: `Permanently deletes a Product from the project. Omit the ID in a terminal
+to pick from a list.
 
 Reversibility: irreversible. Prefer ` + "`rc products archive`" + ` for
 reversible removal.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc products delete prod_old --yes`,
+		Example: `  rc products delete prod_x --yes`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())

--- a/internal/cli/products_store.go
+++ b/internal/cli/products_store.go
@@ -16,7 +16,7 @@ import (
 func newProductsStoreCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "store",
-		Short: "Plan and sync product configuration with an app store",
+		Short: "Plan and sync Product state with the App Store or Google Play",
 		Long: `Product store-state plans are persisted by RevenueCat, not by the rc
 process. Humans can use sync for an in-memory plan/review/apply flow. Agents can
 create a plan, inspect its plan ID in a later process, then apply or discard
@@ -38,7 +38,7 @@ func newProductsStoreListCmd() *cobra.Command {
 	var status string
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List product store-state plans",
+		Short: "List Product store-state plans",
 		Long: `Lists the project's persisted store-state plans so a lost plan ID can be
 recovered in a later session. Filter with --status (draft, planned, applied,
 apply_errored, discarded, ...).`,
@@ -87,7 +87,8 @@ func newProductsStoreSyncCmd() *cobra.Command {
 		Short: "Gather desired state, review its plan, and optionally apply it",
 		Long: `Runs the complete human workflow in one rc process: gather desired state
 interactively or from CSV/JSON, persist it as a RevenueCat plan, wait for its
-diff, display warnings, and ask before applying the exact plan.
+diff, display warnings, and ask before applying the exact plan to the App Store
+or Google Play.
 
 No local file is required. Without --file, interactive terminals prompt for
 product fields and keep the answers only in process memory. For automation,
@@ -138,7 +139,7 @@ func newProductsStorePlanCmd() *cobra.Command {
 	var timeout time.Duration
 	cmd := &cobra.Command{
 		Use:   "plan [app-id]",
-		Short: "Create and review a persisted product store-state plan",
+		Short: "Create and review a persisted Product store-state plan",
 		Long: `Creates a server-side RevenueCat plan containing the complete desired
 state and computed diff. The returned plan ID remains usable after this rc
 process exits. Apply that exact reviewed plan with:
@@ -188,7 +189,8 @@ screenshot is uploaded automatically; replace it before submitting to Apple.`,
 func newProductsStoreShowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "show <plan-id>",
-		Short:   "Show a persisted product store-state plan",
+		Short:   "Show a persisted Product store-state plan",
+		Long:    `Fetches a persisted plan by ID and prints its diff, warnings, and per-Product apply status. Read-only; makes no changes.`,
 		Example: `  rc products store show plan_123 --json --no-input`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -215,10 +217,16 @@ func newProductsStoreApplyCmd() *cobra.Command {
 	var timeout time.Duration
 	cmd := &cobra.Command{
 		Use:   "apply <plan-id>",
-		Short: "Apply an already-reviewed product store-state plan",
+		Short: "Apply an already-reviewed Product store-state plan",
 		Long: `Fetches the persisted plan, displays its exact diff and warnings, and
-applies it after confirmation. Automation must pass --yes. This command never
-reconstructs desired state from a local file; it applies the plan ID supplied.`,
+applies it to the App Store or Google Play after confirmation. Automation must
+pass --yes. This command never reconstructs desired state from a local file; it
+applies the plan ID supplied.
+
+Reversibility: writes to the connected store — undo by planning and applying
+the reverse state.
+
+Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
 		Example: `  rc products store apply plan_123 --yes --json --no-input`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -248,9 +256,14 @@ reconstructs desired state from a local file; it applies the plan ID supplied.`,
 
 func newProductsStoreDiscardCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "discard <plan-id>",
-		Short:   "Discard a product store-state plan without applying it",
-		Long:    "Discards a persisted plan. Automation must pass --yes.",
+		Use:   "discard <plan-id>",
+		Short: "Discard a Product store-state plan without applying it",
+		Long: `Discards a persisted plan so it can no longer be applied. Nothing is
+written to the App Store or Google Play.
+
+Reversibility: irreversible — re-plan to review the changes again.
+
+Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
 		Example: `  rc products store discard plan_123 --yes --json --no-input`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/products_store_screenshot.go
+++ b/internal/cli/products_store_screenshot.go
@@ -24,9 +24,10 @@ func newProductsStoreScreenshotCmd() *cobra.Command {
 	var timeout time.Duration
 	cmd := &cobra.Command{
 		Use:   "screenshot [product-id]",
-		Short: "Upload a real App Review screenshot for a product",
+		Short: "Upload a real App Review screenshot for a Product",
 		Long: `Uploads a paywall screenshot to App Store Connect for App Review and
-attaches it to the product, replacing the automatic placeholder.
+attaches it to the Product, replacing the automatic placeholder. Omit the
+product-id in a terminal to pick from a list.
 
 The image bytes upload directly to Apple through presigned URLs; RevenueCat
 only stores the resulting screenshot reference. Attaching is asynchronous —

--- a/internal/cli/profiles.go
+++ b/internal/cli/profiles.go
@@ -37,8 +37,10 @@ RC_PROFILE env > .active pointer file > "default".`,
 
 func newProfilesListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
-		Short: "List configured profiles",
+		Use:     "list",
+		Short:   "List configured profiles",
+		Long:    `Lists the local credential profiles on disk, marking the active one and showing each profile's default project and whether it holds an API key.`,
+		Example: `  rc profiles list`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			names, err := config.ListProfiles()
@@ -98,9 +100,11 @@ The profile must already exist on disk (create it with ` + "`rc login --profile 
 
 func newProfilesShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show [name]",
-		Short: "Show the resolved configuration for a profile (API key redacted)",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "show [name]",
+		Short:   "Show a profile's resolved configuration (API key redacted)",
+		Long:    `Shows the resolved project, base URL, and redacted API key for a profile. Defaults to the active profile when no name is given.`,
+		Example: "  rc profiles show prod\n  rc profiles show                 # active profile",
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			name := ""

--- a/internal/cli/projects.go
+++ b/internal/cli/projects.go
@@ -17,7 +17,12 @@ func newProjectsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "projects",
 		Aliases: []string{"project"},
-		Short:   "List and switch between projects",
+		Short:   "List and switch between Projects",
+		Long: `A Project groups your apps, catalog (Entitlements, Offerings, Packages,
+Products), and settings. Most commands run against one active Project; set it
+once with rc projects use so you don't pass --project-id every time.`,
+		Example: `  rc projects list
+  rc projects use proj_x`,
 		// Bare `rc projects` runs `list` for convenience.
 		RunE: runProjectsList,
 	}
@@ -34,7 +39,10 @@ func newProjectsListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List projects",
-		RunE:  runProjectsList,
+		Long:  `Lists the Projects on your account. The active Project is marked with an asterisk.`,
+		Example: `  rc projects list
+  rc projects list --json | jq '.data.items[].id'`,
+		RunE: runProjectsList,
 	}
 }
 
@@ -92,9 +100,11 @@ func runProjectsList(cmd *cobra.Command, _ []string) error {
 
 func newProjectsShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show [project-id]",
-		Short: "Show a project's details",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "show [project-id]",
+		Short:   "Show a project's details",
+		Long:    `Shows a Project's details. Defaults to the active Project when no ID is given.`,
+		Example: "  rc projects show proj_x\n  rc projects show                 # active project",
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			client, err := rt.API()

--- a/internal/cli/purchases.go
+++ b/internal/cli/purchases.go
@@ -15,7 +15,12 @@ func newPurchasesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "purchases",
 		Aliases: []string{"purchase"},
-		Short:   "Inspect and refund one-time purchases",
+		Short:   "Inspect and refund Non-Subscription Purchases",
+		Long: `Inspect and refund Non-Subscription Purchases — one-time, consumable,
+non-consumable, and lifetime purchases. View a purchase, list the Entitlements
+it grants, or refund it. For recurring subscriptions use 'rc subscriptions'.`,
+		Example: `  rc purchases show pur_abc
+  rc purchases refund pur_abc --yes`,
 	}
 	cmd.AddCommand(
 		newPurchasesShowCmd(),
@@ -27,9 +32,11 @@ func newPurchasesCmd() *cobra.Command {
 
 func newPurchasesShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show <id>",
-		Short: "Show a purchase",
-		Args:  cobra.ExactArgs(1),
+		Use:     "show <id>",
+		Short:   "Show a purchase",
+		Long:    `Shows a Non-Subscription Purchase: its Product, store, purchase time, and the Customer (App User ID) it belongs to. In a terminal this opens the interactive browser.`,
+		Example: "  rc purchases show pur_abc\n  rc purchases show pur_abc --json | jq '.store'",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -55,9 +62,11 @@ func newPurchasesShowCmd() *cobra.Command {
 
 func newPurchasesEntitlementsCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "entitlements <id>",
-		Short: "List entitlements granted by a purchase",
-		Args:  cobra.ExactArgs(1),
+		Use:     "entitlements <id>",
+		Short:   "List Entitlements granted by a purchase",
+		Long:    `Lists the Entitlements a Non-Subscription Purchase grants the Customer — lifetime access, for example.`,
+		Example: "  rc purchases entitlements pur_abc\n  rc purchases entitlements pur_abc --json | jq '.data.items[].lookup_key'",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -88,11 +97,13 @@ func newPurchasesEntitlementsCmd() *cobra.Command {
 func newPurchasesRefundCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "refund <id>",
-		Short: "Refund a Web Billing purchase",
-		Long: `Refunds a one-time purchase. Web Billing only — store-side refunds
-must be issued through the store.
+		Short: "Refund a Non-Subscription Purchase",
+		Long: `Refunds a Non-Subscription Purchase and emits a CANCELLATION, removing any
+Entitlement access it granted. Only Google Play and RevenueCat Billing
+purchases can be refunded directly; App Store refunds must be issued through
+Apple.
 
-Reversibility: irreversible. Money is returned to the customer's payment
+Reversibility: irreversible. Money is returned to the Customer's payment
 method.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -525,8 +525,10 @@ func newRicoConversationsCmd() *cobra.Command {
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "List conversations",
-		Long: `Lists all conversations for the authenticated account. Pass --project to
-scope to a single project.`,
+		Long: `Lists all Rico conversations for the authenticated account. Pass --project to
+scope to a single Project.`,
+		Example: `  rc rico conversations list
+  rc rico conversations list --project proj_x`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			client, err := ricoClient(rt, baseURL)
@@ -554,9 +556,11 @@ scope to a single project.`,
 	}
 
 	show := &cobra.Command{
-		Use:   "show <id>",
-		Short: "Show a conversation transcript",
-		Args:  cobra.ExactArgs(1),
+		Use:     "show <id>",
+		Short:   "Show a conversation transcript",
+		Long:    `Prints the full message transcript for a Rico conversation, including tool calls and any pending approvals.`,
+		Example: `  rc rico conversations show NQ7bGmww8rLcPT9d`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			client, err := ricoClient(rt, baseURL)
@@ -623,6 +627,7 @@ func newRicoFeedbackCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "feedback <run-id> <good|bad>",
 		Short: "Rate a Rico reply",
+		Long:  `Rates a Rico reply good or bad by run ID (printed after each chat turn), with an optional comment.`,
 		Example: `  rc rico feedback rico_cli_1a2b3c good
   rc rico feedback rico_cli_1a2b3c bad --comment "wrong project"`,
 		Args: cobra.ExactArgs(2),

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -24,6 +24,8 @@ func newSchemaCmd(root *cobra.Command) *cobra.Command {
 
 Always emits JSON regardless of --json (the command is purely informational).
 Use this from an agent rather than scraping the human --help output.`,
+		Example: `  rc schema apps create
+  rc schema rico chat`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -44,6 +46,8 @@ func newCommandsCmd(root *cobra.Command) *cobra.Command {
 		Long: `Prints the command tree as JSON. Pass --schemas to include every command's
 full schema (flags, args, examples) in one call — cheaper for an agent than
 running rc schema per command.`,
+		Example: `  rc commands
+  rc commands --schemas`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			if schemas {

--- a/internal/cli/subscriptions.go
+++ b/internal/cli/subscriptions.go
@@ -14,6 +14,12 @@ func newSubscriptionsCmd() *cobra.Command {
 		Use:     "subscriptions",
 		Aliases: []string{"subscription", "subs", "sub"},
 		Short:   "Inspect and manage subscriptions",
+		Long: `Inspect a subscription and act on it: view its status, list transactions and
+granted Entitlements, fetch the store management URL, or cancel, refund, and
+extend it. Refunds and direct cancellation are limited by store — see each
+subcommand.`,
+		Example: `  rc subscriptions show sub_x
+  rc subscriptions cancel sub_x --yes`,
 	}
 	cmd.AddCommand(
 		newSubsShowCmd(),
@@ -29,9 +35,11 @@ func newSubscriptionsCmd() *cobra.Command {
 
 func newSubsShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show <id>",
-		Short: "Show a subscription",
-		Args:  cobra.ExactArgs(1),
+		Use:     "show <id>",
+		Short:   "Show a subscription",
+		Long:    `Shows a subscription's status, store, current period, and the Customer (App User ID) it belongs to. In a terminal this opens the interactive browser.`,
+		Example: "  rc subscriptions show sub_x\n  rc subscriptions show sub_x --json | jq '.status'",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -57,9 +65,11 @@ func newSubsShowCmd() *cobra.Command {
 
 func newSubsTransactionsCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "transactions <id>",
-		Short: "List transactions for a subscription",
-		Args:  cobra.ExactArgs(1),
+		Use:     "transactions <id>",
+		Short:   "List a subscription's transactions",
+		Long:    `Lists the transactions on a subscription — the initial purchase and each renewal — newest activity first.`,
+		Example: "  rc subscriptions transactions sub_x\n  rc subscriptions transactions sub_x --json | jq '.data.items[].id'",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -89,9 +99,11 @@ func newSubsTransactionsCmd() *cobra.Command {
 
 func newSubsEntitlementsCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "entitlements <id>",
-		Short: "List entitlements granted by a subscription",
-		Args:  cobra.ExactArgs(1),
+		Use:     "entitlements <id>",
+		Short:   "List Entitlements granted by a subscription",
+		Long:    `Lists the Entitlements this subscription grants the Customer while it is active.`,
+		Example: "  rc subscriptions entitlements sub_x\n  rc subscriptions entitlements sub_x --json | jq '.data.items[].lookup_key'",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -121,9 +133,11 @@ func newSubsEntitlementsCmd() *cobra.Command {
 
 func newSubsManagementURLCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "management-url <id>",
-		Short: "Get the store-specific subscription management URL",
-		Args:  cobra.ExactArgs(1),
+		Use:     "management-url <id>",
+		Short:   "Get a subscription's store management URL",
+		Long:    `Returns the store-specific URL where the Customer manages this subscription (App Store, Play Store, or RevenueCat Billing). Send it to a Customer who wants to update or cancel on their own.`,
+		Example: "  rc subscriptions management-url sub_x\n  rc subscriptions management-url sub_x --json | jq -r '.url'",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -146,15 +160,16 @@ func newSubsManagementURLCmd() *cobra.Command {
 func newSubsCancelCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "cancel <id>",
-		Short: "Cancel a Web Billing subscription",
-		Long: `Cancels a subscription. Web Billing only — App Store / Play Store
-subscriptions must be cancelled through the store.
+		Short: "Cancel a subscription",
+		Long: `Cancels a subscription so it stops renewing at the end of the current period.
+RevenueCat Billing only — App Store and Play Store subscriptions must be
+cancelled through the store.
 
 Reversibility: a cancelled subscription cannot be uncancelled via API; the
-customer would need to start a new subscription.
+Customer would need to start a new subscription.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc subscriptions cancel sub_abc --yes`,
+		Example: `  rc subscriptions cancel sub_x --yes`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -183,14 +198,15 @@ func newSubsExtendCmd() *cobra.Command {
 	var duration string
 	cmd := &cobra.Command{
 		Use:   "extend <id> --by <duration>",
-		Short: "Extend a subscription's billing period",
-		Long: `Extends a subscription's current period by an ISO 8601 duration.
-Used for support gestures (free month after an outage, etc.).
+		Short: "Extend a subscription's current period",
+		Long: `Extends a subscription's current period by an ISO 8601 duration, pushing back
+the next renewal. Used for support gestures — a free month after an outage,
+say. Entitlement access lasts through the new period end.
 
 Duration format: P[n]Y[n]M[n]D — e.g. P1M (one month), P7D (seven days),
 P3M (three months).`,
-		Example: `  rc subscriptions extend sub_abc --by P1M
-  rc subscriptions extend sub_abc --by P7D --json`,
+		Example: `  rc subscriptions extend sub_x --by P1M
+  rc subscriptions extend sub_x --by P7D --json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -220,15 +236,17 @@ P3M (three months).`,
 func newSubsRefundCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "refund <id>",
-		Short: "Refund a Web Billing subscription",
-		Long: `Refunds the most recent payment on a Web Billing subscription. Web
-Billing only — store-side refunds must be issued through the store.
+		Short: "Refund a subscription's latest payment",
+		Long: `Refunds the most recent payment on a subscription and emits a CANCELLATION.
+Only Google Play and RevenueCat Billing purchases can be refunded directly;
+App Store refunds must be issued through Apple. The refund immediately
+expires the subscription and removes Entitlement access.
 
-Reversibility: irreversible. Money is returned to the customer's payment
+Reversibility: irreversible. Money is returned to the Customer's payment
 method; recouping requires charging again.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc subscriptions refund sub_abc --yes`,
+		Example: `  rc subscriptions refund sub_x --yes`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())

--- a/internal/cli/webhooks.go
+++ b/internal/cli/webhooks.go
@@ -21,6 +21,12 @@ func newWebhooksCmd() *cobra.Command {
 		Use:     "webhooks",
 		Aliases: []string{"webhook"},
 		Short:   "Manage webhook integrations",
+		Long: `Webhooks send RevenueCat server-to-server notifications whenever a subscription
+or purchase event happens — initial purchases, renewals, cancellations, billing
+issues — so your backend can stay in sync and trigger automations. Each webhook
+has a name and a delivery URL, scoped to the project.`,
+		Example: `  rc webhooks list
+  rc webhooks create --name "Backend sync" --url https://api.example.com/revenuecat`,
 	}
 	cmd.AddCommand(
 		newWebhooksListCmd(),
@@ -36,6 +42,9 @@ func newWebhooksListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List webhooks",
+		Long:  `Lists the webhook integrations configured for the project, with each delivery URL and environment.`,
+		Example: `  rc webhooks list
+  rc webhooks list --json | jq '.data.items[].url'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -93,9 +102,11 @@ func webhookToItem(projectID string, w api.Webhook) tui.BrowserItem {
 
 func newWebhooksShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show [id]",
-		Short: "Show a webhook",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "show [id]",
+		Short:   "Show a webhook",
+		Long:    `Shows a webhook's name, delivery URL, and environment. Omit the ID in a terminal to pick from a list.`,
+		Example: "  rc webhooks show wh_abc\n  rc webhooks show                 # pick interactively",
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -128,8 +139,10 @@ func newWebhooksShowCmd() *cobra.Command {
 func newWebhooksCreateCmd() *cobra.Command {
 	var name, urlStr string
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a webhook",
+		Use:     "create",
+		Short:   "Create a webhook",
+		Long:    `Creates a webhook: RevenueCat POSTs event notifications to the given URL as subscription and purchase events occur. Prompts for the name and URL when run interactively.`,
+		Example: `  rc webhooks create --name "Backend sync" --url https://api.example.com/revenuecat`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -162,9 +175,11 @@ func newWebhooksCreateCmd() *cobra.Command {
 func newWebhooksUpdateCmd() *cobra.Command {
 	var name, urlStr string
 	cmd := &cobra.Command{
-		Use:   "update [id]",
-		Short: "Update a webhook",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "update [id]",
+		Short:   "Update a webhook",
+		Long:    `Updates a webhook's name or delivery URL. Only the flags you pass change; omit the ID in a terminal to pick from a list.`,
+		Example: "  rc webhooks update wh_abc --url https://api.example.com/rc/v2\n  rc webhooks update wh_abc --name \"Prod events\"",
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)


### PR DESCRIPTION
Normalizes **every** command group's help — not just the ones missing it — to RevenueCat's own terminology and voice, sourced from docs.revenuecat.com:

- Catalog nouns capitalized: **Entitlement / Offering / Package / Product**
- **Customer** + **App User ID**, never "user"
- **Non-Subscription Purchases** (was "one-time purchases")
- **Invoices** scoped to RevenueCat Billing; **Overview** metrics / **Charts** / **Benchmarks** framing from the docs
- Refund/cancel help states the real caveats (Google Play + RevenueCat Billing only, emits `CANCELLATION`, expires the subscription)

Every leaf now has a `Long` where it helps and a concrete `Example`; destructive commands use the existing Reversibility/Confirmation template. `webhooks` is the reference the rest matches.

Help strings only — no code, flags, or behavior touched. Independent of the paywall stack; off `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to CLI help strings with no runtime or API changes.
> 
> **Overview**
> **Help-only change** across the `rc` CLI: `Short`, `Long`, and `Example` strings on cobra commands in apps, catalog (entitlements, offerings, packages, products), customers, subscriptions, purchases, invoices, metrics, charts, browse, webhooks, profiles, projects, Rico, schema, and related subcommands. No flags, handlers, or API behavior change.
> 
> The updates align wording with RevenueCat docs: capitalized **Project**, **Customer**, **Entitlement**, **Offering**, **Package**, **Product**; **Non-Subscription Purchases** instead of generic one-time purchase language; **Customer Profile** / **App User ID** framing; invoices scoped to **Web Billing**; metrics as **Overview** vs time series via **charts**.
> 
> Several commands gain richer `Long` text (interactive ID picking, next steps like `rc apps apple setup`) and `jq`-style examples. Destructive or store-sensitive commands add or tighten **Reversibility** and **Confirmation** notes; subscription/purchase refund and cancel help now states Google Play + RevenueCat Billing limits and **CANCELLATION** / entitlement impact where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0168e2aa10037cbbd59e1589b3f27d10768e2cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

