### PR TITLE
feat(codegen): merge a hand-maintained beta spec overlay for store_state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ gen: ## Regenerate API types from OpenAPI spec
 	else \
 		PYTHON=python3; \
 	fi; \
-	$$PYTHON scripts/preprocess-spec.py docs/specs/v2-developer.yaml /tmp/v2-clean.yaml
+	$$PYTHON scripts/preprocess-spec.py docs/specs/v2-developer.yaml /tmp/v2-clean.yaml docs/specs/v2-beta-overlay.yaml
 	go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen \
 		--config oapi-codegen.yaml /tmp/v2-clean.yaml
 

--- a/docs/specs/v2-beta-overlay.yaml
+++ b/docs/specs/v2-beta-overlay.yaml
@@ -1,0 +1,2742 @@
+'# NOTE': 'Hand-maintained beta overlay — see DX-880. Seeded from khepri''s openapi-dev.yaml
+  (x-release-status: development endpoints the CLI uses). Merged onto the public spec
+  by scripts/preprocess-spec.py. Remove entries here once they graduate into the public
+  spec.'
+openapi: 3.0.3
+info:
+  title: RevenueCat v2 — beta overlay
+  version: overlay
+paths:
+  /projects/{project_id}/products/{product_id}/store_state:
+    get:
+      summary: Get a product store state
+      description: "Returns the live ProductStoreState by reading data from the store.\n\
+        \nPricing reflects the next effective price per territory. When App Store\n\
+        Connect has a scheduled price change, this endpoint returns the scheduled\n\
+        price instead of the current one and includes `start_date`.\n This endpoint\
+        \ requires the following permission(s): <code>project_configuration:products:read</code>.\
+        \ This endpoint belongs to the <strong>Project Configuration</strong> domain,\
+        \ which has a default rate limit of <strong>60 requests per minute</strong>."
+      operationId: get-product-store-state
+      x-revenuecat-rate-limiting-domain: project_configuration
+      x-scopes:
+      - project_configuration:products:read
+      x-release-status: development
+      x-revenuecat-mcp-include: true
+      x-revenuecat-mcp-return-as-json: true
+      x-revenuecat-mcp-description: "Returns live ProductStoreState data from the\
+        \ target store (App Store Connect or Google Play Store).\nSubscription pricing\
+        \ note: App Store subscriptions typically require territory-level pricing\
+        \ coverage; partial pricing can leave metadata incomplete until remaining\
+        \ territories are configured.\nResponse shape — read directly from the returned\
+        \ JSON. - `store` (`app_store` | `play_store`) and `store_status.status`\n\
+        \  (e.g. `ok`, `needs_action`, `not_found`) tell you which store this came\n\
+        \  from and the overall product health.\n- `common.availability.territories[<region>]`\
+        \ — boolean: whether the\n  product is available in that region (e.g. `common.availability.territories.US`).\n\
+        - `common.pricing.territory_prices[<region>]` — `{ amount_micros, currency,\n\
+        \  start_date? }` for that region. For App Store this is the next effective\n\
+        \  price (scheduled changes include `start_date`).\n- `common.localizations[<locale>]`\
+        \ — `{ name, description }` per locale\n  (e.g. `en-US`).\n- App Store-specific\
+        \ (`store_state` when `store == app_store`):\n  `subscription_group_localizations`,\
+        \ `trial_offer`, `privacy_policy_url`,\n  `review_information.screenshot`,\
+        \ `review_information.notes`.\n- Play Store-specific (`store_state` when `store\
+        \ == play_store`):\n  `base_plans[<base_plan_id>]` is keyed by base plan id\
+        \ and contains\n  `state` (`ACTIVE` | `DRAFT` | `INACTIVE`), exactly one of\n\
+        \  `auto_renewing_base_plan_type` (fields: `billing_period_duration`\n  (e.g.\
+        \ `P1M`), `grace_period_duration`, `account_hold_duration`,\n  `proration_mode`,\
+        \ `resubscribe_state`, `legacy_compatible`,\n  `legacy_compatible_subscription_offer_id`),\n\
+        \  `prepaid_base_plan_type`, or `installments_base_plan_type`,\n  `regional_configs[<region>].new_subscriber_availability`\
+        \ and\n  `regional_configs[<region>].price`, `offers`, and `offer_tags`."
+      x-revenuecat-release-gatekeeping: false
+      tags:
+      - Product
+      parameters:
+      - name: project_id
+        description: ID of the project
+        required: true
+        in: path
+        schema:
+          type: string
+          maxLength: 255
+          example: proj1ab2c3d4
+      - name: product_id
+        description: ID of the product
+        required: true
+        in: path
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: prod1a2b3c4d5
+      responses:
+        '200':
+          description: The current product store state.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - project_id
+                - product_id
+                - store
+                - common
+                - store_state
+                properties:
+                  project_id:
+                    description: The RevenueCat project identifier.
+                    type: string
+                    example: proj1a2b3c4
+                  product_id:
+                    description: The RevenueCat product identifier.
+                    type: string
+                    example: prod1a2b3c4
+                  store:
+                    description: The store this state was read from.
+                    type: string
+                    enum:
+                    - app_store
+                    - play_store
+                    example: app_store
+                  warnings:
+                    description: Optional guidance for follow-up actions.
+                    type: array
+                    items:
+                      type: string
+                  store_status:
+                    description: Current normalized product status and raw store status
+                      returned by the underlying store, when available.
+                    type: object
+                    nullable: true
+                    required:
+                    - status
+                    properties:
+                      status:
+                        description: Normalized product status used across stores.
+                        type: string
+                        enum:
+                        - ok
+                        - could_not_check
+                        - not_found
+                        - action_in_progress
+                        - needs_action
+                        - inactive_in_store
+                        - draft
+                        - unspecified
+                        - unknown
+                        example: needs_action
+                      raw_store_status:
+                        description: Raw status returned by the store API.
+                        type: string
+                        nullable: true
+                        example: READY_TO_SUBMIT
+                  common:
+                    allOf:
+                    - $ref: '#/components/schemas/ProductStoreStateCommonResponse'
+                    - required:
+                      - pricing
+                      - availability
+                      - localizations
+                  store_state:
+                    anyOf:
+                    - $ref: '#/components/schemas/ProductStoreStateAppStoreStateResponse'
+                    - $ref: '#/components/schemas/ProductStoreStatePlayStoreStateResponse'
+              examples:
+                App Store subscription state:
+                  value:
+                    project_id: proj1a2b3c4
+                    product_id: prod1a2b3c4
+                    store: app_store
+                    store_status:
+                      status: needs_action
+                      raw_store_status: READY_TO_SUBMIT
+                    common:
+                      pricing:
+                        territory_prices:
+                          US:
+                            amount_micros: 10990000
+                            currency: USD
+                            start_date: '2026-05-01'
+                      availability:
+                        territories:
+                          US: true
+                        available_in_new_territories: true
+                      localizations:
+                        en-US:
+                          name: Premium Monthly
+                          description: Access premium content every month.
+                      title: Premium Monthly
+                      duration: ONE_MONTH
+                    store_state:
+                      subscription_group_localizations:
+                        en-US:
+                          name: Premium Plans
+                      privacy_policy_url: https://example.com/privacy
+                      review_information:
+                        notes: Test subscription for review.
+                Play Store subscription state:
+                  value:
+                    project_id: proj1a2b3c4
+                    product_id: prod1a2b3c4
+                    store: play_store
+                    store_status:
+                      status: ok
+                      raw_store_status: null
+                    common:
+                      pricing:
+                        territory_prices:
+                          US:
+                            amount_micros: 9990000
+                            currency: USD
+                      availability:
+                        territories:
+                          US: true
+                      localizations:
+                        en-US:
+                          name: Premium Monthly
+                          description: Access premium content every month.
+                    store_state:
+                      base_plans:
+                        monthly:
+                          state: ACTIVE
+                          auto_renewing_base_plan_type:
+                            billing_period_duration: P1M
+                            grace_period_duration: P3D
+                            account_hold_duration: P30D
+                            proration_mode: SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE
+                            resubscribe_state: RESUBSCRIBE_STATE_ACTIVE
+                            legacy_compatible: false
+                            legacy_compatible_subscription_offer_id: null
+                          regional_configs:
+                            US:
+                              new_subscriber_availability: true
+                              price:
+                                amount_micros: 9990000
+                                currency: USD
+                          offer_tags: []
+                          offers: {}
+          headers:
+            RevenueCat-Rate-Limit-Current-Usage:
+              $ref: '#/components/headers/RateLimitCurrentUsage'
+            RevenueCat-Rate-Limit-Current-Limit:
+              $ref: '#/components/headers/RateLimitCurrentLimit'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '423':
+          $ref: '#/components/responses/Locked'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/InternalError'
+    post:
+      summary: Set a product store state
+      description: "Accepts desired store metadata for a product and enqueues an asynchronous\n\
+        apply operation. Supports partial updates: only provided fields are applied,\n\
+        omitted fields leave the existing state in App Store Connect unchanged.\n\
+        For map fields, keys follow patch semantics:\n- omitted key: no-op (preserves\
+        \ existing state)\n- key with null value: delete that entry in App Store Connect\n\
+        - key with object value: create or update\n`territories` uses `true`/`false`\
+        \ instead of null (true = available,\nfalse = remove). `territory_prices`\
+        \ does not support deletion because\nApple does not allow removing individual\
+        \ territory prices — override\nwith a new `amount_micros` value instead.\n\
+        Exception: a placeholder review screenshot is always uploaded if the product\n\
+        does not have one, regardless of whether review_information is provided.\n\
+        \n`store_state.trial_offer` requires at least one available territory.\nIf\
+        \ availability is omitted, the current territories in App Store Connect\n\
+        are used. If no territories exist, the request will fail.\n\nIf the product\
+        \ does not exist yet in the target store, the apply flow will\ncreate it first\
+        \ and then apply availability, pricing, and localization state.\nFor subscription\
+        \ create-if-missing flows, provide `common.duration`.\nOptionally set `store_state.subscription_group_name`\
+        \ to choose the target\nsubscription group name at creation time.\n This endpoint\
+        \ requires the following permission(s): <code>project_configuration:products:read_write</code>.\
+        \ This endpoint belongs to the <strong>Project Configuration</strong> domain,\
+        \ which has a default rate limit of <strong>60 requests per minute</strong>."
+      operationId: set-product-store-state
+      x-revenuecat-rate-limiting-domain: project_configuration
+      x-scopes:
+      - project_configuration:products:read_write
+      x-release-status: development
+      x-revenuecat-mcp-include: true
+      x-revenuecat-mcp-return-as-json: true
+      x-revenuecat-mcp-description: 'Creates or updates desired store metadata for
+        a product and returns an async operation_id.
+
+        Recommended flow: 1) Call get-product-store-state first. 2) Optional: if user
+        provides a review screenshot, call upload-product-store-state-screenshot and
+        upload bytes to Apple. 3) Call this tool with store=''app_store'' and the
+        fields to change. 4) Poll get-product-store-state-operation until status is
+        ''succeeded'' or ''failed''.
+
+        This endpoint uses patch semantics: omitted fields are not changed.
+
+        Pricing guidance: - In-app purchases can often start from a base territory
+        price. - Subscriptions may require territory-by-territory pricing coverage
+        in App Store Connect, otherwise validation/missing-metadata issues can remain.
+        - Inspect `warnings` from `get-product-store-state`; if it indicates incomplete
+        subscription territory pricing, call `equalize-subscription-prices` to fill
+        missing territories.
+
+        Subscription-group guidance for subscription products: - Prefer reusing an
+        existing subscription group when available. - If no subscription group exists,
+        create a new one. - If the user explicitly asks for a different group, use
+        that group instead (set `store_state.subscription_group_name` accordingly).
+
+        If available, include review_information.notes, privacy_policy_url (especially
+        for subscriptions), and trial_offer for subscription products.'
+      x-revenuecat-release-gatekeeping: false
+      tags:
+      - Product
+      parameters:
+      - name: project_id
+        description: ID of the project
+        required: true
+        in: path
+        schema:
+          type: string
+          maxLength: 255
+          example: proj1ab2c3d4
+      - name: product_id
+        description: ID of the product
+        required: true
+        in: path
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: prod1a2b3c4d5
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - store
+              properties:
+                store:
+                  description: The target store for this desired state.
+                  type: string
+                  enum:
+                  - app_store
+                  - play_store
+                  example: app_store
+                common:
+                  type: object
+                  properties:
+                    pricing:
+                      type: object
+                      properties:
+                        territory_prices:
+                          type: object
+                          additionalProperties:
+                            type: object
+                            required:
+                            - amount_micros
+                            properties:
+                              amount_micros:
+                                description: Territory price amount in micros.
+                                type: integer
+                                format: int64
+                                minimum: 0
+                                example: 9990000
+                              currency:
+                                description: ISO currency code for this territory
+                                  price.
+                                type: string
+                                minLength: 3
+                                maxLength: 3
+                                example: USD
+                              start_date:
+                                description: ISO-8601 date (YYYY-MM-DD) for a scheduled
+                                  price change. Required for approved subscriptions
+                                  — Apple does not allow modifying the current price
+                                  of an approved subscription directly; a future start
+                                  date must be provided to schedule the change. Omit
+                                  for initial pricing of unapproved products. For
+                                  in-app purchases, sets the start date on the price
+                                  schedule entry.
+                                type: string
+                                format: date
+                                nullable: true
+                                example: '2026-04-01'
+                            additionalProperties: false
+                      additionalProperties: false
+                    availability:
+                      type: object
+                      properties:
+                        territories:
+                          description: Territories where the product is available.
+                            True = available, false = remove.
+                          type: object
+                          additionalProperties:
+                            type: boolean
+                            example: true
+                        available_in_new_territories:
+                          description: Availability default for newly added territories.
+                            Optional; when omitted, the current App Store Connect
+                            value is preserved.
+                          type: boolean
+                          example: true
+                      additionalProperties: false
+                    localizations:
+                      type: object
+                      nullable: true
+                      additionalProperties:
+                        type: object
+                        nullable: true
+                        required:
+                        - name
+                        - description
+                        properties:
+                          name:
+                            description: 'Localized product display name. App Store
+                              Connect limits: 30 characters for both subscriptions
+                              and in-app purchases.'
+                            type: string
+                            minLength: 1
+                            maxLength: 30
+                            example: Premium Monthly
+                          description:
+                            description: 'Localized product description. App Store
+                              Connect limits: 45 characters for both subscriptions
+                              and in-app purchases.'
+                            type: string
+                            minLength: 1
+                            maxLength: 45
+                            example: Access premium content every month.
+                        additionalProperties: false
+                    title:
+                      description: Optional product title used by create-if-missing
+                        flows.
+                      type: string
+                      nullable: true
+                      minLength: 1
+                      maxLength: 255
+                      example: Premium Monthly
+                    duration:
+                      description: Subscription duration. Required for subscription
+                        creation in create-if-missing flows. Canonical ISO-like durations
+                        are preferred, but legacy App Store Connect period values
+                        are accepted for backwards compatibility.
+                      type: string
+                      nullable: true
+                      enum:
+                      - P1W
+                      - P1M
+                      - P2M
+                      - P3M
+                      - P6M
+                      - P1Y
+                      - ONE_WEEK
+                      - ONE_MONTH
+                      - TWO_MONTHS
+                      - THREE_MONTHS
+                      - SIX_MONTHS
+                      - ONE_YEAR
+                      example: ONE_MONTH
+                  additionalProperties: false
+                store_state:
+                  description: Store-specific desired state. Must match the `store`
+                    discriminator.
+                  anyOf:
+                  - $ref: '#/components/schemas/ProductStoreStateAppStoreState'
+                  - $ref: '#/components/schemas/ProductStoreStatePlayStoreState'
+              additionalProperties: false
+            examples:
+              App Store product state:
+                value:
+                  store: app_store
+                  common:
+                    pricing:
+                      territory_prices:
+                        US:
+                          amount_micros: 9990000
+                          currency: USD
+                        CA:
+                          amount_micros: 9990000
+                          currency: USD
+                    availability:
+                      territories:
+                        US: true
+                        CA: true
+                      available_in_new_territories: true
+                    localizations:
+                      en-US:
+                        name: Premium Monthly
+                        description: Access premium content every month.
+                  store_state:
+                    subscription_group_name: Premium Subscriptions
+                    privacy_policy_url: https://example.com/privacy
+                    review_information:
+                      notes: Reviewing updated metadata and pricing.
+              Play Store product state:
+                value:
+                  store: play_store
+                  store_state:
+                    base_plans:
+                      monthly:
+                        state: ACTIVE
+                        auto_renewing_base_plan_type:
+                          billing_period_duration: P1M
+                        regional_configs:
+                          US:
+                            new_subscriber_availability: true
+                            price:
+                              amount_micros: 9990000
+                              currency: USD
+                        offer_tags:
+                        - free-trial
+                        - intro-discount
+                        offers:
+                          free-trial:
+                            state: ACTIVE
+                            offer_tags:
+                            - free-trial
+                            phases:
+                            - recurrence_count: 1
+                              duration: P1W
+                              regional_configs:
+                                US:
+                                  free: true
+                          intro-discount:
+                            state: ACTIVE
+                            offer_tags:
+                            - intro-discount
+                            phases:
+                            - recurrence_count: 3
+                              duration: P1M
+                              regional_configs:
+                                US:
+                                  price:
+                                    amount_micros: 4990000
+                                    currency: USD
+      responses:
+        '202':
+          description: Accepted. The product store state operation was queued.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - operation_id
+                - status
+                - polling_url
+                properties:
+                  operation_id:
+                    description: The ID of the queued store state operation.
+                    type: string
+                    minLength: 1
+                    maxLength: 255
+                    example: 4d5c046e-fadd-4d91-bd78-744fe44d314d
+                  status:
+                    description: Current status of the queued operation.
+                    type: string
+                    enum:
+                    - pending
+                    example: pending
+                  polling_url:
+                    description: Relative URL to poll operation status.
+                    type: string
+                    minLength: 1
+                    maxLength: 5000
+                    example: /v2/projects/proj1a2b3c4/products/prod1a2b3c4/store_state/4d5c046e-fadd-4d91-bd78-744fe44d314d
+                additionalProperties: false
+          headers:
+            RevenueCat-Rate-Limit-Current-Usage:
+              $ref: '#/components/headers/RateLimitCurrentUsage'
+            RevenueCat-Rate-Limit-Current-Limit:
+              $ref: '#/components/headers/RateLimitCurrentLimit'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '423':
+          $ref: '#/components/responses/Locked'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/InternalError'
+  /projects/{project_id}/products/{product_id}/store_state/actions/equalize_subscription_prices:
+    post:
+      summary: Equalize subscription prices for missing territories
+      description: "Enqueues an asynchronous operation that fills missing App Store\
+        \ subscription\nterritory prices using Apple's equalized price points derived\
+        \ from the\ncurrent price configured in a base territory.\n\nThis action does\
+        \ not modify sale availability. It only creates missing\nsubscription prices.\n\
+        \ This endpoint requires the following permission(s): <code>project_configuration:products:read_write</code>.\
+        \ This endpoint belongs to the <strong>Project Configuration</strong> domain,\
+        \ which has a default rate limit of <strong>60 requests per minute</strong>."
+      operationId: equalize-subscription-prices
+      x-revenuecat-rate-limiting-domain: project_configuration
+      x-scopes:
+      - project_configuration:products:read_write
+      x-release-status: development
+      x-revenuecat-mcp-include: true
+      x-revenuecat-mcp-description: 'Fills missing App Store subscription territory
+        prices by applying Apple equalizations from the current price configured in
+        `base_territory`.
+
+        Recommended flow: 1) Call get-product-store-state and inspect `warnings`.
+        2) If warnings indicate missing territory pricing coverage, call this endpoint.
+        3) Poll get-product-store-state-operation until status is ''succeeded'' or
+        ''failed''.'
+      x-revenuecat-release-gatekeeping: false
+      tags:
+      - Product
+      parameters:
+      - name: project_id
+        description: ID of the project
+        required: true
+        in: path
+        schema:
+          type: string
+          maxLength: 255
+          example: proj1ab2c3d4
+      - name: product_id
+        description: ID of the product
+        required: true
+        in: path
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: prod1a2b3c4d5
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - store
+              - base_territory
+              properties:
+                store:
+                  description: The target store for this operation.
+                  type: string
+                  enum:
+                  - app_store
+                  example: app_store
+                base_territory:
+                  description: 'Base territory used to resolve the source price point
+                    from the
+
+                    territory''s current App Store price (alpha-2 or alpha-3 code).
+
+                    '
+                  type: string
+                  minLength: 2
+                  maxLength: 3
+                  example: US
+              additionalProperties: false
+      responses:
+        '202':
+          description: Accepted. The equalization operation was queued.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - operation_id
+                - status
+                - polling_url
+                properties:
+                  operation_id:
+                    description: The ID of the queued operation.
+                    type: string
+                    minLength: 1
+                    maxLength: 255
+                    example: 4d5c046e-fadd-4d91-bd78-744fe44d314d
+                  status:
+                    description: Current status of the queued operation.
+                    type: string
+                    enum:
+                    - pending
+                    example: pending
+                  polling_url:
+                    description: Relative URL to poll operation status.
+                    type: string
+                    minLength: 1
+                    maxLength: 5000
+                    example: /v2/projects/proj1a2b3c4/products/prod1a2b3c4/store_state/4d5c046e-fadd-4d91-bd78-744fe44d314d
+                additionalProperties: false
+          headers:
+            RevenueCat-Rate-Limit-Current-Usage:
+              $ref: '#/components/headers/RateLimitCurrentUsage'
+            RevenueCat-Rate-Limit-Current-Limit:
+              $ref: '#/components/headers/RateLimitCurrentLimit'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '423':
+          $ref: '#/components/responses/Locked'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/InternalError'
+  /projects/{project_id}/products/{product_id}/store_state/{operation_id}:
+    get:
+      summary: Get a product store state operation
+      description: "Polls status/result of async operation started by POST /store_state.\n\
+        \ This endpoint requires the following permission(s): <code>project_configuration:products:read</code>.\
+        \ This endpoint belongs to the <strong>Project Configuration</strong> domain,\
+        \ which has a default rate limit of <strong>60 requests per minute</strong>."
+      operationId: get-product-store-state-operation
+      x-revenuecat-rate-limiting-domain: project_configuration
+      x-scopes:
+      - project_configuration:products:read
+      x-release-status: development
+      x-revenuecat-mcp-include: true
+      x-revenuecat-mcp-return-as-json: true
+      x-revenuecat-mcp-description: 'Polls the async operation created by set-product-store-state.
+
+        Keep polling until terminal status: - succeeded: operation completed - failed:
+        inspect error_message, adjust input, and retry the set call'
+      x-revenuecat-release-gatekeeping: false
+      tags:
+      - Product
+      parameters:
+      - name: project_id
+        description: ID of the project
+        required: true
+        in: path
+        schema:
+          type: string
+          maxLength: 255
+          example: proj1ab2c3d4
+      - name: product_id
+        description: ID of the product
+        required: true
+        in: path
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: prod1a2b3c4d5
+      - name: operation_id
+        description: ID of the operation
+        required: true
+        in: path
+        schema:
+          type: string
+          format: uuid
+          example: 4d5c046e-fadd-4d91-bd78-744fe44d314d
+      responses:
+        '200':
+          description: The current status/result for the operation.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - id
+                - product_id
+                - status
+                properties:
+                  id:
+                    description: Operation identifier.
+                    type: string
+                    minLength: 1
+                    maxLength: 255
+                    example: 4d5c046e-fadd-4d91-bd78-744fe44d314d
+                  product_id:
+                    description: The RevenueCat product identifier.
+                    type: string
+                    minLength: 1
+                    maxLength: 255
+                    example: prod1a2b3c4
+                  status:
+                    description: Current status for the operation.
+                    type: string
+                    enum:
+                    - pending
+                    - running
+                    - succeeded
+                    - failed
+                    example: failed
+                  error_message:
+                    description: Error message when status is failed.
+                    type: string
+                    nullable: true
+                    example: 'Conflict detected: territory ''ZZZ'' is invalid.'
+                  completed_at:
+                    description: Timestamp (ms since epoch) when the operation completed.
+                    type: integer
+                    format: int64
+                    nullable: true
+                    example: 1739383320000
+                additionalProperties: false
+          headers:
+            RevenueCat-Rate-Limit-Current-Usage:
+              $ref: '#/components/headers/RateLimitCurrentUsage'
+            RevenueCat-Rate-Limit-Current-Limit:
+              $ref: '#/components/headers/RateLimitCurrentLimit'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '423':
+          $ref: '#/components/responses/Locked'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/InternalError'
+  /projects/{project_id}/products/{product_id}/store_state/screenshot_upload:
+    post:
+      summary: Reserve a product store state screenshot upload
+      description: "Reserves an App Store Connect review screenshot upload slot for\
+        \ an existing\nproduct and returns upload operations that the client can use\
+        \ to upload\nscreenshot bytes directly to Apple.\n\nAfter upload, pass `screenshot_id`\
+        \ and `source_file_checksum` in\n`POST /store_state` under `store_state.review_information.screenshot`.\n\
+        \ This endpoint requires the following permission(s): <code>project_configuration:products:read_write</code>.\
+        \ This endpoint belongs to the <strong>Project Configuration</strong> domain,\
+        \ which has a default rate limit of <strong>60 requests per minute</strong>."
+      operationId: upload-product-store-state-screenshot
+      x-revenuecat-rate-limiting-domain: project_configuration
+      x-scopes:
+      - project_configuration:products:read_write
+      x-release-status: development
+      x-revenuecat-mcp-include: true
+      x-revenuecat-mcp-description: 'Reserves an App Store Connect review screenshot
+        slot and returns upload_operations.
+
+        Important: this tool does not upload bytes. Use each returned upload operation
+        to upload the file (including chunked uploads when multiple operations are
+        returned).
+
+        After upload completes, pass screenshot_id and source_file_checksum to set-product-store-state
+        under store_state.review_information.screenshot.'
+      x-revenuecat-release-gatekeeping: false
+      tags:
+      - Product
+      parameters:
+      - name: project_id
+        description: ID of the project
+        required: true
+        in: path
+        schema:
+          type: string
+          maxLength: 255
+          example: proj1ab2c3d4
+      - name: product_id
+        description: ID of the product
+        required: true
+        in: path
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: prod1a2b3c4d5
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - filename
+              - file_size
+              properties:
+                filename:
+                  description: Screenshot filename to reserve in App Store Connect.
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                  example: review.png
+                file_size:
+                  description: Screenshot file size in bytes.
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  example: 125000
+              additionalProperties: false
+      responses:
+        '200':
+          description: Screenshot upload slot successfully reserved.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - screenshot_id
+                properties:
+                  screenshot_id:
+                    description: App Store Connect screenshot identifier.
+                    type: string
+                    minLength: 1
+                    maxLength: 255
+                    example: asc_screenshot_123
+                  filename:
+                    description: Reserved filename echoed from App Store Connect.
+                    type: string
+                    nullable: true
+                    example: review.png
+                  file_size:
+                    description: Reserved file size echoed from App Store Connect.
+                    type: integer
+                    nullable: true
+                    format: int64
+                    minimum: 0
+                    example: 125000
+                  upload_operations:
+                    description: Upload operations for direct upload to Apple.
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      required:
+                      - method
+                      - url
+                      - length
+                      - offset
+                      properties:
+                        method:
+                          description: HTTP method for the upload operation.
+                          type: string
+                          example: PUT
+                        url:
+                          description: Presigned upload URL from App Store Connect.
+                          type: string
+                          example: https://example-upload-url
+                        length:
+                          description: Chunk length in bytes for this upload operation.
+                          type: integer
+                          format: int64
+                          minimum: 1
+                          example: 125000
+                        offset:
+                          description: Byte offset in the source file for this upload
+                            operation.
+                          type: integer
+                          format: int64
+                          minimum: 0
+                          example: 0
+                        request_headers:
+                          description: Headers required by App Store Connect for upload.
+                          type: array
+                          nullable: true
+                          items:
+                            type: object
+                            required:
+                            - name
+                            - value
+                            properties:
+                              name:
+                                description: Header name.
+                                type: string
+                                example: Content-Type
+                              value:
+                                description: Header value.
+                                type: string
+                                example: image/png
+                            additionalProperties: false
+                      additionalProperties: false
+                additionalProperties: false
+          headers:
+            RevenueCat-Rate-Limit-Current-Usage:
+              $ref: '#/components/headers/RateLimitCurrentUsage'
+            RevenueCat-Rate-Limit-Current-Limit:
+              $ref: '#/components/headers/RateLimitCurrentLimit'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '423':
+          $ref: '#/components/responses/Locked'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/InternalError'
+components:
+  headers:
+    RateLimitCurrentLimit:
+      required: true
+      description: The rate limit for this endpoint, expressed in requests per minute.
+      schema:
+        type: integer
+      example: 30
+    RateLimitCurrentUsage:
+      required: true
+      description: The current number of requests used for the current limit (including
+        the current request).
+      schema:
+        type: integer
+      example: 25
+    RateLimitRetryAfter:
+      required: true
+      description: The number of seconds to wait before retrying a rate limited request.Only
+        present when a request is rate limited.
+      schema:
+        type: integer
+      example: 10
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            allOf:
+            - $ref: '#/components/schemas/Error'
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - parameter_error
+                  - invalid_request
+          examples:
+            parameter_error:
+              value:
+                object: error
+                type: parameter_error
+                param: customer_id
+                message: id is too long
+                retryable: false
+                doc_url: https://errors.rev.cat/parameter-error
+            invalid_request:
+              value:
+                object: error
+                type: invalid_request
+                message: Content-Type not application/json
+                retryable: false
+                doc_url: https://errors.rev.cat/invalid-request
+    Conflict:
+      description: Conflict
+      content:
+        application/json:
+          schema:
+            allOf:
+            - $ref: '#/components/schemas/Error'
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - resource_already_exists
+                  - idempotency_error
+                  - invalid_request
+          examples:
+            resource_already_exists:
+              value:
+                object: error
+                type: resource_already_exists
+                message: Name is already taken
+                retryable: false
+                doc_url: https://errors.rev.cat/resource-already-exists
+            idempotency_error:
+              value:
+                object: error
+                type: idempotency_error
+                message: Idempotency key already used for a different request
+                retryable: false
+                doc_url: https://errors.rev.cat/idempotency-error
+            invalid_request:
+              value:
+                object: error
+                type: invalid_request
+                message: Request conflicts with the current resource state
+                retryable: false
+                doc_url: https://errors.rev.cat/invalid-request
+    Forbidden:
+      description: Access denied
+      content:
+        application/json:
+          schema:
+            allOf:
+            - $ref: '#/components/schemas/Error'
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - authorization_error
+            example:
+              object: error
+              type: authorization_error
+              message: You're not authorized to access this resource
+              retryable: false
+              doc_url: https://errors.rev.cat/authorization-error
+    InternalError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            allOf:
+            - $ref: '#/components/schemas/Error'
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - server_error
+            example:
+              object: error
+              type: server_error
+              message: There was an internal server error
+              retryable: true
+              doc_url: https://errors.rev.cat/server-error
+              backoff_ms: 1000
+    Locked:
+      description: Locked
+      content:
+        application/json:
+          schema:
+            allOf:
+            - $ref: '#/components/schemas/Error'
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - resource_locked_error
+            example:
+              object: error
+              type: resource_locked_error
+              message: The resource is currently being modified by a concurrent request
+              retryable: true
+              doc_url: https://errors.rev.cat/resource-locked-error
+              backoff_ms: 1000
+    NotFound:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            allOf:
+            - $ref: '#/components/schemas/Error'
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - resource_missing
+            example:
+              object: error
+              type: resource_missing
+              message: Resource not found
+              retryable: false
+              doc_url: https://errors.rev.cat/resource-missing
+    RateLimited:
+      description: The request could not be completed because the rate limiting domain
+        for this endpoint is currently at its limit for this project.
+      headers:
+        RevenueCat-Rate-Limit-Current-Usage:
+          $ref: '#/components/headers/RateLimitCurrentUsage'
+        RevenueCat-Rate-Limit-Current-Limit:
+          $ref: '#/components/headers/RateLimitCurrentLimit'
+        Retry-After:
+          $ref: '#/components/headers/RateLimitRetryAfter'
+      content:
+        application/json:
+          schema:
+            allOf:
+            - $ref: '#/components/schemas/Error'
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - rate_limit_error
+            example:
+              object: error
+              type: rate_limit_error
+              message: Rate limit exceeded
+              retryable: true
+              doc_url: https://errors.rev.cat/rate-limit-error
+              backoff_ms: 1000
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            allOf:
+            - $ref: '#/components/schemas/Error'
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - authentication_error
+            example:
+              object: error
+              type: authentication_error
+              message: Invalid API key
+              retryable: false
+              doc_url: https://errors.rev.cat/authentication-error
+    UnprocessableEntity:
+      description: Unprocessable entity
+      content:
+        application/json:
+          schema:
+            allOf:
+            - $ref: '#/components/schemas/Error'
+            - type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                  - unprocessable_entity_error
+                  - parameter_error
+                  - store_error
+                  - entity_references_archived_entities
+          examples:
+            unprocessable_entity:
+              value:
+                object: error
+                type: unprocessable_entity_error
+                message: Cannot delete a product that has purchases
+                retryable: false
+                doc_url: https://errors.rev.cat/unprocessable-entity-error
+            parameter_error:
+              value:
+                object: error
+                type: parameter_error
+                message: Date must in the future
+                retryable: false
+                doc_url: https://errors.rev.cat/parameter-error
+            store_error:
+              value:
+                object: error
+                type: store_error
+                message: There was a problem on the App Store
+                retryable: true
+                doc_url: https://errors.rev.cat/store-error
+                backoff_ms: 1000
+            entity_references_archived_entities:
+              value:
+                object: error
+                type: entity_references_archived_entities
+                message: This offering references inactive products. You will need
+                  to make the products active first before making the offering active.
+                retryable: false
+                doc_url: https://errors.rev.cat/entity-references-archived-entities
+                referenced_object_ids:
+                - prodabcd1234
+                - prodwxyz5678
+  schemas:
+    Error:
+      type: object
+      required:
+      - type
+      - message
+      - retryable
+      - object
+      properties:
+        object:
+          description: String representing the object's type. Objects of the same
+            type share the same value.
+          enum:
+          - error
+          type: string
+          example: error
+        type:
+          description: The error type
+          type: string
+          nullable: false
+          enum:
+          - parameter_error
+          - resource_already_exists
+          - resource_missing
+          - idempotency_error
+          - rate_limit_error
+          - authentication_error
+          - authorization_error
+          - store_error
+          - server_error
+          - resource_locked_error
+          - unprocessable_entity_error
+          - invalid_request
+          - entity_references_archived_entities
+          example: parameter_error
+        param:
+          description: If the error is parameter-specific, the parameter related to
+            the error
+          type: string
+          nullable: true
+          example: customer_id
+        doc_url:
+          description: A URL to more information about the error reported
+          type: string
+          nullable: false
+          example: https://errors.rev.cat/parameter-error
+        message:
+          type: string
+          description: A message describing the reason of the error
+          nullable: false
+          example: id shouldn't be longer than 1,500 characters
+        retryable:
+          description: Indicates if the error is retryable or not
+          type: boolean
+          nullable: false
+          example: false
+        backoff_ms:
+          description: The ms the client should wait before retrying the request.
+            Only present for retryable errors.
+          type: integer
+          nullable: true
+          example: null
+        referenced_object_ids:
+          description: The IDs of related objects relevant to the error, such as the
+            archived entities that need to be made active before the operation can
+            succeed.
+          type: array
+          items:
+            type: string
+          example:
+          - prodabcd1234
+          - prodwxyz5678
+      additionalProperties: false
+    PlayStoreBasePlanConfig:
+      type: object
+      description: Configuration for a single Play subscription base plan. Mirrors
+        Google's `BasePlan`. At most one of `auto_renewing_base_plan_type`, `prepaid_base_plan_type`,
+        or `installments_base_plan_type` may be set; setting more than one is rejected
+        at plan creation. Plan items that only modify regional/state/offer fields
+        may omit all three.
+      properties:
+        state:
+          description: Lifecycle state of the base plan.
+          type: string
+          nullable: true
+          enum:
+          - DRAFT
+          - ACTIVE
+          - INACTIVE
+          - null
+          example: ACTIVE
+        regional_configs:
+          description: Per-region availability and price overrides keyed by region
+            code.
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              new_subscriber_availability:
+                type: boolean
+                nullable: true
+                example: true
+              price:
+                $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+            additionalProperties: false
+        other_regions_config:
+          description: Default availability and pricing for regions without an explicit
+            `regional_configs` entry.
+          type: object
+          nullable: true
+          properties:
+            new_subscriber_availability:
+              type: boolean
+              nullable: true
+              example: true
+            usd_price:
+              $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+            eur_price:
+              $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+          additionalProperties: false
+        auto_renewing_base_plan_type:
+          description: Auto-renewing variant of the base plan.
+          type: object
+          nullable: true
+          required:
+          - billing_period_duration
+          properties:
+            billing_period_duration:
+              description: ISO-8601 duration string (e.g. `P1M`).
+              type: string
+              minLength: 2
+              maxLength: 64
+              example: P1M
+            grace_period_duration:
+              type: string
+              nullable: true
+              minLength: 2
+              maxLength: 64
+              example: P3D
+            account_hold_duration:
+              type: string
+              nullable: true
+              minLength: 2
+              maxLength: 64
+              example: P30D
+            resubscribe_state:
+              type: string
+              nullable: true
+              enum:
+              - RESUBSCRIBE_STATE_UNSPECIFIED
+              - RESUBSCRIBE_STATE_ACTIVE
+              - RESUBSCRIBE_STATE_INACTIVE
+              - null
+              example: RESUBSCRIBE_STATE_ACTIVE
+            proration_mode:
+              type: string
+              nullable: true
+              enum:
+              - SUBSCRIPTION_PRORATION_MODE_UNSPECIFIED
+              - SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE
+              - SUBSCRIPTION_PRORATION_MODE_CHARGE_FULL_PRICE_IMMEDIATELY
+              - null
+              example: SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE
+            legacy_compatible:
+              type: boolean
+              nullable: true
+              example: false
+            legacy_compatible_subscription_offer_id:
+              type: string
+              nullable: true
+              maxLength: 255
+              example: legacy-offer
+          additionalProperties: false
+        prepaid_base_plan_type:
+          description: Prepaid variant of the base plan.
+          type: object
+          nullable: true
+          required:
+          - billing_period_duration
+          properties:
+            billing_period_duration:
+              type: string
+              minLength: 2
+              maxLength: 64
+              example: P1M
+            time_extension:
+              type: string
+              nullable: true
+              enum:
+              - TIME_EXTENSION_UNSPECIFIED
+              - TIME_EXTENSION_ACTIVE
+              - TIME_EXTENSION_INACTIVE
+              - null
+              example: TIME_EXTENSION_ACTIVE
+          additionalProperties: false
+        installments_base_plan_type:
+          description: Installments variant of the base plan.
+          type: object
+          nullable: true
+          required:
+          - billing_period_duration
+          - committed_payments_count
+          - renewal_type
+          properties:
+            billing_period_duration:
+              type: string
+              minLength: 2
+              maxLength: 64
+              example: P1M
+            committed_payments_count:
+              type: integer
+              minimum: 1
+              example: 12
+            renewal_type:
+              type: string
+              enum:
+              - RENEWAL_TYPE_UNSPECIFIED
+              - RENEWAL_TYPE_RENEWS_WITHOUT_COMMITMENT
+              - RENEWAL_TYPE_RENEWS_WITH_COMMITMENT
+              example: RENEWAL_TYPE_RENEWS_WITHOUT_COMMITMENT
+            grace_period_duration:
+              type: string
+              nullable: true
+              minLength: 2
+              maxLength: 64
+              example: P3D
+            account_hold_duration:
+              type: string
+              nullable: true
+              minLength: 2
+              maxLength: 64
+              example: P30D
+            resubscribe_state:
+              type: string
+              nullable: true
+              enum:
+              - RESUBSCRIBE_STATE_UNSPECIFIED
+              - RESUBSCRIBE_STATE_ACTIVE
+              - RESUBSCRIBE_STATE_INACTIVE
+              - null
+              example: RESUBSCRIBE_STATE_ACTIVE
+            proration_mode:
+              type: string
+              nullable: true
+              enum:
+              - SUBSCRIPTION_PRORATION_MODE_UNSPECIFIED
+              - SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE
+              - SUBSCRIPTION_PRORATION_MODE_CHARGE_FULL_PRICE_IMMEDIATELY
+              - null
+              example: SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE
+          additionalProperties: false
+        offer_tags:
+          description: Free-form tags attached to the base plan.
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 255
+            example: launch-promo
+        offers:
+          description: "Subscription offers attached to this base plan, keyed by `offer_id`\
+            \ (1-63 lowercase alphanumerics or hyphens). Each value is a `PlayStoreOfferConfig`:\n\
+            \n- `state`: `DRAFT` | `ACTIVE` | `INACTIVE` (defaults to `DRAFT`; an\n\
+            \  `ACTIVE` offer must define at least one phase).\n\n- `phases`: ordered\
+            \ list of `{ recurrence_count (int >= 1),\n  duration (ISO-8601, e.g.\
+            \ P1W), regional_configs{ <region>: { EXACTLY\n  ONE of `price` (`{ amount_micros,\
+            \ currency }`) / `free: true` /\n  `absolute_discount` (`{ amount_micros,\
+            \ currency }`) /\n  `relative_discount` (fraction in `[0, 1]`) } }, other_regions_config?\
+            \ }`.\n\n- `regional_configs`: per-region `{ new_subscriber_availability\
+            \ }`\n  overrides keyed by region code.\n\n- `other_regions_config`, `targeting`\n\
+            \  (`{ acquisition_rule?, upgrade_rule? }`, at most one), and\n  `offer_tags`\
+            \ (array of strings) are all optional."
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/PlayStoreOfferConfig'
+          example:
+            welcome-offer:
+              state: ACTIVE
+              phases:
+              - recurrence_count: 1
+                duration: P1W
+                regional_configs:
+                  US:
+                    free: true
+              offer_tags:
+              - launch-promo
+      additionalProperties: false
+    PlayStoreOfferConfig:
+      type: object
+      description: "A single subscription offer attached to a base plan (keyed by\
+        \ `offer_id` on the parent base plan's `offers` map). Fields:\n\n- `state`:\
+        \ `DRAFT` | `ACTIVE` | `INACTIVE` (defaults to `ACTIVE` on create).\n  An\
+        \ offer created with `state: ACTIVE` must define at least one phase.\n\n-\
+        \ `phases`: ordered list of phases (see `PlayStorePhaseConfig`). Each phase\n\
+        \  is `{ recurrence_count (int >= 1), duration (ISO-8601, e.g. P1W),\n  regional_configs{\
+        \ <region>: { one of price / free / absolute_discount /\n  relative_discount\
+        \ } }, other_regions_config? }`.\n\n- `regional_configs`: per-region availability\
+        \ overrides keyed by region\n  code, each `{ new_subscriber_availability:\
+        \ bool }`.\n\n- `other_regions_config`: availability fallback for regions\
+        \ without an\n  explicit `regional_configs` entry.\n\n- `targeting`: optional\
+        \ `{ acquisition_rule? , upgrade_rule? }`; at most one\n  of the two.\n\n\
+        - `offer_tags`: optional array of strings."
+      properties:
+        state:
+          description: Lifecycle state of the offer.
+          type: string
+          nullable: true
+          enum:
+          - DRAFT
+          - ACTIVE
+          - INACTIVE
+          - null
+          example: ACTIVE
+        phases:
+          description: 'Ordered list of offer phases. Each item is a `PlayStorePhaseConfig`:
+            `{ recurrence_count (int >= 1), duration (ISO-8601 string, e.g. `P1W`),
+            regional_configs{ <region_code>: { EXACTLY ONE of price / relative_discount
+            / absolute_discount / free: true } }, other_regions_config? }`. A phase
+            must define at least one `regional_configs` entry or `other_regions_config`.
+            Example: a free trial phase followed by a discounted introductory phase.'
+          type: array
+          items:
+            $ref: '#/components/schemas/PlayStorePhaseConfig'
+          example:
+          - recurrence_count: 1
+            duration: P1W
+            regional_configs:
+              US:
+                free: true
+          - recurrence_count: 3
+            duration: P1M
+            regional_configs:
+              US:
+                price:
+                  amount_micros: 4990000
+                  currency: USD
+        regional_configs:
+          description: Per-region availability overrides keyed by region code.
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              new_subscriber_availability:
+                type: boolean
+                nullable: true
+                example: true
+            additionalProperties: false
+        other_regions_config:
+          description: Default availability for regions without an explicit `regional_configs`
+            entry.
+          type: object
+          nullable: true
+          properties:
+            other_regions_new_subscriber_availability:
+              type: boolean
+              nullable: true
+              example: true
+          additionalProperties: false
+        targeting:
+          description: Targeting rule. At most one of `acquisition_rule` or `upgrade_rule`
+            should be set; leaving both unset means developer-determined offer eligibility.
+          type: object
+          nullable: true
+          properties:
+            acquisition_rule:
+              type: object
+              nullable: true
+              additionalProperties: true
+            upgrade_rule:
+              type: object
+              nullable: true
+              additionalProperties: true
+          additionalProperties: false
+        offer_tags:
+          description: Free-form tags attached to the offer.
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 255
+            example: launch-promo
+      additionalProperties: false
+    PlayStoreOneTimeOfferConfig:
+      type: object
+      description: A pre-order or discounted offer attached to a Play one-time product
+        purchase option. At most one of `pre_order_offer` or `discounted_offer` may
+        be set in one payload; create flows require one offer type.
+      properties:
+        state:
+          description: Lifecycle state of the one-time product offer.
+          type: string
+          nullable: true
+          enum:
+          - DRAFT
+          - ACTIVE
+          - CANCELLED
+          - INACTIVE
+          - null
+          example: DRAFT
+        regional_configs:
+          description: Per-region availability and price overrides keyed by region
+            code.
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/PlayStoreOneTimeOfferRegionalConfig'
+          example:
+            US:
+              availability: AVAILABLE
+              relative_discount: 0.5
+        offer_tags:
+          description: Free-form tags attached to the one-time product offer.
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 255
+            example: launch-promo
+        pre_order_offer:
+          description: Pre-order offer configuration. Mutually exclusive with `discounted_offer`.
+          nullable: true
+          $ref: '#/components/schemas/PlayStoreOneTimeOfferPreOrderConfig'
+        discounted_offer:
+          description: Discounted offer configuration. Mutually exclusive with `pre_order_offer`.
+          nullable: true
+          $ref: '#/components/schemas/PlayStoreOneTimeOfferDiscountedConfig'
+      additionalProperties: false
+    PlayStoreOneTimeOfferDiscountedConfig:
+      type: object
+      description: Discounted variant of a Play one-time product offer.
+      properties:
+        start_time:
+          description: Optional date-time when the discounted offer starts.
+          type: string
+          nullable: true
+          format: date-time
+          example: '2026-01-01T00:00:00Z'
+        end_time:
+          description: Optional date-time when the discounted offer ends.
+          type: string
+          nullable: true
+          format: date-time
+          example: '2026-01-31T00:00:00Z'
+        redemption_limit:
+          description: Maximum redemptions per user. Omit or set 0 for unlimited.
+          type: integer
+          nullable: true
+          minimum: 0
+          maximum: 50
+          example: 10
+      additionalProperties: false
+    PlayStoreOneTimeOfferPreOrderConfig:
+      type: object
+      description: Pre-order variant of a Play one-time product offer.
+      required:
+      - start_time
+      - end_time
+      - release_time
+      - price_change_behavior
+      properties:
+        start_time:
+          description: Date-time when the pre-order offer starts.
+          type: string
+          format: date-time
+          example: '2026-01-01T00:00:00Z'
+        end_time:
+          description: Date-time when the pre-order offer ends.
+          type: string
+          format: date-time
+          example: '2026-01-31T00:00:00Z'
+        release_time:
+          description: Date-time when the product is released.
+          type: string
+          format: date-time
+          example: '2026-02-01T00:00:00Z'
+        price_change_behavior:
+          description: How Play handles pre-order price changes before release.
+          type: string
+          enum:
+          - PRE_ORDER_PRICE_CHANGE_BEHAVIOR_UNSPECIFIED
+          - PRE_ORDER_PRICE_CHANGE_BEHAVIOR_TWO_POINT_LOWEST
+          - PRE_ORDER_PRICE_CHANGE_BEHAVIOR_NEW_ORDERS_ONLY
+          example: PRE_ORDER_PRICE_CHANGE_BEHAVIOR_NEW_ORDERS_ONLY
+      additionalProperties: false
+    PlayStoreOneTimeOfferRegionalConfig:
+      type: object
+      description: Per-region availability and price override for a Play one-time
+        product offer.
+      properties:
+        availability:
+          description: Offer availability in this region.
+          type: string
+          nullable: true
+          enum:
+          - AVAILABLE
+          - NO_LONGER_AVAILABLE
+          - AVAILABLE_IF_RELEASED
+          - AVAILABLE_FOR_OFFERS_ONLY
+          - null
+          example: AVAILABLE
+        no_override:
+          description: Set to `true` to use the purchase option price without a regional
+            offer override. Omit the field to leave the override unspecified; `false`
+            is rejected.
+          type: boolean
+          nullable: true
+          example: true
+        relative_discount:
+          description: Relative discount fraction, strictly between 0 and 1, following
+            Google Play's `relativeDiscount` semantics.
+          type: number
+          nullable: true
+          minimum: 0
+          exclusiveMinimum: true
+          maximum: 1
+          exclusiveMaximum: true
+          example: 0.5
+        absolute_discount:
+          description: Absolute discount amount for this region.
+          $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+      additionalProperties: false
+    PlayStorePhaseConfig:
+      type: object
+      description: A single phase within a subscription offer (e.g. a 1-week free
+        trial, or a 3-month introductory price). Phases are ordered; `recurrence_count`
+        and `duration` are required. Pricing is set per region in `regional_configs`
+        and/or as a fallback in `other_regions_config`; a phase must define at least
+        one of the two.
+      required:
+      - recurrence_count
+      - duration
+      properties:
+        recurrence_count:
+          description: Number of times this phase repeats.
+          type: integer
+          minimum: 1
+          example: 1
+        duration:
+          description: ISO-8601 duration string (e.g. `P1W`).
+          type: string
+          minLength: 2
+          maxLength: 64
+          example: P1W
+        regional_configs:
+          description: "Per-region price override, keyed by region code (e.g. `US`,\
+            \ `GB`). Each value is a regional config object that sets EXACTLY ONE\
+            \ of the following mutually exclusive pricing fields (a discriminated\
+            \ union — setting zero or more than one is rejected with a 400):\n\n-\
+            \ `price`: absolute price, a `{ amount_micros, currency }` object\n  (e.g.\
+            \ `{ \"amount_micros\": 9990000, \"currency\": \"GBP\" }`).\n\n- `free`:\
+            \ the boolean literal `true` for a free phase. NOTE: this is a\n  boolean,\
+            \ not an object — use `\"free\": true`, never `{}` or a price\n  object.\n\
+            \n- `absolute_discount`: a fixed amount off, as a\n  `{ amount_micros,\
+            \ currency }` object.\n\n- `relative_discount`: a fraction off in `[0,\
+            \ 1]`\n  (e.g. `0.5` = 50% off)."
+          type: object
+          additionalProperties:
+            type: object
+            description: 'Per-region phase pricing. Set EXACTLY ONE of `price` / `relative_discount`
+              / `absolute_discount` / `free: true`.'
+            properties:
+              price:
+                $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+              relative_discount:
+                description: Relative discount expressed as a fraction (e.g. `0.5`
+                  = 50% off).
+                type: number
+                nullable: true
+                minimum: 0
+                maximum: 1
+                example: 0.5
+              absolute_discount:
+                $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+              free:
+                description: Set to `true` to make this phase free in the region.
+                  Boolean literal, not an object.
+                type: boolean
+                nullable: true
+                example: true
+            additionalProperties: false
+          example:
+            US:
+              free: true
+            GB:
+              price:
+                amount_micros: 9990000
+                currency: GBP
+        other_regions_config:
+          description: 'Default price override for regions without an explicit `regional_configs`
+            entry. Set EXACTLY ONE pricing option: both `other_regions_usd_price`
+            and `other_regions_eur_price` together, OR `relative_discount`, OR both
+            `absolute_discount_usd` and `absolute_discount_eur` together, OR `free:
+            true`.'
+          type: object
+          nullable: true
+          properties:
+            other_regions_usd_price:
+              $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+            other_regions_eur_price:
+              $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+            relative_discount:
+              type: number
+              nullable: true
+              minimum: 0
+              maximum: 1
+              example: 0.5
+            absolute_discount_usd:
+              $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+            absolute_discount_eur:
+              $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+            free:
+              description: Set to `true` to make this phase free in fallback regions.
+                Boolean literal, not an object.
+              type: boolean
+              nullable: true
+              example: true
+          additionalProperties: false
+      additionalProperties: false
+    PlayStorePurchaseOptionBuyOptionConfig:
+      type: object
+      description: Buy variant of a Play one-time product purchase option.
+      properties:
+        legacy_compatible:
+          description: Whether this buy option is visible to legacy Play Billing Library
+            clients.
+          type: boolean
+          nullable: true
+          example: true
+        multi_quantity_enabled:
+          description: Whether users can buy multiple quantities of this purchase
+            option.
+          type: boolean
+          nullable: true
+          example: false
+      additionalProperties: false
+    PlayStorePurchaseOptionConfig:
+      type: object
+      description: Configuration for a single Play one-time product purchase option.
+        At most one of `buy_option` or `rent_option` may be set in one payload; create
+        flows require one purchase option type.
+      properties:
+        state:
+          description: Lifecycle state of the purchase option.
+          type: string
+          nullable: true
+          enum:
+          - DRAFT
+          - ACTIVE
+          - INACTIVE
+          - INACTIVE_PUBLISHED
+          - null
+          example: ACTIVE
+        regional_configs:
+          description: Per-region availability and price keyed by region code.
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/PlayStorePurchaseOptionRegionalConfig'
+          example:
+            US:
+              availability: AVAILABLE
+              price:
+                amount_micros: 4990000
+                currency: USD
+        new_regions_config:
+          description: Default availability and pricing for new Play regions.
+          nullable: true
+          $ref: '#/components/schemas/PlayStorePurchaseOptionNewRegionsConfig'
+        buy_option:
+          description: Buy purchase option configuration. Mutually exclusive with
+            `rent_option`.
+          nullable: true
+          $ref: '#/components/schemas/PlayStorePurchaseOptionBuyOptionConfig'
+        rent_option:
+          description: Rent purchase option configuration. Mutually exclusive with
+            `buy_option`.
+          nullable: true
+          $ref: '#/components/schemas/PlayStorePurchaseOptionRentOptionConfig'
+        offer_tags:
+          description: Free-form tags attached to the purchase option.
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 255
+            example: one-time
+        tax_and_compliance:
+          description: Purchase-option-level tax and compliance settings.
+          nullable: true
+          $ref: '#/components/schemas/PlayStorePurchaseOptionTaxAndComplianceConfig'
+        offers:
+          description: One-time product offers keyed by `offer_id`.
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/PlayStoreOneTimeOfferConfig'
+          example:
+            launch-offer:
+              state: DRAFT
+              regional_configs:
+                US:
+                  availability: AVAILABLE
+                  relative_discount: 0.5
+              discounted_offer:
+                redemption_limit: 10
+              offer_tags:
+              - launch-promo
+      additionalProperties: false
+    PlayStorePurchaseOptionNewRegionsConfig:
+      type: object
+      description: Default availability and pricing for new Play regions on a one-time
+        purchase option.
+      properties:
+        usd_price:
+          description: USD fallback price for new regions.
+          $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+        eur_price:
+          description: EUR fallback price for new regions.
+          $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+        availability:
+          description: Availability applied to new regions.
+          type: string
+          nullable: true
+          enum:
+          - AVAILABLE
+          - NO_LONGER_AVAILABLE
+          - AVAILABLE_IF_RELEASED
+          - AVAILABLE_FOR_OFFERS_ONLY
+          - null
+          example: AVAILABLE
+      additionalProperties: false
+    PlayStorePurchaseOptionRegionalConfig:
+      type: object
+      description: Per-region availability and price for a Play one-time product purchase
+        option.
+      properties:
+        availability:
+          description: Availability of the purchase option in this region.
+          type: string
+          nullable: true
+          enum:
+          - AVAILABLE
+          - NO_LONGER_AVAILABLE
+          - AVAILABLE_IF_RELEASED
+          - AVAILABLE_FOR_OFFERS_ONLY
+          - null
+          example: AVAILABLE
+        price:
+          description: Price for this purchase option in the region.
+          $ref: '#/components/schemas/PlayStoreTerritoryPrice'
+      additionalProperties: false
+    PlayStorePurchaseOptionRentOptionConfig:
+      type: object
+      description: Rent variant of a Play one-time product purchase option.
+      required:
+      - rental_period
+      properties:
+        rental_period:
+          description: ISO-8601 duration for the rental period.
+          type: string
+          minLength: 2
+          maxLength: 64
+          example: P30D
+        expiration_period:
+          description: Optional ISO-8601 duration after which the rental expires.
+          type: string
+          nullable: true
+          minLength: 2
+          maxLength: 64
+          example: P7D
+      additionalProperties: false
+    PlayStorePurchaseOptionTaxAndComplianceConfig:
+      type: object
+      description: Purchase-option-level tax and compliance settings.
+      properties:
+        withdrawal_right_type:
+          description: Withdrawal right type for this purchase option.
+          type: string
+          nullable: true
+          enum:
+          - WITHDRAWAL_RIGHT_TYPE_UNSPECIFIED
+          - WITHDRAWAL_RIGHT_DIGITAL_CONTENT
+          - WITHDRAWAL_RIGHT_SERVICE
+          - null
+          example: WITHDRAWAL_RIGHT_DIGITAL_CONTENT
+      additionalProperties: false
+    PlayStoreRegionalProductAgeRatingInfo:
+      type: object
+      description: Per-region age-rating override.
+      required:
+      - region_code
+      - product_age_rating_tier
+      properties:
+        region_code:
+          description: ISO region code.
+          type: string
+          minLength: 1
+          maxLength: 255
+          example: US
+        product_age_rating_tier:
+          description: Age-rating tier for the region. Values come from Google's `ProductAgeRatingTier`
+            enum.
+          type: string
+          enum:
+          - PRODUCT_AGE_RATING_TIER_UNKNOWN
+          - PRODUCT_AGE_RATING_TIER_EVERYONE
+          - PRODUCT_AGE_RATING_TIER_THIRTEEN_AND_ABOVE
+          - PRODUCT_AGE_RATING_TIER_SIXTEEN_AND_ABOVE
+          - PRODUCT_AGE_RATING_TIER_EIGHTEEN_AND_ABOVE
+          example: PRODUCT_AGE_RATING_TIER_EVERYONE
+      additionalProperties: false
+    PlayStoreRegionalTaxRateInfo:
+      type: object
+      description: Per-region tax-rate hint used by Google's tax calculation. All
+        fields are optional; an absent field means "no override for this region".
+      properties:
+        eligible_for_streaming_service_tax_rate:
+          description: Whether the region is eligible for the streaming-service tax
+            rate.
+          type: boolean
+          nullable: true
+          example: false
+        streaming_tax_type:
+          description: Streaming-tax-type code.
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 255
+          example: STREAMING_TAX_TYPE_AUDIO_VIDEO
+        tax_tier:
+          description: Tax-tier code.
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 255
+          example: TIER_1
+      additionalProperties: false
+    PlayStoreRestrictedPaymentCountriesConfig:
+      type: object
+      description: Subscription-level list of region codes where payment is restricted.
+        Lives on the parent subscription; must agree across plan items targeting the
+        same `subscription_id`. Shared by request and response shapes.
+      required:
+      - region_codes
+      properties:
+        region_codes:
+          description: ISO region codes where payment is restricted.
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 255
+            example: US
+      additionalProperties: false
+    PlayStoreTaxAndComplianceConfig:
+      type: object
+      description: Product-level tax and compliance settings. For subscriptions this
+        lives on the parent subscription in Google's API and must agree across plan
+        items targeting the same `subscription_id`. Shared by request and response
+        shapes.
+      properties:
+        eea_withdrawal_right_type:
+          description: EEA withdrawal-right type code. Only supported for subscriptions;
+            one-time products configure withdrawal rights per purchase option via
+            `tax_and_compliance.withdrawal_right_type`.
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 255
+          example: WITHDRAWAL_RIGHT_DIGITAL_CONTENT
+        tax_rate_info_by_region_code:
+          description: Per-region tax-rate hints used by Google's tax calculation.
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/PlayStoreRegionalTaxRateInfo'
+          example:
+            US:
+              tax_tier: TIER_1
+        is_tokenized_digital_asset:
+          description: Whether the product represents a tokenized digital asset.
+          type: boolean
+          nullable: true
+          example: false
+        regional_product_age_rating_infos:
+          description: Per-region age-rating overrides.
+          type: array
+          items:
+            $ref: '#/components/schemas/PlayStoreRegionalProductAgeRatingInfo'
+          example:
+          - region_code: US
+            product_age_rating_tier: PRODUCT_AGE_RATING_TIER_EVERYONE
+        product_tax_category_code:
+          description: Product tax-category code.
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 255
+          example: DIGITAL_GOODS
+      additionalProperties: false
+    PlayStoreTerritoryPrice:
+      type: object
+      nullable: true
+      description: Territory price expressed in micros, mirroring App Store inputs.
+        The Play driver converts to/from Google's `Money{units, nanos, currencyCode}`
+        at the API boundary.
+      required:
+      - amount_micros
+      properties:
+        amount_micros:
+          description: Price amount in micros (1 unit = 1_000_000 micros).
+          type: integer
+          format: int64
+          minimum: 0
+          example: 9990000
+        currency:
+          description: ISO-4217 currency code.
+          type: string
+          minLength: 3
+          maxLength: 3
+          example: USD
+      additionalProperties: false
+    ProductStoreStateAppStoreState:
+      type: object
+      properties:
+        subscription_group_localizations:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: object
+            nullable: true
+            required:
+            - name
+            properties:
+              name:
+                description: Localized subscription group name.
+                type: string
+                minLength: 1
+                maxLength: 255
+                example: Premium Subscriptions
+              custom_app_name:
+                description: Custom app name shown in App Store subscription UI.
+                type: string
+                nullable: true
+                minLength: 1
+                maxLength: 255
+                example: MagicWeather
+            additionalProperties: false
+        subscription_group_name:
+          description: Optional subscription group name used when creating a missing
+            App Store subscription. If omitted, defaults to `Default`.
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 255
+          example: Premium Subscriptions
+        trial_offer:
+          description: Free trial introductory offer for the subscription. Applied
+            uniformly to all territories.
+          type: object
+          nullable: true
+          required:
+          - duration
+          properties:
+            duration:
+              description: Trial offer duration.
+              type: string
+              enum:
+              - THREE_DAYS
+              - ONE_WEEK
+              - TWO_WEEKS
+              - ONE_MONTH
+              - TWO_MONTHS
+              - THREE_MONTHS
+              - SIX_MONTHS
+              - ONE_YEAR
+              example: ONE_WEEK
+            start_date:
+              description: Optional start date for newly created introductory offers.
+              type: string
+              nullable: true
+              format: date
+              example: '2026-05-01'
+          additionalProperties: false
+        preserve_current_subscription_price:
+          description: When true, existing App Store subscription subscribers keep
+            their current price when a new subscription price is scheduled.
+          type: boolean
+          nullable: true
+          example: true
+        privacy_policy_url:
+          description: Privacy policy URL shown in App Store metadata.
+          type: string
+          nullable: true
+          format: uri
+          maxLength: 5000
+          example: https://example.com/privacy
+        review_information:
+          type: object
+          nullable: true
+          properties:
+            screenshot:
+              description: Review screenshot configuration. If omitted or null, a
+                placeholder screenshot is uploaded automatically so the product can
+                reach READY_TO_SUBMIT state.
+              type: object
+              nullable: true
+              properties:
+                screenshot_id:
+                  description: App Store Connect screenshot identifier.
+                  type: string
+                  nullable: true
+                  minLength: 1
+                  maxLength: 255
+                  example: asc_screenshot_123
+                filename:
+                  description: Original screenshot filename.
+                  type: string
+                  nullable: true
+                  minLength: 1
+                  maxLength: 255
+                  example: review.png
+                file_size:
+                  description: Screenshot size in bytes.
+                  type: integer
+                  nullable: true
+                  format: int64
+                  minimum: 0
+                  example: 125000
+                source_file_checksum:
+                  description: MD5 checksum of the uploaded source file.
+                  type: string
+                  nullable: true
+                  minLength: 1
+                  maxLength: 255
+                  example: d41d8cd98f00b204e9800998ecf8427e
+              additionalProperties: false
+            notes:
+              description: App review notes for this product.
+              type: string
+              nullable: true
+              maxLength: 4000
+              example: Screenshot uploaded through screenshot_upload endpoint.
+          additionalProperties: false
+      additionalProperties: false
+    ProductStoreStateAppStoreStateResponse:
+      type: object
+      nullable: true
+      properties:
+        subscription_group_localizations:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: object
+            nullable: true
+            required:
+            - name
+            properties:
+              name:
+                description: Localized subscription group name.
+                type: string
+                minLength: 1
+                maxLength: 255
+                example: Premium Subscriptions
+              custom_app_name:
+                description: Custom app name shown in App Store subscription UI.
+                type: string
+                nullable: true
+                minLength: 1
+                maxLength: 255
+                example: MagicWeather
+            additionalProperties: false
+        subscription_group_name:
+          description: Optional subscription group name used when creating a missing
+            App Store subscription. If omitted, defaults to `Default`.
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 255
+          example: Premium Subscriptions
+        trial_offer:
+          description: Free trial introductory offer for the subscription. Applied
+            uniformly to all territories.
+          type: object
+          nullable: true
+          required:
+          - duration
+          properties:
+            duration:
+              description: Trial offer duration.
+              type: string
+              enum:
+              - THREE_DAYS
+              - ONE_WEEK
+              - TWO_WEEKS
+              - ONE_MONTH
+              - TWO_MONTHS
+              - THREE_MONTHS
+              - SIX_MONTHS
+              - ONE_YEAR
+              example: ONE_WEEK
+          additionalProperties: false
+        preserve_current_subscription_price:
+          description: Whether App Store Connect returns any preserved subscription
+            price for existing subscribers.
+          type: boolean
+          nullable: true
+          example: true
+        privacy_policy_url:
+          description: Privacy policy URL shown in App Store metadata.
+          type: string
+          nullable: true
+          format: uri
+          maxLength: 5000
+          example: https://example.com/privacy
+        review_information:
+          type: object
+          nullable: true
+          properties:
+            screenshot:
+              description: Review screenshot configuration. If omitted or null, a
+                placeholder screenshot is uploaded automatically so the product can
+                reach READY_TO_SUBMIT state.
+              type: object
+              nullable: true
+              properties:
+                screenshot_id:
+                  description: App Store Connect screenshot identifier.
+                  type: string
+                  nullable: true
+                  minLength: 1
+                  maxLength: 255
+                  example: asc_screenshot_123
+                filename:
+                  description: Original screenshot filename.
+                  type: string
+                  nullable: true
+                  minLength: 1
+                  maxLength: 255
+                  example: review.png
+                file_size:
+                  description: Screenshot size in bytes.
+                  type: integer
+                  nullable: true
+                  format: int64
+                  minimum: 0
+                  example: 125000
+                source_file_checksum:
+                  description: MD5 checksum of the uploaded source file.
+                  type: string
+                  nullable: true
+                  minLength: 1
+                  maxLength: 255
+                  example: d41d8cd98f00b204e9800998ecf8427e
+              additionalProperties: false
+            notes:
+              description: App review notes for this product.
+              type: string
+              nullable: true
+              maxLength: 4000
+              example: Screenshot uploaded through screenshot_upload endpoint.
+          additionalProperties: false
+      additionalProperties: false
+    ProductStoreStateCommonResponse:
+      type: object
+      nullable: true
+      properties:
+        pricing:
+          type: object
+          properties:
+            territory_prices:
+              type: object
+              additionalProperties:
+                type: object
+                required:
+                - amount_micros
+                properties:
+                  amount_micros:
+                    description: Territory price amount in micros.
+                    type: integer
+                    format: int64
+                    minimum: 0
+                    example: 9990000
+                  currency:
+                    description: ISO currency code for this territory price.
+                    type: string
+                    minLength: 3
+                    maxLength: 3
+                    example: USD
+                  start_date:
+                    description: ISO-8601 date (YYYY-MM-DD) when this price takes
+                      effect. Present when the next effective price for the territory
+                      is scheduled in the future.
+                    type: string
+                    format: date
+                    nullable: true
+                    example: '2026-05-01'
+                  subscription_price_point_id:
+                    description: Optional App Store Connect price point identifier.
+                    type: string
+                    nullable: true
+                    minLength: 1
+                    maxLength: 255
+                    example: null
+                additionalProperties: false
+          additionalProperties: false
+        availability:
+          type: object
+          properties:
+            territories:
+              description: Territories where the product is available. True = available,
+                false = remove.
+              type: object
+              additionalProperties:
+                type: boolean
+                example: true
+            available_in_new_territories:
+              description: Availability default for newly added territories. Optional;
+                when omitted, the current App Store Connect value is preserved.
+              type: boolean
+              example: true
+          additionalProperties: false
+        localizations:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: object
+            nullable: true
+            required:
+            - name
+            - description
+            properties:
+              name:
+                description: Localized product display name.
+                type: string
+                minLength: 1
+                maxLength: 255
+                example: Premium Monthly
+              description:
+                description: Localized product description.
+                type: string
+                nullable: true
+                minLength: 1
+                maxLength: 4000
+                example: Access premium content every month.
+            additionalProperties: false
+        title:
+          description: Optional product title used by create-if-missing flows.
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 255
+          example: Premium Monthly
+        duration:
+          description: Subscription duration. App Store product store state operations
+            return this value using App Store Connect period names for backwards compatibility.
+          type: string
+          nullable: true
+          enum:
+          - ONE_WEEK
+          - ONE_MONTH
+          - TWO_MONTHS
+          - THREE_MONTHS
+          - SIX_MONTHS
+          - ONE_YEAR
+          - null
+          example: ONE_MONTH
+      additionalProperties: false
+    ProductStoreStatePlayStoreState:
+      type: object
+      description: Play Store specific desired state for a single plan item. Subscriptions
+        use `base_plans` keyed by `base_plan_id`; one-time products use `purchase_options`
+        keyed by `purchase_option_id`. Do not combine both maps in a single desired
+        state.
+      properties:
+        base_plans:
+          description: "Configuration for each base plan keyed by `base_plan_id`.\
+            \ Only applies to subscriptions; one-time products use `purchase_options`\
+            \ instead. Plan-item granularity is `(subscription_id, base_plan_id)`,\
+            \ so this typically contains a single entry — the targeted base plan.\
+            \ May be omitted for plan items that only touch `common.*` or top-level\
+            \ fields (`tax_and_compliance`, `restricted_payment_countries`, `archived`,\
+            \ `regions_version`).\nEach value follows `PlayStoreBasePlanConfig`. The\
+            \ most important inner fields when creating a subscription are:\n- `state`\
+            \ (`ACTIVE` | `DRAFT` | `INACTIVE`, default `ACTIVE` on\n  create).\n\
+            - Exactly one billing plan type: `auto_renewing_base_plan_type`\n  (most\
+            \ common — requires `billing_period_duration`; optional\n  `grace_period_duration`,\
+            \ `account_hold_duration`,\n  `proration_mode`, `resubscribe_state`, `legacy_compatible`,\n\
+            \  `legacy_compatible_subscription_offer_id`),\n  `prepaid_base_plan_type`,\
+            \ or `installments_base_plan_type`.\n- `regional_configs[<region>]` with\n\
+            \  `new_subscriber_availability` and/or `price`\n  (`{ amount_micros,\
+            \ currency }`).\n- Optional `offer_tags` (array of strings) and `offers`\
+            \ (keyed by\n  `offer_id`). Each offer is `{ state (DRAFT|ACTIVE|INACTIVE),\n\
+            \  phases: [ { recurrence_count, duration, regional_configs{ <region>:\n\
+            \  { EXACTLY ONE of price / free: true / absolute_discount /\n  relative_discount\
+            \ } } } ], targeting?, offer_tags? }`. See the\n  `offers` field on `PlayStoreBasePlanConfig`\
+            \ for the full shape."
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/PlayStoreBasePlanConfig'
+          example:
+            monthly:
+              state: ACTIVE
+              auto_renewing_base_plan_type:
+                billing_period_duration: P1M
+                grace_period_duration: P3D
+                account_hold_duration: P30D
+                proration_mode: SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE
+                resubscribe_state: RESUBSCRIBE_STATE_ACTIVE
+                legacy_compatible: false
+                legacy_compatible_subscription_offer_id: null
+              regional_configs:
+                US:
+                  new_subscriber_availability: true
+                  price:
+                    amount_micros: 9990000
+                    currency: USD
+              offer_tags: []
+              offers: {}
+        purchase_options:
+          description: "Configuration for each one-time product purchase option keyed\
+            \ by `purchase_option_id`. Only applies to one-time products; subscriptions\
+            \ use `base_plans` instead. One-time product plan-item granularity is\
+            \ the product itself, so purchase options are managed inline on the product.\n\
+            Each value follows `PlayStorePurchaseOptionConfig`. Notable inner fields\
+            \ are:\n- `state` (`DRAFT` | `ACTIVE` | `INACTIVE` |\n  `INACTIVE_PUBLISHED`).\n\
+            - At most one of `buy_option` or `rent_option`; Google requires one\n\
+            \  when creating a purchase option.\n- `regional_configs[<region>]` with\
+            \ `availability` and/or `price`\n  (`{ amount_micros, currency }`).\n\
+            - Optional `offer_tags`, purchase-option `tax_and_compliance`, and\n \
+            \ `offers` keyed by `offer_id`."
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/PlayStorePurchaseOptionConfig'
+          example:
+            buy:
+              state: ACTIVE
+              buy_option:
+                legacy_compatible: true
+                multi_quantity_enabled: false
+              regional_configs:
+                US:
+                  availability: AVAILABLE
+                  price:
+                    amount_micros: 4990000
+                    currency: USD
+              offer_tags:
+              - one-time
+              offers: {}
+        tax_and_compliance:
+          description: Product-level tax and compliance settings. For subscriptions
+            this lives on the parent subscription in Google's API and must agree across
+            plan items targeting the same `subscription_id`. For one-time products,
+            `eea_withdrawal_right_type` is not supported — withdrawal rights are configured
+            per purchase option via `purchase_options.<id>.tax_and_compliance.withdrawal_right_type`.
+          nullable: true
+          $ref: '#/components/schemas/PlayStoreTaxAndComplianceConfig'
+        restricted_payment_countries:
+          description: Product-level list of region codes where payment is restricted.
+            For subscriptions this lives on the parent subscription and must agree
+            across plan items targeting the same `subscription_id`.
+          nullable: true
+          $ref: '#/components/schemas/PlayStoreRestrictedPaymentCountriesConfig'
+        archived:
+          description: Whether the parent subscription is archived in Play Console.
+            Must agree across plan items targeting the same `subscription_id`. Not
+            supported for one-time products.
+          type: boolean
+          nullable: true
+          example: false
+        regions_version:
+          description: Google Play regions version used to interpret region codes.
+            Optional; when omitted, the driver applies a sensible default.
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 32
+          example: 2025/03
+        latency_tolerance:
+          description: Latency tolerance hint for Google's monetization API (e.g.
+            `LATENCY_TOLERANT_FRESHNESS` / `LATENCY_TOLERANT_LOW_LATENCY`).
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 255
+          example: PRODUCT_UPDATE_LATENCY_TOLERANCE_LATENCY_TOLERANT
+      additionalProperties: false
+    ProductStoreStatePlayStoreStateResponse:
+      type: object
+      description: Play Store specific desired state as returned by the plan endpoints.
+        Same shape as the request schema with relaxed required-field constraints;
+        in particular the response may omit `base_plans`, `purchase_options`, or any
+        store-level field if the plan item didn't touch it.
+      properties:
+        base_plans:
+          description: 'Configuration for each base plan keyed by `base_plan_id`.
+            Only present for subscriptions; one-time products use `purchase_options`
+            instead. May be empty or omitted in responses for plan items that only
+            touch `common.*` fields.
+
+            Each value follows `PlayStoreBasePlanConfig` — see that schema for the
+            full inner shape. Notable inner fields: `state` (`ACTIVE` | `DRAFT` |
+            `INACTIVE`), one of `auto_renewing_base_plan_type` (with `billing_period_duration`
+            plus optional `grace_period_duration`, `account_hold_duration`, `proration_mode`,
+            `resubscribe_state`, `legacy_compatible`, `legacy_compatible_subscription_offer_id`),
+            `prepaid_base_plan_type`, or `installments_base_plan_type`, plus `regional_configs[<region>]`,
+            `offer_tags`, and `offers`.'
+          type: object
+          nullable: true
+          additionalProperties:
+            $ref: '#/components/schemas/PlayStoreBasePlanConfig'
+          example:
+            monthly:
+              state: ACTIVE
+              auto_renewing_base_plan_type:
+                billing_period_duration: P1M
+                grace_period_duration: P3D
+                account_hold_duration: P30D
+                proration_mode: SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE
+                resubscribe_state: RESUBSCRIBE_STATE_ACTIVE
+                legacy_compatible: false
+                legacy_compatible_subscription_offer_id: null
+              regional_configs:
+                US:
+                  new_subscriber_availability: true
+                  price:
+                    amount_micros: 9990000
+                    currency: USD
+              offer_tags: []
+              offers: {}
+        purchase_options:
+          description: Configuration for each one-time product purchase option keyed
+            by `purchase_option_id`. Only present for one-time products; subscriptions
+            use `base_plans` instead. May be empty or omitted in responses for plan
+            items that only touch `common.*` fields.
+          type: object
+          nullable: true
+          additionalProperties:
+            $ref: '#/components/schemas/PlayStorePurchaseOptionConfig'
+          example:
+            buy:
+              state: ACTIVE
+              buy_option:
+                legacy_compatible: true
+                multi_quantity_enabled: false
+              regional_configs:
+                US:
+                  availability: AVAILABLE
+                  price:
+                    amount_micros: 4990000
+                    currency: USD
+              offer_tags:
+              - one-time
+              offers: {}
+        tax_and_compliance:
+          description: Product-level tax and compliance settings. `eea_withdrawal_right_type`
+            only applies to subscriptions.
+          nullable: true
+          $ref: '#/components/schemas/PlayStoreTaxAndComplianceConfig'
+        restricted_payment_countries:
+          description: Product-level list of region codes where payment is restricted.
+          nullable: true
+          $ref: '#/components/schemas/PlayStoreRestrictedPaymentCountriesConfig'
+        archived:
+          description: Whether the parent subscription is archived in Play Console.
+            Not supported for one-time products.
+          type: boolean
+          nullable: true
+          example: false
+        regions_version:
+          description: Google Play regions version used to interpret region codes.
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 32
+          example: 2025/03
+        latency_tolerance:
+          description: Latency tolerance hint for Google's monetization API.
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 255
+          example: PRODUCT_UPDATE_LATENCY_TOLERANCE_LATENCY_TOLERANT
+      additionalProperties: false

--- a/internal/api/types_gen.go
+++ b/internal/api/types_gen.go
@@ -1017,28 +1017,28 @@ func (e Country) Valid() bool {
 
 // Defines values for CreateAppStoreConnectSubscriptionInputDuration.
 const (
-	ONEMONTH    CreateAppStoreConnectSubscriptionInputDuration = "ONE_MONTH"
-	ONEWEEK     CreateAppStoreConnectSubscriptionInputDuration = "ONE_WEEK"
-	ONEYEAR     CreateAppStoreConnectSubscriptionInputDuration = "ONE_YEAR"
-	SIXMONTHS   CreateAppStoreConnectSubscriptionInputDuration = "SIX_MONTHS"
-	THREEMONTHS CreateAppStoreConnectSubscriptionInputDuration = "THREE_MONTHS"
-	TWOMONTHS   CreateAppStoreConnectSubscriptionInputDuration = "TWO_MONTHS"
+	CreateAppStoreConnectSubscriptionInputDurationONEMONTH    CreateAppStoreConnectSubscriptionInputDuration = "ONE_MONTH"
+	CreateAppStoreConnectSubscriptionInputDurationONEWEEK     CreateAppStoreConnectSubscriptionInputDuration = "ONE_WEEK"
+	CreateAppStoreConnectSubscriptionInputDurationONEYEAR     CreateAppStoreConnectSubscriptionInputDuration = "ONE_YEAR"
+	CreateAppStoreConnectSubscriptionInputDurationSIXMONTHS   CreateAppStoreConnectSubscriptionInputDuration = "SIX_MONTHS"
+	CreateAppStoreConnectSubscriptionInputDurationTHREEMONTHS CreateAppStoreConnectSubscriptionInputDuration = "THREE_MONTHS"
+	CreateAppStoreConnectSubscriptionInputDurationTWOMONTHS   CreateAppStoreConnectSubscriptionInputDuration = "TWO_MONTHS"
 )
 
 // Valid indicates whether the value is a known member of the CreateAppStoreConnectSubscriptionInputDuration enum.
 func (e CreateAppStoreConnectSubscriptionInputDuration) Valid() bool {
 	switch e {
-	case ONEMONTH:
+	case CreateAppStoreConnectSubscriptionInputDurationONEMONTH:
 		return true
-	case ONEWEEK:
+	case CreateAppStoreConnectSubscriptionInputDurationONEWEEK:
 		return true
-	case ONEYEAR:
+	case CreateAppStoreConnectSubscriptionInputDurationONEYEAR:
 		return true
-	case SIXMONTHS:
+	case CreateAppStoreConnectSubscriptionInputDurationSIXMONTHS:
 		return true
-	case THREEMONTHS:
+	case CreateAppStoreConnectSubscriptionInputDurationTHREEMONTHS:
 		return true
-	case TWOMONTHS:
+	case CreateAppStoreConnectSubscriptionInputDurationTWOMONTHS:
 		return true
 	default:
 		return false
@@ -2064,28 +2064,28 @@ func (e DiscountPercentageVariantType) Valid() bool {
 
 // Defines values for Duration.
 const (
-	P1M Duration = "P1M"
-	P1W Duration = "P1W"
-	P1Y Duration = "P1Y"
-	P2M Duration = "P2M"
-	P3M Duration = "P3M"
-	P6M Duration = "P6M"
+	DurationP1M Duration = "P1M"
+	DurationP1W Duration = "P1W"
+	DurationP1Y Duration = "P1Y"
+	DurationP2M Duration = "P2M"
+	DurationP3M Duration = "P3M"
+	DurationP6M Duration = "P6M"
 )
 
 // Valid indicates whether the value is a known member of the Duration enum.
 func (e Duration) Valid() bool {
 	switch e {
-	case P1M:
+	case DurationP1M:
 		return true
-	case P1W:
+	case DurationP1W:
 		return true
-	case P1Y:
+	case DurationP1Y:
 		return true
-	case P2M:
+	case DurationP2M:
 		return true
-	case P3M:
+	case DurationP3M:
 		return true
-	case P6M:
+	case DurationP6M:
 		return true
 	default:
 		return false
@@ -2791,6 +2791,402 @@ func (e PlayStoreAppCreateType) Valid() bool {
 	}
 }
 
+// Defines values for PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationMode.
+const (
+	PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationModeLessThanNil                                         PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationMode = "<nil>"
+	PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODECHARGEFULLPRICEIMMEDIATELY PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationMode = "SUBSCRIPTION_PRORATION_MODE_CHARGE_FULL_PRICE_IMMEDIATELY"
+	PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODECHARGEONNEXTBILLINGDATE    PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationMode = "SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE"
+	PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODEUNSPECIFIED                PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationMode = "SUBSCRIPTION_PRORATION_MODE_UNSPECIFIED"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationMode enum.
+func (e PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationMode) Valid() bool {
+	switch e {
+	case PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationModeLessThanNil:
+		return true
+	case PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODECHARGEFULLPRICEIMMEDIATELY:
+		return true
+	case PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODECHARGEONNEXTBILLINGDATE:
+		return true
+	case PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODEUNSPECIFIED:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeState.
+const (
+	PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeStateLessThanNil                 PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeState = "<nil>"
+	PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeStateRESUBSCRIBESTATEACTIVE      PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeState = "RESUBSCRIBE_STATE_ACTIVE"
+	PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeStateRESUBSCRIBESTATEINACTIVE    PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeState = "RESUBSCRIBE_STATE_INACTIVE"
+	PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeStateRESUBSCRIBESTATEUNSPECIFIED PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeState = "RESUBSCRIBE_STATE_UNSPECIFIED"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeState enum.
+func (e PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeState) Valid() bool {
+	switch e {
+	case PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeStateLessThanNil:
+		return true
+	case PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeStateRESUBSCRIBESTATEACTIVE:
+		return true
+	case PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeStateRESUBSCRIBESTATEINACTIVE:
+		return true
+	case PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeStateRESUBSCRIBESTATEUNSPECIFIED:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationMode.
+const (
+	PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationModeLessThanNil                                         PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationMode = "<nil>"
+	PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODECHARGEFULLPRICEIMMEDIATELY PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationMode = "SUBSCRIPTION_PRORATION_MODE_CHARGE_FULL_PRICE_IMMEDIATELY"
+	PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODECHARGEONNEXTBILLINGDATE    PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationMode = "SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE"
+	PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODEUNSPECIFIED                PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationMode = "SUBSCRIPTION_PRORATION_MODE_UNSPECIFIED"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationMode enum.
+func (e PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationMode) Valid() bool {
+	switch e {
+	case PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationModeLessThanNil:
+		return true
+	case PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODECHARGEFULLPRICEIMMEDIATELY:
+		return true
+	case PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODECHARGEONNEXTBILLINGDATE:
+		return true
+	case PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationModeSUBSCRIPTIONPRORATIONMODEUNSPECIFIED:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStoreBasePlanConfigInstallmentsBasePlanTypeRenewalType.
+const (
+	RENEWALTYPERENEWSWITHCOMMITMENT    PlayStoreBasePlanConfigInstallmentsBasePlanTypeRenewalType = "RENEWAL_TYPE_RENEWS_WITH_COMMITMENT"
+	RENEWALTYPERENEWSWITHOUTCOMMITMENT PlayStoreBasePlanConfigInstallmentsBasePlanTypeRenewalType = "RENEWAL_TYPE_RENEWS_WITHOUT_COMMITMENT"
+	RENEWALTYPEUNSPECIFIED             PlayStoreBasePlanConfigInstallmentsBasePlanTypeRenewalType = "RENEWAL_TYPE_UNSPECIFIED"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreBasePlanConfigInstallmentsBasePlanTypeRenewalType enum.
+func (e PlayStoreBasePlanConfigInstallmentsBasePlanTypeRenewalType) Valid() bool {
+	switch e {
+	case RENEWALTYPERENEWSWITHCOMMITMENT:
+		return true
+	case RENEWALTYPERENEWSWITHOUTCOMMITMENT:
+		return true
+	case RENEWALTYPEUNSPECIFIED:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeState.
+const (
+	PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeStateLessThanNil                 PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeState = "<nil>"
+	PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeStateRESUBSCRIBESTATEACTIVE      PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeState = "RESUBSCRIBE_STATE_ACTIVE"
+	PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeStateRESUBSCRIBESTATEINACTIVE    PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeState = "RESUBSCRIBE_STATE_INACTIVE"
+	PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeStateRESUBSCRIBESTATEUNSPECIFIED PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeState = "RESUBSCRIBE_STATE_UNSPECIFIED"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeState enum.
+func (e PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeState) Valid() bool {
+	switch e {
+	case PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeStateLessThanNil:
+		return true
+	case PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeStateRESUBSCRIBESTATEACTIVE:
+		return true
+	case PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeStateRESUBSCRIBESTATEINACTIVE:
+		return true
+	case PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeStateRESUBSCRIBESTATEUNSPECIFIED:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtension.
+const (
+	PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtensionLessThanNil              PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtension = "<nil>"
+	PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtensionTIMEEXTENSIONACTIVE      PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtension = "TIME_EXTENSION_ACTIVE"
+	PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtensionTIMEEXTENSIONINACTIVE    PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtension = "TIME_EXTENSION_INACTIVE"
+	PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtensionTIMEEXTENSIONUNSPECIFIED PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtension = "TIME_EXTENSION_UNSPECIFIED"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtension enum.
+func (e PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtension) Valid() bool {
+	switch e {
+	case PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtensionLessThanNil:
+		return true
+	case PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtensionTIMEEXTENSIONACTIVE:
+		return true
+	case PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtensionTIMEEXTENSIONINACTIVE:
+		return true
+	case PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtensionTIMEEXTENSIONUNSPECIFIED:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStoreBasePlanConfigState.
+const (
+	PlayStoreBasePlanConfigStateACTIVE      PlayStoreBasePlanConfigState = "ACTIVE"
+	PlayStoreBasePlanConfigStateDRAFT       PlayStoreBasePlanConfigState = "DRAFT"
+	PlayStoreBasePlanConfigStateINACTIVE    PlayStoreBasePlanConfigState = "INACTIVE"
+	PlayStoreBasePlanConfigStateLessThanNil PlayStoreBasePlanConfigState = "<nil>"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreBasePlanConfigState enum.
+func (e PlayStoreBasePlanConfigState) Valid() bool {
+	switch e {
+	case PlayStoreBasePlanConfigStateACTIVE:
+		return true
+	case PlayStoreBasePlanConfigStateDRAFT:
+		return true
+	case PlayStoreBasePlanConfigStateINACTIVE:
+		return true
+	case PlayStoreBasePlanConfigStateLessThanNil:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStoreOfferConfigState.
+const (
+	PlayStoreOfferConfigStateACTIVE      PlayStoreOfferConfigState = "ACTIVE"
+	PlayStoreOfferConfigStateDRAFT       PlayStoreOfferConfigState = "DRAFT"
+	PlayStoreOfferConfigStateINACTIVE    PlayStoreOfferConfigState = "INACTIVE"
+	PlayStoreOfferConfigStateLessThanNil PlayStoreOfferConfigState = "<nil>"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreOfferConfigState enum.
+func (e PlayStoreOfferConfigState) Valid() bool {
+	switch e {
+	case PlayStoreOfferConfigStateACTIVE:
+		return true
+	case PlayStoreOfferConfigStateDRAFT:
+		return true
+	case PlayStoreOfferConfigStateINACTIVE:
+		return true
+	case PlayStoreOfferConfigStateLessThanNil:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStoreOneTimeOfferConfigState.
+const (
+	PlayStoreOneTimeOfferConfigStateACTIVE      PlayStoreOneTimeOfferConfigState = "ACTIVE"
+	PlayStoreOneTimeOfferConfigStateCANCELLED   PlayStoreOneTimeOfferConfigState = "CANCELLED"
+	PlayStoreOneTimeOfferConfigStateDRAFT       PlayStoreOneTimeOfferConfigState = "DRAFT"
+	PlayStoreOneTimeOfferConfigStateINACTIVE    PlayStoreOneTimeOfferConfigState = "INACTIVE"
+	PlayStoreOneTimeOfferConfigStateLessThanNil PlayStoreOneTimeOfferConfigState = "<nil>"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreOneTimeOfferConfigState enum.
+func (e PlayStoreOneTimeOfferConfigState) Valid() bool {
+	switch e {
+	case PlayStoreOneTimeOfferConfigStateACTIVE:
+		return true
+	case PlayStoreOneTimeOfferConfigStateCANCELLED:
+		return true
+	case PlayStoreOneTimeOfferConfigStateDRAFT:
+		return true
+	case PlayStoreOneTimeOfferConfigStateINACTIVE:
+		return true
+	case PlayStoreOneTimeOfferConfigStateLessThanNil:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStoreOneTimeOfferPreOrderConfigPriceChangeBehavior.
+const (
+	PREORDERPRICECHANGEBEHAVIORNEWORDERSONLY  PlayStoreOneTimeOfferPreOrderConfigPriceChangeBehavior = "PRE_ORDER_PRICE_CHANGE_BEHAVIOR_NEW_ORDERS_ONLY"
+	PREORDERPRICECHANGEBEHAVIORTWOPOINTLOWEST PlayStoreOneTimeOfferPreOrderConfigPriceChangeBehavior = "PRE_ORDER_PRICE_CHANGE_BEHAVIOR_TWO_POINT_LOWEST"
+	PREORDERPRICECHANGEBEHAVIORUNSPECIFIED    PlayStoreOneTimeOfferPreOrderConfigPriceChangeBehavior = "PRE_ORDER_PRICE_CHANGE_BEHAVIOR_UNSPECIFIED"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreOneTimeOfferPreOrderConfigPriceChangeBehavior enum.
+func (e PlayStoreOneTimeOfferPreOrderConfigPriceChangeBehavior) Valid() bool {
+	switch e {
+	case PREORDERPRICECHANGEBEHAVIORNEWORDERSONLY:
+		return true
+	case PREORDERPRICECHANGEBEHAVIORTWOPOINTLOWEST:
+		return true
+	case PREORDERPRICECHANGEBEHAVIORUNSPECIFIED:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStoreOneTimeOfferRegionalConfigAvailability.
+const (
+	PlayStoreOneTimeOfferRegionalConfigAvailabilityAVAILABLE              PlayStoreOneTimeOfferRegionalConfigAvailability = "AVAILABLE"
+	PlayStoreOneTimeOfferRegionalConfigAvailabilityAVAILABLEFOROFFERSONLY PlayStoreOneTimeOfferRegionalConfigAvailability = "AVAILABLE_FOR_OFFERS_ONLY"
+	PlayStoreOneTimeOfferRegionalConfigAvailabilityAVAILABLEIFRELEASED    PlayStoreOneTimeOfferRegionalConfigAvailability = "AVAILABLE_IF_RELEASED"
+	PlayStoreOneTimeOfferRegionalConfigAvailabilityLessThanNil            PlayStoreOneTimeOfferRegionalConfigAvailability = "<nil>"
+	PlayStoreOneTimeOfferRegionalConfigAvailabilityNOLONGERAVAILABLE      PlayStoreOneTimeOfferRegionalConfigAvailability = "NO_LONGER_AVAILABLE"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreOneTimeOfferRegionalConfigAvailability enum.
+func (e PlayStoreOneTimeOfferRegionalConfigAvailability) Valid() bool {
+	switch e {
+	case PlayStoreOneTimeOfferRegionalConfigAvailabilityAVAILABLE:
+		return true
+	case PlayStoreOneTimeOfferRegionalConfigAvailabilityAVAILABLEFOROFFERSONLY:
+		return true
+	case PlayStoreOneTimeOfferRegionalConfigAvailabilityAVAILABLEIFRELEASED:
+		return true
+	case PlayStoreOneTimeOfferRegionalConfigAvailabilityLessThanNil:
+		return true
+	case PlayStoreOneTimeOfferRegionalConfigAvailabilityNOLONGERAVAILABLE:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStorePurchaseOptionConfigState.
+const (
+	PlayStorePurchaseOptionConfigStateACTIVE            PlayStorePurchaseOptionConfigState = "ACTIVE"
+	PlayStorePurchaseOptionConfigStateDRAFT             PlayStorePurchaseOptionConfigState = "DRAFT"
+	PlayStorePurchaseOptionConfigStateINACTIVE          PlayStorePurchaseOptionConfigState = "INACTIVE"
+	PlayStorePurchaseOptionConfigStateINACTIVEPUBLISHED PlayStorePurchaseOptionConfigState = "INACTIVE_PUBLISHED"
+	PlayStorePurchaseOptionConfigStateLessThanNil       PlayStorePurchaseOptionConfigState = "<nil>"
+)
+
+// Valid indicates whether the value is a known member of the PlayStorePurchaseOptionConfigState enum.
+func (e PlayStorePurchaseOptionConfigState) Valid() bool {
+	switch e {
+	case PlayStorePurchaseOptionConfigStateACTIVE:
+		return true
+	case PlayStorePurchaseOptionConfigStateDRAFT:
+		return true
+	case PlayStorePurchaseOptionConfigStateINACTIVE:
+		return true
+	case PlayStorePurchaseOptionConfigStateINACTIVEPUBLISHED:
+		return true
+	case PlayStorePurchaseOptionConfigStateLessThanNil:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStorePurchaseOptionNewRegionsConfigAvailability.
+const (
+	PlayStorePurchaseOptionNewRegionsConfigAvailabilityAVAILABLE              PlayStorePurchaseOptionNewRegionsConfigAvailability = "AVAILABLE"
+	PlayStorePurchaseOptionNewRegionsConfigAvailabilityAVAILABLEFOROFFERSONLY PlayStorePurchaseOptionNewRegionsConfigAvailability = "AVAILABLE_FOR_OFFERS_ONLY"
+	PlayStorePurchaseOptionNewRegionsConfigAvailabilityAVAILABLEIFRELEASED    PlayStorePurchaseOptionNewRegionsConfigAvailability = "AVAILABLE_IF_RELEASED"
+	PlayStorePurchaseOptionNewRegionsConfigAvailabilityLessThanNil            PlayStorePurchaseOptionNewRegionsConfigAvailability = "<nil>"
+	PlayStorePurchaseOptionNewRegionsConfigAvailabilityNOLONGERAVAILABLE      PlayStorePurchaseOptionNewRegionsConfigAvailability = "NO_LONGER_AVAILABLE"
+)
+
+// Valid indicates whether the value is a known member of the PlayStorePurchaseOptionNewRegionsConfigAvailability enum.
+func (e PlayStorePurchaseOptionNewRegionsConfigAvailability) Valid() bool {
+	switch e {
+	case PlayStorePurchaseOptionNewRegionsConfigAvailabilityAVAILABLE:
+		return true
+	case PlayStorePurchaseOptionNewRegionsConfigAvailabilityAVAILABLEFOROFFERSONLY:
+		return true
+	case PlayStorePurchaseOptionNewRegionsConfigAvailabilityAVAILABLEIFRELEASED:
+		return true
+	case PlayStorePurchaseOptionNewRegionsConfigAvailabilityLessThanNil:
+		return true
+	case PlayStorePurchaseOptionNewRegionsConfigAvailabilityNOLONGERAVAILABLE:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStorePurchaseOptionRegionalConfigAvailability.
+const (
+	PlayStorePurchaseOptionRegionalConfigAvailabilityAVAILABLE              PlayStorePurchaseOptionRegionalConfigAvailability = "AVAILABLE"
+	PlayStorePurchaseOptionRegionalConfigAvailabilityAVAILABLEFOROFFERSONLY PlayStorePurchaseOptionRegionalConfigAvailability = "AVAILABLE_FOR_OFFERS_ONLY"
+	PlayStorePurchaseOptionRegionalConfigAvailabilityAVAILABLEIFRELEASED    PlayStorePurchaseOptionRegionalConfigAvailability = "AVAILABLE_IF_RELEASED"
+	PlayStorePurchaseOptionRegionalConfigAvailabilityLessThanNil            PlayStorePurchaseOptionRegionalConfigAvailability = "<nil>"
+	PlayStorePurchaseOptionRegionalConfigAvailabilityNOLONGERAVAILABLE      PlayStorePurchaseOptionRegionalConfigAvailability = "NO_LONGER_AVAILABLE"
+)
+
+// Valid indicates whether the value is a known member of the PlayStorePurchaseOptionRegionalConfigAvailability enum.
+func (e PlayStorePurchaseOptionRegionalConfigAvailability) Valid() bool {
+	switch e {
+	case PlayStorePurchaseOptionRegionalConfigAvailabilityAVAILABLE:
+		return true
+	case PlayStorePurchaseOptionRegionalConfigAvailabilityAVAILABLEFOROFFERSONLY:
+		return true
+	case PlayStorePurchaseOptionRegionalConfigAvailabilityAVAILABLEIFRELEASED:
+		return true
+	case PlayStorePurchaseOptionRegionalConfigAvailabilityLessThanNil:
+		return true
+	case PlayStorePurchaseOptionRegionalConfigAvailabilityNOLONGERAVAILABLE:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightType.
+const (
+	PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightTypeLessThanNil                    PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightType = "<nil>"
+	PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightTypeWITHDRAWALRIGHTDIGITALCONTENT  PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightType = "WITHDRAWAL_RIGHT_DIGITAL_CONTENT"
+	PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightTypeWITHDRAWALRIGHTSERVICE         PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightType = "WITHDRAWAL_RIGHT_SERVICE"
+	PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightTypeWITHDRAWALRIGHTTYPEUNSPECIFIED PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightType = "WITHDRAWAL_RIGHT_TYPE_UNSPECIFIED"
+)
+
+// Valid indicates whether the value is a known member of the PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightType enum.
+func (e PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightType) Valid() bool {
+	switch e {
+	case PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightTypeLessThanNil:
+		return true
+	case PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightTypeWITHDRAWALRIGHTDIGITALCONTENT:
+		return true
+	case PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightTypeWITHDRAWALRIGHTSERVICE:
+		return true
+	case PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightTypeWITHDRAWALRIGHTTYPEUNSPECIFIED:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PlayStoreRegionalProductAgeRatingInfoProductAgeRatingTier.
+const (
+	PRODUCTAGERATINGTIEREIGHTEENANDABOVE PlayStoreRegionalProductAgeRatingInfoProductAgeRatingTier = "PRODUCT_AGE_RATING_TIER_EIGHTEEN_AND_ABOVE"
+	PRODUCTAGERATINGTIEREVERYONE         PlayStoreRegionalProductAgeRatingInfoProductAgeRatingTier = "PRODUCT_AGE_RATING_TIER_EVERYONE"
+	PRODUCTAGERATINGTIERSIXTEENANDABOVE  PlayStoreRegionalProductAgeRatingInfoProductAgeRatingTier = "PRODUCT_AGE_RATING_TIER_SIXTEEN_AND_ABOVE"
+	PRODUCTAGERATINGTIERTHIRTEENANDABOVE PlayStoreRegionalProductAgeRatingInfoProductAgeRatingTier = "PRODUCT_AGE_RATING_TIER_THIRTEEN_AND_ABOVE"
+	PRODUCTAGERATINGTIERUNKNOWN          PlayStoreRegionalProductAgeRatingInfoProductAgeRatingTier = "PRODUCT_AGE_RATING_TIER_UNKNOWN"
+)
+
+// Valid indicates whether the value is a known member of the PlayStoreRegionalProductAgeRatingInfoProductAgeRatingTier enum.
+func (e PlayStoreRegionalProductAgeRatingInfoProductAgeRatingTier) Valid() bool {
+	switch e {
+	case PRODUCTAGERATINGTIEREIGHTEENANDABOVE:
+		return true
+	case PRODUCTAGERATINGTIEREVERYONE:
+		return true
+	case PRODUCTAGERATINGTIERSIXTEENANDABOVE:
+		return true
+	case PRODUCTAGERATINGTIERTHIRTEENANDABOVE:
+		return true
+	case PRODUCTAGERATINGTIERUNKNOWN:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ProductObject.
 const (
 	ProductObjectProduct ProductObject = "product"
@@ -2818,6 +3214,111 @@ func (e ProductState) Valid() bool {
 	case ProductStateActive:
 		return true
 	case ProductStateInactive:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ProductStoreStateAppStoreStateTrialOfferDuration.
+const (
+	ProductStoreStateAppStoreStateTrialOfferDurationONEMONTH    ProductStoreStateAppStoreStateTrialOfferDuration = "ONE_MONTH"
+	ProductStoreStateAppStoreStateTrialOfferDurationONEWEEK     ProductStoreStateAppStoreStateTrialOfferDuration = "ONE_WEEK"
+	ProductStoreStateAppStoreStateTrialOfferDurationONEYEAR     ProductStoreStateAppStoreStateTrialOfferDuration = "ONE_YEAR"
+	ProductStoreStateAppStoreStateTrialOfferDurationSIXMONTHS   ProductStoreStateAppStoreStateTrialOfferDuration = "SIX_MONTHS"
+	ProductStoreStateAppStoreStateTrialOfferDurationTHREEDAYS   ProductStoreStateAppStoreStateTrialOfferDuration = "THREE_DAYS"
+	ProductStoreStateAppStoreStateTrialOfferDurationTHREEMONTHS ProductStoreStateAppStoreStateTrialOfferDuration = "THREE_MONTHS"
+	ProductStoreStateAppStoreStateTrialOfferDurationTWOMONTHS   ProductStoreStateAppStoreStateTrialOfferDuration = "TWO_MONTHS"
+	ProductStoreStateAppStoreStateTrialOfferDurationTWOWEEKS    ProductStoreStateAppStoreStateTrialOfferDuration = "TWO_WEEKS"
+)
+
+// Valid indicates whether the value is a known member of the ProductStoreStateAppStoreStateTrialOfferDuration enum.
+func (e ProductStoreStateAppStoreStateTrialOfferDuration) Valid() bool {
+	switch e {
+	case ProductStoreStateAppStoreStateTrialOfferDurationONEMONTH:
+		return true
+	case ProductStoreStateAppStoreStateTrialOfferDurationONEWEEK:
+		return true
+	case ProductStoreStateAppStoreStateTrialOfferDurationONEYEAR:
+		return true
+	case ProductStoreStateAppStoreStateTrialOfferDurationSIXMONTHS:
+		return true
+	case ProductStoreStateAppStoreStateTrialOfferDurationTHREEDAYS:
+		return true
+	case ProductStoreStateAppStoreStateTrialOfferDurationTHREEMONTHS:
+		return true
+	case ProductStoreStateAppStoreStateTrialOfferDurationTWOMONTHS:
+		return true
+	case ProductStoreStateAppStoreStateTrialOfferDurationTWOWEEKS:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ProductStoreStateAppStoreStateResponseTrialOfferDuration.
+const (
+	ProductStoreStateAppStoreStateResponseTrialOfferDurationONEMONTH    ProductStoreStateAppStoreStateResponseTrialOfferDuration = "ONE_MONTH"
+	ProductStoreStateAppStoreStateResponseTrialOfferDurationONEWEEK     ProductStoreStateAppStoreStateResponseTrialOfferDuration = "ONE_WEEK"
+	ProductStoreStateAppStoreStateResponseTrialOfferDurationONEYEAR     ProductStoreStateAppStoreStateResponseTrialOfferDuration = "ONE_YEAR"
+	ProductStoreStateAppStoreStateResponseTrialOfferDurationSIXMONTHS   ProductStoreStateAppStoreStateResponseTrialOfferDuration = "SIX_MONTHS"
+	ProductStoreStateAppStoreStateResponseTrialOfferDurationTHREEDAYS   ProductStoreStateAppStoreStateResponseTrialOfferDuration = "THREE_DAYS"
+	ProductStoreStateAppStoreStateResponseTrialOfferDurationTHREEMONTHS ProductStoreStateAppStoreStateResponseTrialOfferDuration = "THREE_MONTHS"
+	ProductStoreStateAppStoreStateResponseTrialOfferDurationTWOMONTHS   ProductStoreStateAppStoreStateResponseTrialOfferDuration = "TWO_MONTHS"
+	ProductStoreStateAppStoreStateResponseTrialOfferDurationTWOWEEKS    ProductStoreStateAppStoreStateResponseTrialOfferDuration = "TWO_WEEKS"
+)
+
+// Valid indicates whether the value is a known member of the ProductStoreStateAppStoreStateResponseTrialOfferDuration enum.
+func (e ProductStoreStateAppStoreStateResponseTrialOfferDuration) Valid() bool {
+	switch e {
+	case ProductStoreStateAppStoreStateResponseTrialOfferDurationONEMONTH:
+		return true
+	case ProductStoreStateAppStoreStateResponseTrialOfferDurationONEWEEK:
+		return true
+	case ProductStoreStateAppStoreStateResponseTrialOfferDurationONEYEAR:
+		return true
+	case ProductStoreStateAppStoreStateResponseTrialOfferDurationSIXMONTHS:
+		return true
+	case ProductStoreStateAppStoreStateResponseTrialOfferDurationTHREEDAYS:
+		return true
+	case ProductStoreStateAppStoreStateResponseTrialOfferDurationTHREEMONTHS:
+		return true
+	case ProductStoreStateAppStoreStateResponseTrialOfferDurationTWOMONTHS:
+		return true
+	case ProductStoreStateAppStoreStateResponseTrialOfferDurationTWOWEEKS:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ProductStoreStateCommonResponseDuration.
+const (
+	ProductStoreStateCommonResponseDurationLessThanNil ProductStoreStateCommonResponseDuration = "<nil>"
+	ProductStoreStateCommonResponseDurationONEMONTH    ProductStoreStateCommonResponseDuration = "ONE_MONTH"
+	ProductStoreStateCommonResponseDurationONEWEEK     ProductStoreStateCommonResponseDuration = "ONE_WEEK"
+	ProductStoreStateCommonResponseDurationONEYEAR     ProductStoreStateCommonResponseDuration = "ONE_YEAR"
+	ProductStoreStateCommonResponseDurationSIXMONTHS   ProductStoreStateCommonResponseDuration = "SIX_MONTHS"
+	ProductStoreStateCommonResponseDurationTHREEMONTHS ProductStoreStateCommonResponseDuration = "THREE_MONTHS"
+	ProductStoreStateCommonResponseDurationTWOMONTHS   ProductStoreStateCommonResponseDuration = "TWO_MONTHS"
+)
+
+// Valid indicates whether the value is a known member of the ProductStoreStateCommonResponseDuration enum.
+func (e ProductStoreStateCommonResponseDuration) Valid() bool {
+	switch e {
+	case ProductStoreStateCommonResponseDurationLessThanNil:
+		return true
+	case ProductStoreStateCommonResponseDurationONEMONTH:
+		return true
+	case ProductStoreStateCommonResponseDurationONEWEEK:
+		return true
+	case ProductStoreStateCommonResponseDurationONEYEAR:
+		return true
+	case ProductStoreStateCommonResponseDurationSIXMONTHS:
+		return true
+	case ProductStoreStateCommonResponseDurationTHREEMONTHS:
+		return true
+	case ProductStoreStateCommonResponseDurationTWOMONTHS:
 		return true
 	default:
 		return false
@@ -30319,6 +30820,1740 @@ func (e CreateProductInStore503JSONResponseBodyType) Valid() bool {
 	}
 }
 
+// Defines values for GetProductStoreState200JSONResponseBodyCommonDuration.
+const (
+	GetProductStoreState200JSONResponseBodyCommonDurationLessThanNil GetProductStoreState200JSONResponseBodyCommonDuration = "<nil>"
+	GetProductStoreState200JSONResponseBodyCommonDurationONEMONTH    GetProductStoreState200JSONResponseBodyCommonDuration = "ONE_MONTH"
+	GetProductStoreState200JSONResponseBodyCommonDurationONEWEEK     GetProductStoreState200JSONResponseBodyCommonDuration = "ONE_WEEK"
+	GetProductStoreState200JSONResponseBodyCommonDurationONEYEAR     GetProductStoreState200JSONResponseBodyCommonDuration = "ONE_YEAR"
+	GetProductStoreState200JSONResponseBodyCommonDurationSIXMONTHS   GetProductStoreState200JSONResponseBodyCommonDuration = "SIX_MONTHS"
+	GetProductStoreState200JSONResponseBodyCommonDurationTHREEMONTHS GetProductStoreState200JSONResponseBodyCommonDuration = "THREE_MONTHS"
+	GetProductStoreState200JSONResponseBodyCommonDurationTWOMONTHS   GetProductStoreState200JSONResponseBodyCommonDuration = "TWO_MONTHS"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState200JSONResponseBodyCommonDuration enum.
+func (e GetProductStoreState200JSONResponseBodyCommonDuration) Valid() bool {
+	switch e {
+	case GetProductStoreState200JSONResponseBodyCommonDurationLessThanNil:
+		return true
+	case GetProductStoreState200JSONResponseBodyCommonDurationONEMONTH:
+		return true
+	case GetProductStoreState200JSONResponseBodyCommonDurationONEWEEK:
+		return true
+	case GetProductStoreState200JSONResponseBodyCommonDurationONEYEAR:
+		return true
+	case GetProductStoreState200JSONResponseBodyCommonDurationSIXMONTHS:
+		return true
+	case GetProductStoreState200JSONResponseBodyCommonDurationTHREEMONTHS:
+		return true
+	case GetProductStoreState200JSONResponseBodyCommonDurationTWOMONTHS:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState200JSONResponseBodyStore.
+const (
+	GetProductStoreState200JSONResponseBodyStoreAppStore  GetProductStoreState200JSONResponseBodyStore = "app_store"
+	GetProductStoreState200JSONResponseBodyStorePlayStore GetProductStoreState200JSONResponseBodyStore = "play_store"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState200JSONResponseBodyStore enum.
+func (e GetProductStoreState200JSONResponseBodyStore) Valid() bool {
+	switch e {
+	case GetProductStoreState200JSONResponseBodyStoreAppStore:
+		return true
+	case GetProductStoreState200JSONResponseBodyStorePlayStore:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState200JSONResponseBodyStoreStatusStatus.
+const (
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusActionInProgress GetProductStoreState200JSONResponseBodyStoreStatusStatus = "action_in_progress"
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusCouldNotCheck    GetProductStoreState200JSONResponseBodyStoreStatusStatus = "could_not_check"
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusDraft            GetProductStoreState200JSONResponseBodyStoreStatusStatus = "draft"
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusInactiveInStore  GetProductStoreState200JSONResponseBodyStoreStatusStatus = "inactive_in_store"
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusNeedsAction      GetProductStoreState200JSONResponseBodyStoreStatusStatus = "needs_action"
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusNotFound         GetProductStoreState200JSONResponseBodyStoreStatusStatus = "not_found"
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusOk               GetProductStoreState200JSONResponseBodyStoreStatusStatus = "ok"
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusUnknown          GetProductStoreState200JSONResponseBodyStoreStatusStatus = "unknown"
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusUnspecified      GetProductStoreState200JSONResponseBodyStoreStatusStatus = "unspecified"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState200JSONResponseBodyStoreStatusStatus enum.
+func (e GetProductStoreState200JSONResponseBodyStoreStatusStatus) Valid() bool {
+	switch e {
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusActionInProgress:
+		return true
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusCouldNotCheck:
+		return true
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusDraft:
+		return true
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusInactiveInStore:
+		return true
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusNeedsAction:
+		return true
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusNotFound:
+		return true
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusOk:
+		return true
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusUnknown:
+		return true
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusUnspecified:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState400JSONResponseBodyObject.
+const (
+	GetProductStoreState400JSONResponseBodyObjectError GetProductStoreState400JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState400JSONResponseBodyObject enum.
+func (e GetProductStoreState400JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreState400JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState400JSONResponseBodyType.
+const (
+	GetProductStoreState400JSONResponseBodyTypeInvalidRequest GetProductStoreState400JSONResponseBodyType = "invalid_request"
+	GetProductStoreState400JSONResponseBodyTypeParameterError GetProductStoreState400JSONResponseBodyType = "parameter_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState400JSONResponseBodyType enum.
+func (e GetProductStoreState400JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreState400JSONResponseBodyTypeInvalidRequest:
+		return true
+	case GetProductStoreState400JSONResponseBodyTypeParameterError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState401JSONResponseBodyObject.
+const (
+	GetProductStoreState401JSONResponseBodyObjectError GetProductStoreState401JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState401JSONResponseBodyObject enum.
+func (e GetProductStoreState401JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreState401JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState401JSONResponseBodyType.
+const (
+	GetProductStoreState401JSONResponseBodyTypeAuthenticationError GetProductStoreState401JSONResponseBodyType = "authentication_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState401JSONResponseBodyType enum.
+func (e GetProductStoreState401JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreState401JSONResponseBodyTypeAuthenticationError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState403JSONResponseBodyObject.
+const (
+	GetProductStoreState403JSONResponseBodyObjectError GetProductStoreState403JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState403JSONResponseBodyObject enum.
+func (e GetProductStoreState403JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreState403JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState403JSONResponseBodyType.
+const (
+	GetProductStoreState403JSONResponseBodyTypeAuthorizationError GetProductStoreState403JSONResponseBodyType = "authorization_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState403JSONResponseBodyType enum.
+func (e GetProductStoreState403JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreState403JSONResponseBodyTypeAuthorizationError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState404JSONResponseBodyObject.
+const (
+	GetProductStoreState404JSONResponseBodyObjectError GetProductStoreState404JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState404JSONResponseBodyObject enum.
+func (e GetProductStoreState404JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreState404JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState404JSONResponseBodyType.
+const (
+	GetProductStoreState404JSONResponseBodyTypeResourceMissing GetProductStoreState404JSONResponseBodyType = "resource_missing"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState404JSONResponseBodyType enum.
+func (e GetProductStoreState404JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreState404JSONResponseBodyTypeResourceMissing:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState422JSONResponseBodyObject.
+const (
+	GetProductStoreState422JSONResponseBodyObjectError GetProductStoreState422JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState422JSONResponseBodyObject enum.
+func (e GetProductStoreState422JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreState422JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState422JSONResponseBodyType.
+const (
+	GetProductStoreState422JSONResponseBodyTypeEntityReferencesArchivedEntities GetProductStoreState422JSONResponseBodyType = "entity_references_archived_entities"
+	GetProductStoreState422JSONResponseBodyTypeParameterError                   GetProductStoreState422JSONResponseBodyType = "parameter_error"
+	GetProductStoreState422JSONResponseBodyTypeStoreError                       GetProductStoreState422JSONResponseBodyType = "store_error"
+	GetProductStoreState422JSONResponseBodyTypeUnprocessableEntityError         GetProductStoreState422JSONResponseBodyType = "unprocessable_entity_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState422JSONResponseBodyType enum.
+func (e GetProductStoreState422JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreState422JSONResponseBodyTypeEntityReferencesArchivedEntities:
+		return true
+	case GetProductStoreState422JSONResponseBodyTypeParameterError:
+		return true
+	case GetProductStoreState422JSONResponseBodyTypeStoreError:
+		return true
+	case GetProductStoreState422JSONResponseBodyTypeUnprocessableEntityError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState423JSONResponseBodyObject.
+const (
+	GetProductStoreState423JSONResponseBodyObjectError GetProductStoreState423JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState423JSONResponseBodyObject enum.
+func (e GetProductStoreState423JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreState423JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState423JSONResponseBodyType.
+const (
+	GetProductStoreState423JSONResponseBodyTypeResourceLockedError GetProductStoreState423JSONResponseBodyType = "resource_locked_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState423JSONResponseBodyType enum.
+func (e GetProductStoreState423JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreState423JSONResponseBodyTypeResourceLockedError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState429JSONResponseBodyObject.
+const (
+	GetProductStoreState429JSONResponseBodyObjectError GetProductStoreState429JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState429JSONResponseBodyObject enum.
+func (e GetProductStoreState429JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreState429JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState429JSONResponseBodyType.
+const (
+	GetProductStoreState429JSONResponseBodyTypeRateLimitError GetProductStoreState429JSONResponseBodyType = "rate_limit_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState429JSONResponseBodyType enum.
+func (e GetProductStoreState429JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreState429JSONResponseBodyTypeRateLimitError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState500JSONResponseBodyObject.
+const (
+	GetProductStoreState500JSONResponseBodyObjectError GetProductStoreState500JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState500JSONResponseBodyObject enum.
+func (e GetProductStoreState500JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreState500JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState500JSONResponseBodyType.
+const (
+	GetProductStoreState500JSONResponseBodyTypeServerError GetProductStoreState500JSONResponseBodyType = "server_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState500JSONResponseBodyType enum.
+func (e GetProductStoreState500JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreState500JSONResponseBodyTypeServerError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState503JSONResponseBodyObject.
+const (
+	GetProductStoreState503JSONResponseBodyObjectError GetProductStoreState503JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState503JSONResponseBodyObject enum.
+func (e GetProductStoreState503JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreState503JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState503JSONResponseBodyType.
+const (
+	GetProductStoreState503JSONResponseBodyTypeServerError GetProductStoreState503JSONResponseBodyType = "server_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState503JSONResponseBodyType enum.
+func (e GetProductStoreState503JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreState503JSONResponseBodyTypeServerError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreStateJSONBodyCommonDuration.
+const (
+	SetProductStoreStateJSONBodyCommonDurationONEMONTH    SetProductStoreStateJSONBodyCommonDuration = "ONE_MONTH"
+	SetProductStoreStateJSONBodyCommonDurationONEWEEK     SetProductStoreStateJSONBodyCommonDuration = "ONE_WEEK"
+	SetProductStoreStateJSONBodyCommonDurationONEYEAR     SetProductStoreStateJSONBodyCommonDuration = "ONE_YEAR"
+	SetProductStoreStateJSONBodyCommonDurationP1M         SetProductStoreStateJSONBodyCommonDuration = "P1M"
+	SetProductStoreStateJSONBodyCommonDurationP1W         SetProductStoreStateJSONBodyCommonDuration = "P1W"
+	SetProductStoreStateJSONBodyCommonDurationP1Y         SetProductStoreStateJSONBodyCommonDuration = "P1Y"
+	SetProductStoreStateJSONBodyCommonDurationP2M         SetProductStoreStateJSONBodyCommonDuration = "P2M"
+	SetProductStoreStateJSONBodyCommonDurationP3M         SetProductStoreStateJSONBodyCommonDuration = "P3M"
+	SetProductStoreStateJSONBodyCommonDurationP6M         SetProductStoreStateJSONBodyCommonDuration = "P6M"
+	SetProductStoreStateJSONBodyCommonDurationSIXMONTHS   SetProductStoreStateJSONBodyCommonDuration = "SIX_MONTHS"
+	SetProductStoreStateJSONBodyCommonDurationTHREEMONTHS SetProductStoreStateJSONBodyCommonDuration = "THREE_MONTHS"
+	SetProductStoreStateJSONBodyCommonDurationTWOMONTHS   SetProductStoreStateJSONBodyCommonDuration = "TWO_MONTHS"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreStateJSONBodyCommonDuration enum.
+func (e SetProductStoreStateJSONBodyCommonDuration) Valid() bool {
+	switch e {
+	case SetProductStoreStateJSONBodyCommonDurationONEMONTH:
+		return true
+	case SetProductStoreStateJSONBodyCommonDurationONEWEEK:
+		return true
+	case SetProductStoreStateJSONBodyCommonDurationONEYEAR:
+		return true
+	case SetProductStoreStateJSONBodyCommonDurationP1M:
+		return true
+	case SetProductStoreStateJSONBodyCommonDurationP1W:
+		return true
+	case SetProductStoreStateJSONBodyCommonDurationP1Y:
+		return true
+	case SetProductStoreStateJSONBodyCommonDurationP2M:
+		return true
+	case SetProductStoreStateJSONBodyCommonDurationP3M:
+		return true
+	case SetProductStoreStateJSONBodyCommonDurationP6M:
+		return true
+	case SetProductStoreStateJSONBodyCommonDurationSIXMONTHS:
+		return true
+	case SetProductStoreStateJSONBodyCommonDurationTHREEMONTHS:
+		return true
+	case SetProductStoreStateJSONBodyCommonDurationTWOMONTHS:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreStateJSONBodyStore.
+const (
+	SetProductStoreStateJSONBodyStoreAppStore  SetProductStoreStateJSONBodyStore = "app_store"
+	SetProductStoreStateJSONBodyStorePlayStore SetProductStoreStateJSONBodyStore = "play_store"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreStateJSONBodyStore enum.
+func (e SetProductStoreStateJSONBodyStore) Valid() bool {
+	switch e {
+	case SetProductStoreStateJSONBodyStoreAppStore:
+		return true
+	case SetProductStoreStateJSONBodyStorePlayStore:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState202JSONResponseBodyStatus.
+const (
+	SetProductStoreState202JSONResponseBodyStatusPending SetProductStoreState202JSONResponseBodyStatus = "pending"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState202JSONResponseBodyStatus enum.
+func (e SetProductStoreState202JSONResponseBodyStatus) Valid() bool {
+	switch e {
+	case SetProductStoreState202JSONResponseBodyStatusPending:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState400JSONResponseBodyObject.
+const (
+	SetProductStoreState400JSONResponseBodyObjectError SetProductStoreState400JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState400JSONResponseBodyObject enum.
+func (e SetProductStoreState400JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case SetProductStoreState400JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState400JSONResponseBodyType.
+const (
+	SetProductStoreState400JSONResponseBodyTypeInvalidRequest SetProductStoreState400JSONResponseBodyType = "invalid_request"
+	SetProductStoreState400JSONResponseBodyTypeParameterError SetProductStoreState400JSONResponseBodyType = "parameter_error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState400JSONResponseBodyType enum.
+func (e SetProductStoreState400JSONResponseBodyType) Valid() bool {
+	switch e {
+	case SetProductStoreState400JSONResponseBodyTypeInvalidRequest:
+		return true
+	case SetProductStoreState400JSONResponseBodyTypeParameterError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState401JSONResponseBodyObject.
+const (
+	SetProductStoreState401JSONResponseBodyObjectError SetProductStoreState401JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState401JSONResponseBodyObject enum.
+func (e SetProductStoreState401JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case SetProductStoreState401JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState401JSONResponseBodyType.
+const (
+	SetProductStoreState401JSONResponseBodyTypeAuthenticationError SetProductStoreState401JSONResponseBodyType = "authentication_error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState401JSONResponseBodyType enum.
+func (e SetProductStoreState401JSONResponseBodyType) Valid() bool {
+	switch e {
+	case SetProductStoreState401JSONResponseBodyTypeAuthenticationError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState403JSONResponseBodyObject.
+const (
+	SetProductStoreState403JSONResponseBodyObjectError SetProductStoreState403JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState403JSONResponseBodyObject enum.
+func (e SetProductStoreState403JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case SetProductStoreState403JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState403JSONResponseBodyType.
+const (
+	SetProductStoreState403JSONResponseBodyTypeAuthorizationError SetProductStoreState403JSONResponseBodyType = "authorization_error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState403JSONResponseBodyType enum.
+func (e SetProductStoreState403JSONResponseBodyType) Valid() bool {
+	switch e {
+	case SetProductStoreState403JSONResponseBodyTypeAuthorizationError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState404JSONResponseBodyObject.
+const (
+	SetProductStoreState404JSONResponseBodyObjectError SetProductStoreState404JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState404JSONResponseBodyObject enum.
+func (e SetProductStoreState404JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case SetProductStoreState404JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState404JSONResponseBodyType.
+const (
+	SetProductStoreState404JSONResponseBodyTypeResourceMissing SetProductStoreState404JSONResponseBodyType = "resource_missing"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState404JSONResponseBodyType enum.
+func (e SetProductStoreState404JSONResponseBodyType) Valid() bool {
+	switch e {
+	case SetProductStoreState404JSONResponseBodyTypeResourceMissing:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState409JSONResponseBodyObject.
+const (
+	SetProductStoreState409JSONResponseBodyObjectError SetProductStoreState409JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState409JSONResponseBodyObject enum.
+func (e SetProductStoreState409JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case SetProductStoreState409JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState409JSONResponseBodyType.
+const (
+	SetProductStoreState409JSONResponseBodyTypeIdempotencyError      SetProductStoreState409JSONResponseBodyType = "idempotency_error"
+	SetProductStoreState409JSONResponseBodyTypeResourceAlreadyExists SetProductStoreState409JSONResponseBodyType = "resource_already_exists"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState409JSONResponseBodyType enum.
+func (e SetProductStoreState409JSONResponseBodyType) Valid() bool {
+	switch e {
+	case SetProductStoreState409JSONResponseBodyTypeIdempotencyError:
+		return true
+	case SetProductStoreState409JSONResponseBodyTypeResourceAlreadyExists:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState422JSONResponseBodyObject.
+const (
+	SetProductStoreState422JSONResponseBodyObjectError SetProductStoreState422JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState422JSONResponseBodyObject enum.
+func (e SetProductStoreState422JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case SetProductStoreState422JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState422JSONResponseBodyType.
+const (
+	SetProductStoreState422JSONResponseBodyTypeEntityReferencesArchivedEntities SetProductStoreState422JSONResponseBodyType = "entity_references_archived_entities"
+	SetProductStoreState422JSONResponseBodyTypeParameterError                   SetProductStoreState422JSONResponseBodyType = "parameter_error"
+	SetProductStoreState422JSONResponseBodyTypeStoreError                       SetProductStoreState422JSONResponseBodyType = "store_error"
+	SetProductStoreState422JSONResponseBodyTypeUnprocessableEntityError         SetProductStoreState422JSONResponseBodyType = "unprocessable_entity_error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState422JSONResponseBodyType enum.
+func (e SetProductStoreState422JSONResponseBodyType) Valid() bool {
+	switch e {
+	case SetProductStoreState422JSONResponseBodyTypeEntityReferencesArchivedEntities:
+		return true
+	case SetProductStoreState422JSONResponseBodyTypeParameterError:
+		return true
+	case SetProductStoreState422JSONResponseBodyTypeStoreError:
+		return true
+	case SetProductStoreState422JSONResponseBodyTypeUnprocessableEntityError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState423JSONResponseBodyObject.
+const (
+	SetProductStoreState423JSONResponseBodyObjectError SetProductStoreState423JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState423JSONResponseBodyObject enum.
+func (e SetProductStoreState423JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case SetProductStoreState423JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState423JSONResponseBodyType.
+const (
+	SetProductStoreState423JSONResponseBodyTypeResourceLockedError SetProductStoreState423JSONResponseBodyType = "resource_locked_error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState423JSONResponseBodyType enum.
+func (e SetProductStoreState423JSONResponseBodyType) Valid() bool {
+	switch e {
+	case SetProductStoreState423JSONResponseBodyTypeResourceLockedError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState429JSONResponseBodyObject.
+const (
+	SetProductStoreState429JSONResponseBodyObjectError SetProductStoreState429JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState429JSONResponseBodyObject enum.
+func (e SetProductStoreState429JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case SetProductStoreState429JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState429JSONResponseBodyType.
+const (
+	SetProductStoreState429JSONResponseBodyTypeRateLimitError SetProductStoreState429JSONResponseBodyType = "rate_limit_error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState429JSONResponseBodyType enum.
+func (e SetProductStoreState429JSONResponseBodyType) Valid() bool {
+	switch e {
+	case SetProductStoreState429JSONResponseBodyTypeRateLimitError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState500JSONResponseBodyObject.
+const (
+	SetProductStoreState500JSONResponseBodyObjectError SetProductStoreState500JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState500JSONResponseBodyObject enum.
+func (e SetProductStoreState500JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case SetProductStoreState500JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState500JSONResponseBodyType.
+const (
+	SetProductStoreState500JSONResponseBodyTypeServerError SetProductStoreState500JSONResponseBodyType = "server_error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState500JSONResponseBodyType enum.
+func (e SetProductStoreState500JSONResponseBodyType) Valid() bool {
+	switch e {
+	case SetProductStoreState500JSONResponseBodyTypeServerError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState503JSONResponseBodyObject.
+const (
+	SetProductStoreState503JSONResponseBodyObjectError SetProductStoreState503JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState503JSONResponseBodyObject enum.
+func (e SetProductStoreState503JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case SetProductStoreState503JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SetProductStoreState503JSONResponseBodyType.
+const (
+	SetProductStoreState503JSONResponseBodyTypeServerError SetProductStoreState503JSONResponseBodyType = "server_error"
+)
+
+// Valid indicates whether the value is a known member of the SetProductStoreState503JSONResponseBodyType enum.
+func (e SetProductStoreState503JSONResponseBodyType) Valid() bool {
+	switch e {
+	case SetProductStoreState503JSONResponseBodyTypeServerError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPricesJSONBodyStore.
+const (
+	EqualizeSubscriptionPricesJSONBodyStoreAppStore EqualizeSubscriptionPricesJSONBodyStore = "app_store"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPricesJSONBodyStore enum.
+func (e EqualizeSubscriptionPricesJSONBodyStore) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPricesJSONBodyStoreAppStore:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices202JSONResponseBodyStatus.
+const (
+	EqualizeSubscriptionPrices202JSONResponseBodyStatusPending EqualizeSubscriptionPrices202JSONResponseBodyStatus = "pending"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices202JSONResponseBodyStatus enum.
+func (e EqualizeSubscriptionPrices202JSONResponseBodyStatus) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices202JSONResponseBodyStatusPending:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices400JSONResponseBodyObject.
+const (
+	EqualizeSubscriptionPrices400JSONResponseBodyObjectError EqualizeSubscriptionPrices400JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices400JSONResponseBodyObject enum.
+func (e EqualizeSubscriptionPrices400JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices400JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices400JSONResponseBodyType.
+const (
+	EqualizeSubscriptionPrices400JSONResponseBodyTypeInvalidRequest EqualizeSubscriptionPrices400JSONResponseBodyType = "invalid_request"
+	EqualizeSubscriptionPrices400JSONResponseBodyTypeParameterError EqualizeSubscriptionPrices400JSONResponseBodyType = "parameter_error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices400JSONResponseBodyType enum.
+func (e EqualizeSubscriptionPrices400JSONResponseBodyType) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices400JSONResponseBodyTypeInvalidRequest:
+		return true
+	case EqualizeSubscriptionPrices400JSONResponseBodyTypeParameterError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices401JSONResponseBodyObject.
+const (
+	EqualizeSubscriptionPrices401JSONResponseBodyObjectError EqualizeSubscriptionPrices401JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices401JSONResponseBodyObject enum.
+func (e EqualizeSubscriptionPrices401JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices401JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices401JSONResponseBodyType.
+const (
+	EqualizeSubscriptionPrices401JSONResponseBodyTypeAuthenticationError EqualizeSubscriptionPrices401JSONResponseBodyType = "authentication_error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices401JSONResponseBodyType enum.
+func (e EqualizeSubscriptionPrices401JSONResponseBodyType) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices401JSONResponseBodyTypeAuthenticationError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices403JSONResponseBodyObject.
+const (
+	EqualizeSubscriptionPrices403JSONResponseBodyObjectError EqualizeSubscriptionPrices403JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices403JSONResponseBodyObject enum.
+func (e EqualizeSubscriptionPrices403JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices403JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices403JSONResponseBodyType.
+const (
+	EqualizeSubscriptionPrices403JSONResponseBodyTypeAuthorizationError EqualizeSubscriptionPrices403JSONResponseBodyType = "authorization_error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices403JSONResponseBodyType enum.
+func (e EqualizeSubscriptionPrices403JSONResponseBodyType) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices403JSONResponseBodyTypeAuthorizationError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices404JSONResponseBodyObject.
+const (
+	EqualizeSubscriptionPrices404JSONResponseBodyObjectError EqualizeSubscriptionPrices404JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices404JSONResponseBodyObject enum.
+func (e EqualizeSubscriptionPrices404JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices404JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices404JSONResponseBodyType.
+const (
+	EqualizeSubscriptionPrices404JSONResponseBodyTypeResourceMissing EqualizeSubscriptionPrices404JSONResponseBodyType = "resource_missing"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices404JSONResponseBodyType enum.
+func (e EqualizeSubscriptionPrices404JSONResponseBodyType) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices404JSONResponseBodyTypeResourceMissing:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices409JSONResponseBodyObject.
+const (
+	EqualizeSubscriptionPrices409JSONResponseBodyObjectError EqualizeSubscriptionPrices409JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices409JSONResponseBodyObject enum.
+func (e EqualizeSubscriptionPrices409JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices409JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices409JSONResponseBodyType.
+const (
+	EqualizeSubscriptionPrices409JSONResponseBodyTypeIdempotencyError      EqualizeSubscriptionPrices409JSONResponseBodyType = "idempotency_error"
+	EqualizeSubscriptionPrices409JSONResponseBodyTypeResourceAlreadyExists EqualizeSubscriptionPrices409JSONResponseBodyType = "resource_already_exists"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices409JSONResponseBodyType enum.
+func (e EqualizeSubscriptionPrices409JSONResponseBodyType) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices409JSONResponseBodyTypeIdempotencyError:
+		return true
+	case EqualizeSubscriptionPrices409JSONResponseBodyTypeResourceAlreadyExists:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices422JSONResponseBodyObject.
+const (
+	EqualizeSubscriptionPrices422JSONResponseBodyObjectError EqualizeSubscriptionPrices422JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices422JSONResponseBodyObject enum.
+func (e EqualizeSubscriptionPrices422JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices422JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices422JSONResponseBodyType.
+const (
+	EqualizeSubscriptionPrices422JSONResponseBodyTypeEntityReferencesArchivedEntities EqualizeSubscriptionPrices422JSONResponseBodyType = "entity_references_archived_entities"
+	EqualizeSubscriptionPrices422JSONResponseBodyTypeParameterError                   EqualizeSubscriptionPrices422JSONResponseBodyType = "parameter_error"
+	EqualizeSubscriptionPrices422JSONResponseBodyTypeStoreError                       EqualizeSubscriptionPrices422JSONResponseBodyType = "store_error"
+	EqualizeSubscriptionPrices422JSONResponseBodyTypeUnprocessableEntityError         EqualizeSubscriptionPrices422JSONResponseBodyType = "unprocessable_entity_error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices422JSONResponseBodyType enum.
+func (e EqualizeSubscriptionPrices422JSONResponseBodyType) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices422JSONResponseBodyTypeEntityReferencesArchivedEntities:
+		return true
+	case EqualizeSubscriptionPrices422JSONResponseBodyTypeParameterError:
+		return true
+	case EqualizeSubscriptionPrices422JSONResponseBodyTypeStoreError:
+		return true
+	case EqualizeSubscriptionPrices422JSONResponseBodyTypeUnprocessableEntityError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices423JSONResponseBodyObject.
+const (
+	EqualizeSubscriptionPrices423JSONResponseBodyObjectError EqualizeSubscriptionPrices423JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices423JSONResponseBodyObject enum.
+func (e EqualizeSubscriptionPrices423JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices423JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices423JSONResponseBodyType.
+const (
+	EqualizeSubscriptionPrices423JSONResponseBodyTypeResourceLockedError EqualizeSubscriptionPrices423JSONResponseBodyType = "resource_locked_error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices423JSONResponseBodyType enum.
+func (e EqualizeSubscriptionPrices423JSONResponseBodyType) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices423JSONResponseBodyTypeResourceLockedError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices429JSONResponseBodyObject.
+const (
+	EqualizeSubscriptionPrices429JSONResponseBodyObjectError EqualizeSubscriptionPrices429JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices429JSONResponseBodyObject enum.
+func (e EqualizeSubscriptionPrices429JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices429JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices429JSONResponseBodyType.
+const (
+	EqualizeSubscriptionPrices429JSONResponseBodyTypeRateLimitError EqualizeSubscriptionPrices429JSONResponseBodyType = "rate_limit_error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices429JSONResponseBodyType enum.
+func (e EqualizeSubscriptionPrices429JSONResponseBodyType) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices429JSONResponseBodyTypeRateLimitError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices500JSONResponseBodyObject.
+const (
+	EqualizeSubscriptionPrices500JSONResponseBodyObjectError EqualizeSubscriptionPrices500JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices500JSONResponseBodyObject enum.
+func (e EqualizeSubscriptionPrices500JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices500JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices500JSONResponseBodyType.
+const (
+	EqualizeSubscriptionPrices500JSONResponseBodyTypeServerError EqualizeSubscriptionPrices500JSONResponseBodyType = "server_error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices500JSONResponseBodyType enum.
+func (e EqualizeSubscriptionPrices500JSONResponseBodyType) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices500JSONResponseBodyTypeServerError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices503JSONResponseBodyObject.
+const (
+	EqualizeSubscriptionPrices503JSONResponseBodyObjectError EqualizeSubscriptionPrices503JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices503JSONResponseBodyObject enum.
+func (e EqualizeSubscriptionPrices503JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices503JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EqualizeSubscriptionPrices503JSONResponseBodyType.
+const (
+	EqualizeSubscriptionPrices503JSONResponseBodyTypeServerError EqualizeSubscriptionPrices503JSONResponseBodyType = "server_error"
+)
+
+// Valid indicates whether the value is a known member of the EqualizeSubscriptionPrices503JSONResponseBodyType enum.
+func (e EqualizeSubscriptionPrices503JSONResponseBodyType) Valid() bool {
+	switch e {
+	case EqualizeSubscriptionPrices503JSONResponseBodyTypeServerError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot400JSONResponseBodyObject.
+const (
+	UploadProductStoreStateScreenshot400JSONResponseBodyObjectError UploadProductStoreStateScreenshot400JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot400JSONResponseBodyObject enum.
+func (e UploadProductStoreStateScreenshot400JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot400JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot400JSONResponseBodyType.
+const (
+	UploadProductStoreStateScreenshot400JSONResponseBodyTypeInvalidRequest UploadProductStoreStateScreenshot400JSONResponseBodyType = "invalid_request"
+	UploadProductStoreStateScreenshot400JSONResponseBodyTypeParameterError UploadProductStoreStateScreenshot400JSONResponseBodyType = "parameter_error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot400JSONResponseBodyType enum.
+func (e UploadProductStoreStateScreenshot400JSONResponseBodyType) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot400JSONResponseBodyTypeInvalidRequest:
+		return true
+	case UploadProductStoreStateScreenshot400JSONResponseBodyTypeParameterError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot401JSONResponseBodyObject.
+const (
+	UploadProductStoreStateScreenshot401JSONResponseBodyObjectError UploadProductStoreStateScreenshot401JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot401JSONResponseBodyObject enum.
+func (e UploadProductStoreStateScreenshot401JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot401JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot401JSONResponseBodyType.
+const (
+	UploadProductStoreStateScreenshot401JSONResponseBodyTypeAuthenticationError UploadProductStoreStateScreenshot401JSONResponseBodyType = "authentication_error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot401JSONResponseBodyType enum.
+func (e UploadProductStoreStateScreenshot401JSONResponseBodyType) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot401JSONResponseBodyTypeAuthenticationError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot403JSONResponseBodyObject.
+const (
+	UploadProductStoreStateScreenshot403JSONResponseBodyObjectError UploadProductStoreStateScreenshot403JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot403JSONResponseBodyObject enum.
+func (e UploadProductStoreStateScreenshot403JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot403JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot403JSONResponseBodyType.
+const (
+	UploadProductStoreStateScreenshot403JSONResponseBodyTypeAuthorizationError UploadProductStoreStateScreenshot403JSONResponseBodyType = "authorization_error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot403JSONResponseBodyType enum.
+func (e UploadProductStoreStateScreenshot403JSONResponseBodyType) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot403JSONResponseBodyTypeAuthorizationError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot404JSONResponseBodyObject.
+const (
+	UploadProductStoreStateScreenshot404JSONResponseBodyObjectError UploadProductStoreStateScreenshot404JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot404JSONResponseBodyObject enum.
+func (e UploadProductStoreStateScreenshot404JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot404JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot404JSONResponseBodyType.
+const (
+	UploadProductStoreStateScreenshot404JSONResponseBodyTypeResourceMissing UploadProductStoreStateScreenshot404JSONResponseBodyType = "resource_missing"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot404JSONResponseBodyType enum.
+func (e UploadProductStoreStateScreenshot404JSONResponseBodyType) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot404JSONResponseBodyTypeResourceMissing:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot409JSONResponseBodyObject.
+const (
+	UploadProductStoreStateScreenshot409JSONResponseBodyObjectError UploadProductStoreStateScreenshot409JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot409JSONResponseBodyObject enum.
+func (e UploadProductStoreStateScreenshot409JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot409JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot409JSONResponseBodyType.
+const (
+	UploadProductStoreStateScreenshot409JSONResponseBodyTypeIdempotencyError      UploadProductStoreStateScreenshot409JSONResponseBodyType = "idempotency_error"
+	UploadProductStoreStateScreenshot409JSONResponseBodyTypeResourceAlreadyExists UploadProductStoreStateScreenshot409JSONResponseBodyType = "resource_already_exists"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot409JSONResponseBodyType enum.
+func (e UploadProductStoreStateScreenshot409JSONResponseBodyType) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot409JSONResponseBodyTypeIdempotencyError:
+		return true
+	case UploadProductStoreStateScreenshot409JSONResponseBodyTypeResourceAlreadyExists:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot422JSONResponseBodyObject.
+const (
+	UploadProductStoreStateScreenshot422JSONResponseBodyObjectError UploadProductStoreStateScreenshot422JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot422JSONResponseBodyObject enum.
+func (e UploadProductStoreStateScreenshot422JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot422JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot422JSONResponseBodyType.
+const (
+	UploadProductStoreStateScreenshot422JSONResponseBodyTypeEntityReferencesArchivedEntities UploadProductStoreStateScreenshot422JSONResponseBodyType = "entity_references_archived_entities"
+	UploadProductStoreStateScreenshot422JSONResponseBodyTypeParameterError                   UploadProductStoreStateScreenshot422JSONResponseBodyType = "parameter_error"
+	UploadProductStoreStateScreenshot422JSONResponseBodyTypeStoreError                       UploadProductStoreStateScreenshot422JSONResponseBodyType = "store_error"
+	UploadProductStoreStateScreenshot422JSONResponseBodyTypeUnprocessableEntityError         UploadProductStoreStateScreenshot422JSONResponseBodyType = "unprocessable_entity_error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot422JSONResponseBodyType enum.
+func (e UploadProductStoreStateScreenshot422JSONResponseBodyType) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot422JSONResponseBodyTypeEntityReferencesArchivedEntities:
+		return true
+	case UploadProductStoreStateScreenshot422JSONResponseBodyTypeParameterError:
+		return true
+	case UploadProductStoreStateScreenshot422JSONResponseBodyTypeStoreError:
+		return true
+	case UploadProductStoreStateScreenshot422JSONResponseBodyTypeUnprocessableEntityError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot423JSONResponseBodyObject.
+const (
+	UploadProductStoreStateScreenshot423JSONResponseBodyObjectError UploadProductStoreStateScreenshot423JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot423JSONResponseBodyObject enum.
+func (e UploadProductStoreStateScreenshot423JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot423JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot423JSONResponseBodyType.
+const (
+	UploadProductStoreStateScreenshot423JSONResponseBodyTypeResourceLockedError UploadProductStoreStateScreenshot423JSONResponseBodyType = "resource_locked_error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot423JSONResponseBodyType enum.
+func (e UploadProductStoreStateScreenshot423JSONResponseBodyType) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot423JSONResponseBodyTypeResourceLockedError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot429JSONResponseBodyObject.
+const (
+	UploadProductStoreStateScreenshot429JSONResponseBodyObjectError UploadProductStoreStateScreenshot429JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot429JSONResponseBodyObject enum.
+func (e UploadProductStoreStateScreenshot429JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot429JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot429JSONResponseBodyType.
+const (
+	UploadProductStoreStateScreenshot429JSONResponseBodyTypeRateLimitError UploadProductStoreStateScreenshot429JSONResponseBodyType = "rate_limit_error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot429JSONResponseBodyType enum.
+func (e UploadProductStoreStateScreenshot429JSONResponseBodyType) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot429JSONResponseBodyTypeRateLimitError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot500JSONResponseBodyObject.
+const (
+	UploadProductStoreStateScreenshot500JSONResponseBodyObjectError UploadProductStoreStateScreenshot500JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot500JSONResponseBodyObject enum.
+func (e UploadProductStoreStateScreenshot500JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot500JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot500JSONResponseBodyType.
+const (
+	UploadProductStoreStateScreenshot500JSONResponseBodyTypeServerError UploadProductStoreStateScreenshot500JSONResponseBodyType = "server_error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot500JSONResponseBodyType enum.
+func (e UploadProductStoreStateScreenshot500JSONResponseBodyType) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot500JSONResponseBodyTypeServerError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot503JSONResponseBodyObject.
+const (
+	UploadProductStoreStateScreenshot503JSONResponseBodyObjectError UploadProductStoreStateScreenshot503JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot503JSONResponseBodyObject enum.
+func (e UploadProductStoreStateScreenshot503JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot503JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for UploadProductStoreStateScreenshot503JSONResponseBodyType.
+const (
+	UploadProductStoreStateScreenshot503JSONResponseBodyTypeServerError UploadProductStoreStateScreenshot503JSONResponseBodyType = "server_error"
+)
+
+// Valid indicates whether the value is a known member of the UploadProductStoreStateScreenshot503JSONResponseBodyType enum.
+func (e UploadProductStoreStateScreenshot503JSONResponseBodyType) Valid() bool {
+	switch e {
+	case UploadProductStoreStateScreenshot503JSONResponseBodyTypeServerError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation200JSONResponseBodyStatus.
+const (
+	GetProductStoreStateOperation200JSONResponseBodyStatusFailed    GetProductStoreStateOperation200JSONResponseBodyStatus = "failed"
+	GetProductStoreStateOperation200JSONResponseBodyStatusPending   GetProductStoreStateOperation200JSONResponseBodyStatus = "pending"
+	GetProductStoreStateOperation200JSONResponseBodyStatusRunning   GetProductStoreStateOperation200JSONResponseBodyStatus = "running"
+	GetProductStoreStateOperation200JSONResponseBodyStatusSucceeded GetProductStoreStateOperation200JSONResponseBodyStatus = "succeeded"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation200JSONResponseBodyStatus enum.
+func (e GetProductStoreStateOperation200JSONResponseBodyStatus) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation200JSONResponseBodyStatusFailed:
+		return true
+	case GetProductStoreStateOperation200JSONResponseBodyStatusPending:
+		return true
+	case GetProductStoreStateOperation200JSONResponseBodyStatusRunning:
+		return true
+	case GetProductStoreStateOperation200JSONResponseBodyStatusSucceeded:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation400JSONResponseBodyObject.
+const (
+	GetProductStoreStateOperation400JSONResponseBodyObjectError GetProductStoreStateOperation400JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation400JSONResponseBodyObject enum.
+func (e GetProductStoreStateOperation400JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation400JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation400JSONResponseBodyType.
+const (
+	GetProductStoreStateOperation400JSONResponseBodyTypeInvalidRequest GetProductStoreStateOperation400JSONResponseBodyType = "invalid_request"
+	GetProductStoreStateOperation400JSONResponseBodyTypeParameterError GetProductStoreStateOperation400JSONResponseBodyType = "parameter_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation400JSONResponseBodyType enum.
+func (e GetProductStoreStateOperation400JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation400JSONResponseBodyTypeInvalidRequest:
+		return true
+	case GetProductStoreStateOperation400JSONResponseBodyTypeParameterError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation401JSONResponseBodyObject.
+const (
+	GetProductStoreStateOperation401JSONResponseBodyObjectError GetProductStoreStateOperation401JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation401JSONResponseBodyObject enum.
+func (e GetProductStoreStateOperation401JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation401JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation401JSONResponseBodyType.
+const (
+	GetProductStoreStateOperation401JSONResponseBodyTypeAuthenticationError GetProductStoreStateOperation401JSONResponseBodyType = "authentication_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation401JSONResponseBodyType enum.
+func (e GetProductStoreStateOperation401JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation401JSONResponseBodyTypeAuthenticationError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation403JSONResponseBodyObject.
+const (
+	GetProductStoreStateOperation403JSONResponseBodyObjectError GetProductStoreStateOperation403JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation403JSONResponseBodyObject enum.
+func (e GetProductStoreStateOperation403JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation403JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation403JSONResponseBodyType.
+const (
+	GetProductStoreStateOperation403JSONResponseBodyTypeAuthorizationError GetProductStoreStateOperation403JSONResponseBodyType = "authorization_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation403JSONResponseBodyType enum.
+func (e GetProductStoreStateOperation403JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation403JSONResponseBodyTypeAuthorizationError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation404JSONResponseBodyObject.
+const (
+	GetProductStoreStateOperation404JSONResponseBodyObjectError GetProductStoreStateOperation404JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation404JSONResponseBodyObject enum.
+func (e GetProductStoreStateOperation404JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation404JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation404JSONResponseBodyType.
+const (
+	GetProductStoreStateOperation404JSONResponseBodyTypeResourceMissing GetProductStoreStateOperation404JSONResponseBodyType = "resource_missing"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation404JSONResponseBodyType enum.
+func (e GetProductStoreStateOperation404JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation404JSONResponseBodyTypeResourceMissing:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation422JSONResponseBodyObject.
+const (
+	GetProductStoreStateOperation422JSONResponseBodyObjectError GetProductStoreStateOperation422JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation422JSONResponseBodyObject enum.
+func (e GetProductStoreStateOperation422JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation422JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation422JSONResponseBodyType.
+const (
+	GetProductStoreStateOperation422JSONResponseBodyTypeEntityReferencesArchivedEntities GetProductStoreStateOperation422JSONResponseBodyType = "entity_references_archived_entities"
+	GetProductStoreStateOperation422JSONResponseBodyTypeParameterError                   GetProductStoreStateOperation422JSONResponseBodyType = "parameter_error"
+	GetProductStoreStateOperation422JSONResponseBodyTypeStoreError                       GetProductStoreStateOperation422JSONResponseBodyType = "store_error"
+	GetProductStoreStateOperation422JSONResponseBodyTypeUnprocessableEntityError         GetProductStoreStateOperation422JSONResponseBodyType = "unprocessable_entity_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation422JSONResponseBodyType enum.
+func (e GetProductStoreStateOperation422JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation422JSONResponseBodyTypeEntityReferencesArchivedEntities:
+		return true
+	case GetProductStoreStateOperation422JSONResponseBodyTypeParameterError:
+		return true
+	case GetProductStoreStateOperation422JSONResponseBodyTypeStoreError:
+		return true
+	case GetProductStoreStateOperation422JSONResponseBodyTypeUnprocessableEntityError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation423JSONResponseBodyObject.
+const (
+	GetProductStoreStateOperation423JSONResponseBodyObjectError GetProductStoreStateOperation423JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation423JSONResponseBodyObject enum.
+func (e GetProductStoreStateOperation423JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation423JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation423JSONResponseBodyType.
+const (
+	GetProductStoreStateOperation423JSONResponseBodyTypeResourceLockedError GetProductStoreStateOperation423JSONResponseBodyType = "resource_locked_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation423JSONResponseBodyType enum.
+func (e GetProductStoreStateOperation423JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation423JSONResponseBodyTypeResourceLockedError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation429JSONResponseBodyObject.
+const (
+	GetProductStoreStateOperation429JSONResponseBodyObjectError GetProductStoreStateOperation429JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation429JSONResponseBodyObject enum.
+func (e GetProductStoreStateOperation429JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation429JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation429JSONResponseBodyType.
+const (
+	GetProductStoreStateOperation429JSONResponseBodyTypeRateLimitError GetProductStoreStateOperation429JSONResponseBodyType = "rate_limit_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation429JSONResponseBodyType enum.
+func (e GetProductStoreStateOperation429JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation429JSONResponseBodyTypeRateLimitError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation500JSONResponseBodyObject.
+const (
+	GetProductStoreStateOperation500JSONResponseBodyObjectError GetProductStoreStateOperation500JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation500JSONResponseBodyObject enum.
+func (e GetProductStoreStateOperation500JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation500JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation500JSONResponseBodyType.
+const (
+	GetProductStoreStateOperation500JSONResponseBodyTypeServerError GetProductStoreStateOperation500JSONResponseBodyType = "server_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation500JSONResponseBodyType enum.
+func (e GetProductStoreStateOperation500JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation500JSONResponseBodyTypeServerError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation503JSONResponseBodyObject.
+const (
+	GetProductStoreStateOperation503JSONResponseBodyObjectError GetProductStoreStateOperation503JSONResponseBodyObject = "error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation503JSONResponseBodyObject enum.
+func (e GetProductStoreStateOperation503JSONResponseBodyObject) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation503JSONResponseBodyObjectError:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreStateOperation503JSONResponseBodyType.
+const (
+	GetProductStoreStateOperation503JSONResponseBodyTypeServerError GetProductStoreStateOperation503JSONResponseBodyType = "server_error"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreStateOperation503JSONResponseBodyType enum.
+func (e GetProductStoreStateOperation503JSONResponseBodyType) Valid() bool {
+	switch e {
+	case GetProductStoreStateOperation503JSONResponseBodyTypeServerError:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for SearchPurchases400JSONResponseBodyObject.
 const (
 	SearchPurchases400JSONResponseBodyObjectError SearchPurchases400JSONResponseBodyObject = "error"
@@ -37921,6 +40156,563 @@ type PlayStoreAppCreate struct {
 // Mac App Store is disabled by default. See [Legacy Mac Apps](https://www.revenuecat.com/docs/legacy-mac-apps) for more details.
 type PlayStoreAppCreateType string
 
+// PlayStoreBasePlanConfig Configuration for a single Play subscription base plan. Mirrors Google's `BasePlan`. At most one of `auto_renewing_base_plan_type`, `prepaid_base_plan_type`, or `installments_base_plan_type` may be set; setting more than one is rejected at plan creation. Plan items that only modify regional/state/offer fields may omit all three.
+type PlayStoreBasePlanConfig struct {
+	// AutoRenewingBasePlanType Auto-renewing variant of the base plan.
+	AutoRenewingBasePlanType *struct {
+		// AccountHoldDuration Example: P30D
+		AccountHoldDuration *string `json:"account_hold_duration,omitempty"`
+
+		// BillingPeriodDuration ISO-8601 duration string (e.g. `P1M`).
+		//
+		// Example: P1M
+		BillingPeriodDuration string `json:"billing_period_duration"`
+
+		// GracePeriodDuration Example: P3D
+		GracePeriodDuration *string `json:"grace_period_duration,omitempty"`
+
+		// LegacyCompatible Example: false
+		LegacyCompatible *bool `json:"legacy_compatible,omitempty"`
+
+		// LegacyCompatibleSubscriptionOfferID Example: legacy-offer
+		LegacyCompatibleSubscriptionOfferID *string `json:"legacy_compatible_subscription_offer_id,omitempty"`
+
+		// ProrationMode Example: SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE
+		ProrationMode *PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationMode `json:"proration_mode,omitempty"`
+
+		// ResubscribeState Example: RESUBSCRIBE_STATE_ACTIVE
+		ResubscribeState *PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeState `json:"resubscribe_state,omitempty"`
+	} `json:"auto_renewing_base_plan_type,omitempty"`
+
+	// InstallmentsBasePlanType Installments variant of the base plan.
+	InstallmentsBasePlanType *struct {
+		// AccountHoldDuration Example: P30D
+		AccountHoldDuration *string `json:"account_hold_duration,omitempty"`
+
+		// BillingPeriodDuration Example: P1M
+		BillingPeriodDuration string `json:"billing_period_duration"`
+
+		// CommittedPaymentsCount Example: 12
+		CommittedPaymentsCount int `json:"committed_payments_count"`
+
+		// GracePeriodDuration Example: P3D
+		GracePeriodDuration *string `json:"grace_period_duration,omitempty"`
+
+		// ProrationMode Example: SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE
+		ProrationMode *PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationMode `json:"proration_mode,omitempty"`
+
+		// RenewalType Example: RENEWAL_TYPE_RENEWS_WITHOUT_COMMITMENT
+		RenewalType PlayStoreBasePlanConfigInstallmentsBasePlanTypeRenewalType `json:"renewal_type"`
+
+		// ResubscribeState Example: RESUBSCRIBE_STATE_ACTIVE
+		ResubscribeState *PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeState `json:"resubscribe_state,omitempty"`
+	} `json:"installments_base_plan_type,omitempty"`
+
+	// OfferTags Free-form tags attached to the base plan.
+	OfferTags *[]string `json:"offer_tags,omitempty"`
+
+	// Offers Subscription offers attached to this base plan, keyed by `offer_id` (1-63 lowercase alphanumerics or hyphens). Each value is a `PlayStoreOfferConfig`:
+	//
+	// - `state`: `DRAFT` | `ACTIVE` | `INACTIVE` (defaults to `DRAFT`; an
+	//   `ACTIVE` offer must define at least one phase).
+	//
+	// - `phases`: ordered list of `{ recurrence_count (int >= 1),
+	//   duration (ISO-8601, e.g. P1W), regional_configs{ <region>: { EXACTLY
+	//   ONE of `price` (`{ amount_micros, currency }`) / `free: true` /
+	//   `absolute_discount` (`{ amount_micros, currency }`) /
+	//   `relative_discount` (fraction in `[0, 1]`) } }, other_regions_config? }`.
+	//
+	// - `regional_configs`: per-region `{ new_subscriber_availability }`
+	//   overrides keyed by region code.
+	//
+	// - `other_regions_config`, `targeting`
+	//   (`{ acquisition_rule?, upgrade_rule? }`, at most one), and
+	//   `offer_tags` (array of strings) are all optional.
+	//
+	// Example: {"welcome-offer":{"offer_tags":["launch-promo"],"phases":[{"duration":"P1W","recurrence_count":1,"regional_configs":{"US":{"free":true}}}],"state":"ACTIVE"}}
+	Offers *map[string]PlayStoreOfferConfig `json:"offers,omitempty"`
+
+	// OtherRegionsConfig Default availability and pricing for regions without an explicit `regional_configs` entry.
+	OtherRegionsConfig *struct {
+		// EurPrice Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+		EurPrice *PlayStoreTerritoryPrice `json:"eur_price,omitempty"`
+
+		// NewSubscriberAvailability Example: true
+		NewSubscriberAvailability *bool `json:"new_subscriber_availability,omitempty"`
+
+		// UsdPrice Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+		UsdPrice *PlayStoreTerritoryPrice `json:"usd_price,omitempty"`
+	} `json:"other_regions_config,omitempty"`
+
+	// PrepaidBasePlanType Prepaid variant of the base plan.
+	PrepaidBasePlanType *struct {
+		// BillingPeriodDuration Example: P1M
+		BillingPeriodDuration string `json:"billing_period_duration"`
+
+		// TimeExtension Example: TIME_EXTENSION_ACTIVE
+		TimeExtension *PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtension `json:"time_extension,omitempty"`
+	} `json:"prepaid_base_plan_type,omitempty"`
+
+	// RegionalConfigs Per-region availability and price overrides keyed by region code.
+	RegionalConfigs *map[string]struct {
+		// NewSubscriberAvailability Example: true
+		NewSubscriberAvailability *bool `json:"new_subscriber_availability,omitempty"`
+
+		// Price Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+		Price *PlayStoreTerritoryPrice `json:"price,omitempty"`
+	} `json:"regional_configs,omitempty"`
+
+	// State Lifecycle state of the base plan.
+	//
+	// Example: ACTIVE
+	State *PlayStoreBasePlanConfigState `json:"state,omitempty"`
+}
+
+// PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationMode Example: SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE
+type PlayStoreBasePlanConfigAutoRenewingBasePlanTypeProrationMode string
+
+// PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeState Example: RESUBSCRIBE_STATE_ACTIVE
+type PlayStoreBasePlanConfigAutoRenewingBasePlanTypeResubscribeState string
+
+// PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationMode Example: SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE
+type PlayStoreBasePlanConfigInstallmentsBasePlanTypeProrationMode string
+
+// PlayStoreBasePlanConfigInstallmentsBasePlanTypeRenewalType Example: RENEWAL_TYPE_RENEWS_WITHOUT_COMMITMENT
+type PlayStoreBasePlanConfigInstallmentsBasePlanTypeRenewalType string
+
+// PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeState Example: RESUBSCRIBE_STATE_ACTIVE
+type PlayStoreBasePlanConfigInstallmentsBasePlanTypeResubscribeState string
+
+// PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtension Example: TIME_EXTENSION_ACTIVE
+type PlayStoreBasePlanConfigPrepaidBasePlanTypeTimeExtension string
+
+// PlayStoreBasePlanConfigState Lifecycle state of the base plan.
+//
+// Example: ACTIVE
+type PlayStoreBasePlanConfigState string
+
+// PlayStoreOfferConfig A single subscription offer attached to a base plan (keyed by `offer_id` on the parent base plan's `offers` map). Fields:
+//
+//   - `state`: `DRAFT` | `ACTIVE` | `INACTIVE` (defaults to `ACTIVE` on create).
+//     An offer created with `state: ACTIVE` must define at least one phase.
+//
+//   - `phases`: ordered list of phases (see `PlayStorePhaseConfig`). Each phase
+//     is `{ recurrence_count (int >= 1), duration (ISO-8601, e.g. P1W),
+//     regional_configs{ <region>: { one of price / free / absolute_discount /
+//     relative_discount } }, other_regions_config? }`.
+//
+//   - `regional_configs`: per-region availability overrides keyed by region
+//     code, each `{ new_subscriber_availability: bool }`.
+//
+//   - `other_regions_config`: availability fallback for regions without an
+//     explicit `regional_configs` entry.
+//
+//   - `targeting`: optional `{ acquisition_rule? , upgrade_rule? }`; at most one
+//     of the two.
+//
+// - `offer_tags`: optional array of strings.
+type PlayStoreOfferConfig struct {
+	// OfferTags Free-form tags attached to the offer.
+	OfferTags *[]string `json:"offer_tags,omitempty"`
+
+	// OtherRegionsConfig Default availability for regions without an explicit `regional_configs` entry.
+	OtherRegionsConfig *struct {
+		// OtherRegionsNewSubscriberAvailability Example: true
+		OtherRegionsNewSubscriberAvailability *bool `json:"other_regions_new_subscriber_availability,omitempty"`
+	} `json:"other_regions_config,omitempty"`
+
+	// Phases Ordered list of offer phases. Each item is a `PlayStorePhaseConfig`: `{ recurrence_count (int >= 1), duration (ISO-8601 string, e.g. `P1W`), regional_configs{ <region_code>: { EXACTLY ONE of price / relative_discount / absolute_discount / free: true } }, other_regions_config? }`. A phase must define at least one `regional_configs` entry or `other_regions_config`. Example: a free trial phase followed by a discounted introductory phase.
+	//
+	// Example: [{"duration":"P1W","recurrence_count":1,"regional_configs":{"US":{"free":true}}},{"duration":"P1M","recurrence_count":3,"regional_configs":{"US":{"price":{"amount_micros":4990000,"currency":"USD"}}}}]
+	Phases *[]PlayStorePhaseConfig `json:"phases,omitempty"`
+
+	// RegionalConfigs Per-region availability overrides keyed by region code.
+	RegionalConfigs *map[string]struct {
+		// NewSubscriberAvailability Example: true
+		NewSubscriberAvailability *bool `json:"new_subscriber_availability,omitempty"`
+	} `json:"regional_configs,omitempty"`
+
+	// State Lifecycle state of the offer.
+	//
+	// Example: ACTIVE
+	State *PlayStoreOfferConfigState `json:"state,omitempty"`
+
+	// Targeting Targeting rule. At most one of `acquisition_rule` or `upgrade_rule` should be set; leaving both unset means developer-determined offer eligibility.
+	Targeting *struct {
+		AcquisitionRule *map[string]interface{} `json:"acquisition_rule,omitempty"`
+		UpgradeRule     *map[string]interface{} `json:"upgrade_rule,omitempty"`
+	} `json:"targeting,omitempty"`
+}
+
+// PlayStoreOfferConfigState Lifecycle state of the offer.
+//
+// Example: ACTIVE
+type PlayStoreOfferConfigState string
+
+// PlayStoreOneTimeOfferConfig A pre-order or discounted offer attached to a Play one-time product purchase option. At most one of `pre_order_offer` or `discounted_offer` may be set in one payload; create flows require one offer type.
+type PlayStoreOneTimeOfferConfig struct {
+	// DiscountedOffer Discounted variant of a Play one-time product offer.
+	DiscountedOffer *PlayStoreOneTimeOfferDiscountedConfig `json:"discounted_offer,omitempty"`
+
+	// OfferTags Free-form tags attached to the one-time product offer.
+	OfferTags *[]string `json:"offer_tags,omitempty"`
+
+	// PreOrderOffer Pre-order variant of a Play one-time product offer.
+	PreOrderOffer *PlayStoreOneTimeOfferPreOrderConfig `json:"pre_order_offer,omitempty"`
+
+	// RegionalConfigs Per-region availability and price overrides keyed by region code.
+	//
+	// Example: {"US":{"availability":"AVAILABLE","relative_discount":0.5}}
+	RegionalConfigs *map[string]PlayStoreOneTimeOfferRegionalConfig `json:"regional_configs,omitempty"`
+
+	// State Lifecycle state of the one-time product offer.
+	//
+	// Example: DRAFT
+	State *PlayStoreOneTimeOfferConfigState `json:"state,omitempty"`
+}
+
+// PlayStoreOneTimeOfferConfigState Lifecycle state of the one-time product offer.
+//
+// Example: DRAFT
+type PlayStoreOneTimeOfferConfigState string
+
+// PlayStoreOneTimeOfferDiscountedConfig Discounted variant of a Play one-time product offer.
+type PlayStoreOneTimeOfferDiscountedConfig struct {
+	// EndTime Optional date-time when the discounted offer ends.
+	//
+	// Example: 2026-01-31T00:00:00Z
+	EndTime *time.Time `json:"end_time,omitempty"`
+
+	// RedemptionLimit Maximum redemptions per user. Omit or set 0 for unlimited.
+	//
+	// Example: 10
+	RedemptionLimit *int `json:"redemption_limit,omitempty"`
+
+	// StartTime Optional date-time when the discounted offer starts.
+	//
+	// Example: 2026-01-01T00:00:00Z
+	StartTime *time.Time `json:"start_time,omitempty"`
+}
+
+// PlayStoreOneTimeOfferPreOrderConfig Pre-order variant of a Play one-time product offer.
+type PlayStoreOneTimeOfferPreOrderConfig struct {
+	// EndTime Date-time when the pre-order offer ends.
+	//
+	// Example: 2026-01-31T00:00:00Z
+	EndTime time.Time `json:"end_time"`
+
+	// PriceChangeBehavior How Play handles pre-order price changes before release.
+	//
+	// Example: PRE_ORDER_PRICE_CHANGE_BEHAVIOR_NEW_ORDERS_ONLY
+	PriceChangeBehavior PlayStoreOneTimeOfferPreOrderConfigPriceChangeBehavior `json:"price_change_behavior"`
+
+	// ReleaseTime Date-time when the product is released.
+	//
+	// Example: 2026-02-01T00:00:00Z
+	ReleaseTime time.Time `json:"release_time"`
+
+	// StartTime Date-time when the pre-order offer starts.
+	//
+	// Example: 2026-01-01T00:00:00Z
+	StartTime time.Time `json:"start_time"`
+}
+
+// PlayStoreOneTimeOfferPreOrderConfigPriceChangeBehavior How Play handles pre-order price changes before release.
+//
+// Example: PRE_ORDER_PRICE_CHANGE_BEHAVIOR_NEW_ORDERS_ONLY
+type PlayStoreOneTimeOfferPreOrderConfigPriceChangeBehavior string
+
+// PlayStoreOneTimeOfferRegionalConfig Per-region availability and price override for a Play one-time product offer.
+type PlayStoreOneTimeOfferRegionalConfig struct {
+	// AbsoluteDiscount Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+	AbsoluteDiscount *PlayStoreTerritoryPrice `json:"absolute_discount,omitempty"`
+
+	// Availability Offer availability in this region.
+	//
+	// Example: AVAILABLE
+	Availability *PlayStoreOneTimeOfferRegionalConfigAvailability `json:"availability,omitempty"`
+
+	// NoOverride Set to `true` to use the purchase option price without a regional offer override. Omit the field to leave the override unspecified; `false` is rejected.
+	//
+	// Example: true
+	NoOverride *bool `json:"no_override,omitempty"`
+
+	// RelativeDiscount Relative discount fraction, strictly between 0 and 1, following Google Play's `relativeDiscount` semantics.
+	//
+	// Example: 0.5
+	RelativeDiscount *float32 `json:"relative_discount,omitempty"`
+}
+
+// PlayStoreOneTimeOfferRegionalConfigAvailability Offer availability in this region.
+//
+// Example: AVAILABLE
+type PlayStoreOneTimeOfferRegionalConfigAvailability string
+
+// PlayStorePhaseConfig A single phase within a subscription offer (e.g. a 1-week free trial, or a 3-month introductory price). Phases are ordered; `recurrence_count` and `duration` are required. Pricing is set per region in `regional_configs` and/or as a fallback in `other_regions_config`; a phase must define at least one of the two.
+type PlayStorePhaseConfig struct {
+	// Duration ISO-8601 duration string (e.g. `P1W`).
+	//
+	// Example: P1W
+	Duration string `json:"duration"`
+
+	// OtherRegionsConfig Default price override for regions without an explicit `regional_configs` entry. Set EXACTLY ONE pricing option: both `other_regions_usd_price` and `other_regions_eur_price` together, OR `relative_discount`, OR both `absolute_discount_usd` and `absolute_discount_eur` together, OR `free: true`.
+	OtherRegionsConfig *struct {
+		// AbsoluteDiscountEur Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+		AbsoluteDiscountEur *PlayStoreTerritoryPrice `json:"absolute_discount_eur,omitempty"`
+
+		// AbsoluteDiscountUsd Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+		AbsoluteDiscountUsd *PlayStoreTerritoryPrice `json:"absolute_discount_usd,omitempty"`
+
+		// Free Set to `true` to make this phase free in fallback regions. Boolean literal, not an object.
+		//
+		// Example: true
+		Free *bool `json:"free,omitempty"`
+
+		// OtherRegionsEurPrice Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+		OtherRegionsEurPrice *PlayStoreTerritoryPrice `json:"other_regions_eur_price,omitempty"`
+
+		// OtherRegionsUsdPrice Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+		OtherRegionsUsdPrice *PlayStoreTerritoryPrice `json:"other_regions_usd_price,omitempty"`
+
+		// RelativeDiscount Example: 0.5
+		RelativeDiscount *float32 `json:"relative_discount,omitempty"`
+	} `json:"other_regions_config,omitempty"`
+
+	// RecurrenceCount Number of times this phase repeats.
+	//
+	// Example: 1
+	RecurrenceCount int `json:"recurrence_count"`
+
+	// RegionalConfigs Per-region price override, keyed by region code (e.g. `US`, `GB`). Each value is a regional config object that sets EXACTLY ONE of the following mutually exclusive pricing fields (a discriminated union — setting zero or more than one is rejected with a 400):
+	//
+	// - `price`: absolute price, a `{ amount_micros, currency }` object
+	//   (e.g. `{ "amount_micros": 9990000, "currency": "GBP" }`).
+	//
+	// - `free`: the boolean literal `true` for a free phase. NOTE: this is a
+	//   boolean, not an object — use `"free": true`, never `{}` or a price
+	//   object.
+	//
+	// - `absolute_discount`: a fixed amount off, as a
+	//   `{ amount_micros, currency }` object.
+	//
+	// - `relative_discount`: a fraction off in `[0, 1]`
+	//   (e.g. `0.5` = 50% off).
+	//
+	// Example: {"GB":{"price":{"amount_micros":9990000,"currency":"GBP"}},"US":{"free":true}}
+	RegionalConfigs *map[string]struct {
+		// AbsoluteDiscount Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+		AbsoluteDiscount *PlayStoreTerritoryPrice `json:"absolute_discount,omitempty"`
+
+		// Free Set to `true` to make this phase free in the region. Boolean literal, not an object.
+		//
+		// Example: true
+		Free *bool `json:"free,omitempty"`
+
+		// Price Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+		Price *PlayStoreTerritoryPrice `json:"price,omitempty"`
+
+		// RelativeDiscount Relative discount expressed as a fraction (e.g. `0.5` = 50% off).
+		//
+		// Example: 0.5
+		RelativeDiscount *float32 `json:"relative_discount,omitempty"`
+	} `json:"regional_configs,omitempty"`
+}
+
+// PlayStorePurchaseOptionBuyOptionConfig Buy variant of a Play one-time product purchase option.
+type PlayStorePurchaseOptionBuyOptionConfig struct {
+	// LegacyCompatible Whether this buy option is visible to legacy Play Billing Library clients.
+	//
+	// Example: true
+	LegacyCompatible *bool `json:"legacy_compatible,omitempty"`
+
+	// MultiQuantityEnabled Whether users can buy multiple quantities of this purchase option.
+	//
+	// Example: false
+	MultiQuantityEnabled *bool `json:"multi_quantity_enabled,omitempty"`
+}
+
+// PlayStorePurchaseOptionConfig Configuration for a single Play one-time product purchase option. At most one of `buy_option` or `rent_option` may be set in one payload; create flows require one purchase option type.
+type PlayStorePurchaseOptionConfig struct {
+	// BuyOption Buy variant of a Play one-time product purchase option.
+	BuyOption *PlayStorePurchaseOptionBuyOptionConfig `json:"buy_option,omitempty"`
+
+	// NewRegionsConfig Default availability and pricing for new Play regions on a one-time purchase option.
+	NewRegionsConfig *PlayStorePurchaseOptionNewRegionsConfig `json:"new_regions_config,omitempty"`
+
+	// OfferTags Free-form tags attached to the purchase option.
+	OfferTags *[]string `json:"offer_tags,omitempty"`
+
+	// Offers One-time product offers keyed by `offer_id`.
+	//
+	// Example: {"launch-offer":{"discounted_offer":{"redemption_limit":10},"offer_tags":["launch-promo"],"regional_configs":{"US":{"availability":"AVAILABLE","relative_discount":0.5}},"state":"DRAFT"}}
+	Offers *map[string]PlayStoreOneTimeOfferConfig `json:"offers,omitempty"`
+
+	// RegionalConfigs Per-region availability and price keyed by region code.
+	//
+	// Example: {"US":{"availability":"AVAILABLE","price":{"amount_micros":4990000,"currency":"USD"}}}
+	RegionalConfigs *map[string]PlayStorePurchaseOptionRegionalConfig `json:"regional_configs,omitempty"`
+
+	// RentOption Rent variant of a Play one-time product purchase option.
+	RentOption *PlayStorePurchaseOptionRentOptionConfig `json:"rent_option,omitempty"`
+
+	// State Lifecycle state of the purchase option.
+	//
+	// Example: ACTIVE
+	State *PlayStorePurchaseOptionConfigState `json:"state,omitempty"`
+
+	// TaxAndCompliance Purchase-option-level tax and compliance settings.
+	TaxAndCompliance *PlayStorePurchaseOptionTaxAndComplianceConfig `json:"tax_and_compliance,omitempty"`
+}
+
+// PlayStorePurchaseOptionConfigState Lifecycle state of the purchase option.
+//
+// Example: ACTIVE
+type PlayStorePurchaseOptionConfigState string
+
+// PlayStorePurchaseOptionNewRegionsConfig Default availability and pricing for new Play regions on a one-time purchase option.
+type PlayStorePurchaseOptionNewRegionsConfig struct {
+	// Availability Availability applied to new regions.
+	//
+	// Example: AVAILABLE
+	Availability *PlayStorePurchaseOptionNewRegionsConfigAvailability `json:"availability,omitempty"`
+
+	// EurPrice Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+	EurPrice *PlayStoreTerritoryPrice `json:"eur_price,omitempty"`
+
+	// UsdPrice Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+	UsdPrice *PlayStoreTerritoryPrice `json:"usd_price,omitempty"`
+}
+
+// PlayStorePurchaseOptionNewRegionsConfigAvailability Availability applied to new regions.
+//
+// Example: AVAILABLE
+type PlayStorePurchaseOptionNewRegionsConfigAvailability string
+
+// PlayStorePurchaseOptionRegionalConfig Per-region availability and price for a Play one-time product purchase option.
+type PlayStorePurchaseOptionRegionalConfig struct {
+	// Availability Availability of the purchase option in this region.
+	//
+	// Example: AVAILABLE
+	Availability *PlayStorePurchaseOptionRegionalConfigAvailability `json:"availability,omitempty"`
+
+	// Price Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+	Price *PlayStoreTerritoryPrice `json:"price,omitempty"`
+}
+
+// PlayStorePurchaseOptionRegionalConfigAvailability Availability of the purchase option in this region.
+//
+// Example: AVAILABLE
+type PlayStorePurchaseOptionRegionalConfigAvailability string
+
+// PlayStorePurchaseOptionRentOptionConfig Rent variant of a Play one-time product purchase option.
+type PlayStorePurchaseOptionRentOptionConfig struct {
+	// ExpirationPeriod Optional ISO-8601 duration after which the rental expires.
+	//
+	// Example: P7D
+	ExpirationPeriod *string `json:"expiration_period,omitempty"`
+
+	// RentalPeriod ISO-8601 duration for the rental period.
+	//
+	// Example: P30D
+	RentalPeriod string `json:"rental_period"`
+}
+
+// PlayStorePurchaseOptionTaxAndComplianceConfig Purchase-option-level tax and compliance settings.
+type PlayStorePurchaseOptionTaxAndComplianceConfig struct {
+	// WithdrawalRightType Withdrawal right type for this purchase option.
+	//
+	// Example: WITHDRAWAL_RIGHT_DIGITAL_CONTENT
+	WithdrawalRightType *PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightType `json:"withdrawal_right_type,omitempty"`
+}
+
+// PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightType Withdrawal right type for this purchase option.
+//
+// Example: WITHDRAWAL_RIGHT_DIGITAL_CONTENT
+type PlayStorePurchaseOptionTaxAndComplianceConfigWithdrawalRightType string
+
+// PlayStoreRegionalProductAgeRatingInfo Per-region age-rating override.
+type PlayStoreRegionalProductAgeRatingInfo struct {
+	// ProductAgeRatingTier Age-rating tier for the region. Values come from Google's `ProductAgeRatingTier` enum.
+	//
+	// Example: PRODUCT_AGE_RATING_TIER_EVERYONE
+	ProductAgeRatingTier PlayStoreRegionalProductAgeRatingInfoProductAgeRatingTier `json:"product_age_rating_tier"`
+
+	// RegionCode ISO region code.
+	//
+	// Example: US
+	RegionCode string `json:"region_code"`
+}
+
+// PlayStoreRegionalProductAgeRatingInfoProductAgeRatingTier Age-rating tier for the region. Values come from Google's `ProductAgeRatingTier` enum.
+//
+// Example: PRODUCT_AGE_RATING_TIER_EVERYONE
+type PlayStoreRegionalProductAgeRatingInfoProductAgeRatingTier string
+
+// PlayStoreRegionalTaxRateInfo Per-region tax-rate hint used by Google's tax calculation. All fields are optional; an absent field means "no override for this region".
+type PlayStoreRegionalTaxRateInfo struct {
+	// EligibleForStreamingServiceTaxRate Whether the region is eligible for the streaming-service tax rate.
+	//
+	// Example: false
+	EligibleForStreamingServiceTaxRate *bool `json:"eligible_for_streaming_service_tax_rate,omitempty"`
+
+	// StreamingTaxType Streaming-tax-type code.
+	//
+	// Example: STREAMING_TAX_TYPE_AUDIO_VIDEO
+	StreamingTaxType *string `json:"streaming_tax_type,omitempty"`
+
+	// TaxTier Tax-tier code.
+	//
+	// Example: TIER_1
+	TaxTier *string `json:"tax_tier,omitempty"`
+}
+
+// PlayStoreRestrictedPaymentCountriesConfig Subscription-level list of region codes where payment is restricted. Lives on the parent subscription; must agree across plan items targeting the same `subscription_id`. Shared by request and response shapes.
+type PlayStoreRestrictedPaymentCountriesConfig struct {
+	// RegionCodes ISO region codes where payment is restricted.
+	RegionCodes []string `json:"region_codes"`
+}
+
+// PlayStoreTaxAndComplianceConfig Product-level tax and compliance settings. For subscriptions this lives on the parent subscription in Google's API and must agree across plan items targeting the same `subscription_id`. Shared by request and response shapes.
+type PlayStoreTaxAndComplianceConfig struct {
+	// EeaWithdrawalRightType EEA withdrawal-right type code. Only supported for subscriptions; one-time products configure withdrawal rights per purchase option via `tax_and_compliance.withdrawal_right_type`.
+	//
+	// Example: WITHDRAWAL_RIGHT_DIGITAL_CONTENT
+	EeaWithdrawalRightType *string `json:"eea_withdrawal_right_type,omitempty"`
+
+	// IsTokenizedDigitalAsset Whether the product represents a tokenized digital asset.
+	//
+	// Example: false
+	IsTokenizedDigitalAsset *bool `json:"is_tokenized_digital_asset,omitempty"`
+
+	// ProductTaxCategoryCode Product tax-category code.
+	//
+	// Example: DIGITAL_GOODS
+	ProductTaxCategoryCode *string `json:"product_tax_category_code,omitempty"`
+
+	// RegionalProductAgeRatingInfos Per-region age-rating overrides.
+	//
+	// Example: [{"product_age_rating_tier":"PRODUCT_AGE_RATING_TIER_EVERYONE","region_code":"US"}]
+	RegionalProductAgeRatingInfos *[]PlayStoreRegionalProductAgeRatingInfo `json:"regional_product_age_rating_infos,omitempty"`
+
+	// TaxRateInfoByRegionCode Per-region tax-rate hints used by Google's tax calculation.
+	//
+	// Example: {"US":{"tax_tier":"TIER_1"}}
+	TaxRateInfoByRegionCode *map[string]PlayStoreRegionalTaxRateInfo `json:"tax_rate_info_by_region_code,omitempty"`
+}
+
+// PlayStoreTerritoryPrice Territory price expressed in micros, mirroring App Store inputs. The Play driver converts to/from Google's `Money{units, nanos, currencyCode}` at the API boundary.
+type PlayStoreTerritoryPrice struct {
+	// AmountMicros Price amount in micros (1 unit = 1_000_000 micros).
+	//
+	// Example: 9990000
+	AmountMicros int64 `json:"amount_micros"`
+
+	// Currency ISO-4217 currency code.
+	//
+	// Example: USD
+	Currency *string `json:"currency,omitempty"`
+}
+
 // Product defines model for Product.
 type Product struct {
 	App *App `json:"app,omitempty"`
@@ -37969,6 +40761,309 @@ type ProductObject string
 //
 // Example: active
 type ProductState string
+
+// ProductStoreStateAppStoreState defines model for ProductStoreStateAppStoreState.
+type ProductStoreStateAppStoreState struct {
+	// PreserveCurrentSubscriptionPrice When true, existing App Store subscription subscribers keep their current price when a new subscription price is scheduled.
+	//
+	// Example: true
+	PreserveCurrentSubscriptionPrice *bool `json:"preserve_current_subscription_price,omitempty"`
+
+	// PrivacyPolicyURL Privacy policy URL shown in App Store metadata.
+	//
+	// Example: https://example.com/privacy
+	PrivacyPolicyURL  *string `json:"privacy_policy_url,omitempty"`
+	ReviewInformation *struct {
+		// Notes App review notes for this product.
+		//
+		// Example: Screenshot uploaded through screenshot_upload endpoint.
+		Notes *string `json:"notes,omitempty"`
+
+		// Screenshot Review screenshot configuration. If omitted or null, a placeholder screenshot is uploaded automatically so the product can reach READY_TO_SUBMIT state.
+		Screenshot *struct {
+			// FileSize Screenshot size in bytes.
+			//
+			// Example: 125000
+			FileSize *int64 `json:"file_size,omitempty"`
+
+			// Filename Original screenshot filename.
+			//
+			// Example: review.png
+			Filename *string `json:"filename,omitempty"`
+
+			// ScreenshotID App Store Connect screenshot identifier.
+			//
+			// Example: asc_screenshot_123
+			ScreenshotID *string `json:"screenshot_id,omitempty"`
+
+			// SourceFileChecksum MD5 checksum of the uploaded source file.
+			//
+			// Example: d41d8cd98f00b204e9800998ecf8427e
+			SourceFileChecksum *string `json:"source_file_checksum,omitempty"`
+		} `json:"screenshot,omitempty"`
+	} `json:"review_information,omitempty"`
+	SubscriptionGroupLocalizations *map[string]*struct {
+		// CustomAppName Custom app name shown in App Store subscription UI.
+		//
+		// Example: MagicWeather
+		CustomAppName *string `json:"custom_app_name,omitempty"`
+
+		// Name Localized subscription group name.
+		//
+		// Example: Premium Subscriptions
+		Name string `json:"name"`
+	} `json:"subscription_group_localizations,omitempty"`
+
+	// SubscriptionGroupName Optional subscription group name used when creating a missing App Store subscription. If omitted, defaults to `Default`.
+	//
+	// Example: Premium Subscriptions
+	SubscriptionGroupName *string `json:"subscription_group_name,omitempty"`
+
+	// TrialOffer Free trial introductory offer for the subscription. Applied uniformly to all territories.
+	TrialOffer *struct {
+		// Duration Trial offer duration.
+		//
+		// Example: ONE_WEEK
+		Duration ProductStoreStateAppStoreStateTrialOfferDuration `json:"duration"`
+
+		// StartDate Optional start date for newly created introductory offers.
+		//
+		// Example: 2026-05-01
+		StartDate *openapi_types.Date `json:"start_date,omitempty"`
+	} `json:"trial_offer,omitempty"`
+}
+
+// ProductStoreStateAppStoreStateTrialOfferDuration Trial offer duration.
+//
+// Example: ONE_WEEK
+type ProductStoreStateAppStoreStateTrialOfferDuration string
+
+// ProductStoreStateAppStoreStateResponse defines model for ProductStoreStateAppStoreStateResponse.
+type ProductStoreStateAppStoreStateResponse struct {
+	// PreserveCurrentSubscriptionPrice Whether App Store Connect returns any preserved subscription price for existing subscribers.
+	//
+	// Example: true
+	PreserveCurrentSubscriptionPrice *bool `json:"preserve_current_subscription_price,omitempty"`
+
+	// PrivacyPolicyURL Privacy policy URL shown in App Store metadata.
+	//
+	// Example: https://example.com/privacy
+	PrivacyPolicyURL  *string `json:"privacy_policy_url,omitempty"`
+	ReviewInformation *struct {
+		// Notes App review notes for this product.
+		//
+		// Example: Screenshot uploaded through screenshot_upload endpoint.
+		Notes *string `json:"notes,omitempty"`
+
+		// Screenshot Review screenshot configuration. If omitted or null, a placeholder screenshot is uploaded automatically so the product can reach READY_TO_SUBMIT state.
+		Screenshot *struct {
+			// FileSize Screenshot size in bytes.
+			//
+			// Example: 125000
+			FileSize *int64 `json:"file_size,omitempty"`
+
+			// Filename Original screenshot filename.
+			//
+			// Example: review.png
+			Filename *string `json:"filename,omitempty"`
+
+			// ScreenshotID App Store Connect screenshot identifier.
+			//
+			// Example: asc_screenshot_123
+			ScreenshotID *string `json:"screenshot_id,omitempty"`
+
+			// SourceFileChecksum MD5 checksum of the uploaded source file.
+			//
+			// Example: d41d8cd98f00b204e9800998ecf8427e
+			SourceFileChecksum *string `json:"source_file_checksum,omitempty"`
+		} `json:"screenshot,omitempty"`
+	} `json:"review_information,omitempty"`
+	SubscriptionGroupLocalizations *map[string]*struct {
+		// CustomAppName Custom app name shown in App Store subscription UI.
+		//
+		// Example: MagicWeather
+		CustomAppName *string `json:"custom_app_name,omitempty"`
+
+		// Name Localized subscription group name.
+		//
+		// Example: Premium Subscriptions
+		Name string `json:"name"`
+	} `json:"subscription_group_localizations,omitempty"`
+
+	// SubscriptionGroupName Optional subscription group name used when creating a missing App Store subscription. If omitted, defaults to `Default`.
+	//
+	// Example: Premium Subscriptions
+	SubscriptionGroupName *string `json:"subscription_group_name,omitempty"`
+
+	// TrialOffer Free trial introductory offer for the subscription. Applied uniformly to all territories.
+	TrialOffer *struct {
+		// Duration Trial offer duration.
+		//
+		// Example: ONE_WEEK
+		Duration ProductStoreStateAppStoreStateResponseTrialOfferDuration `json:"duration"`
+	} `json:"trial_offer,omitempty"`
+}
+
+// ProductStoreStateAppStoreStateResponseTrialOfferDuration Trial offer duration.
+//
+// Example: ONE_WEEK
+type ProductStoreStateAppStoreStateResponseTrialOfferDuration string
+
+// ProductStoreStateCommonResponse defines model for ProductStoreStateCommonResponse.
+type ProductStoreStateCommonResponse struct {
+	Availability *struct {
+		// AvailableInNewTerritories Availability default for newly added territories. Optional; when omitted, the current App Store Connect value is preserved.
+		//
+		// Example: true
+		AvailableInNewTerritories *bool `json:"available_in_new_territories,omitempty"`
+
+		// Territories Territories where the product is available. True = available, false = remove.
+		Territories *map[string]bool `json:"territories,omitempty"`
+	} `json:"availability,omitempty"`
+
+	// Duration Subscription duration. App Store product store state operations return this value using App Store Connect period names for backwards compatibility.
+	//
+	// Example: ONE_MONTH
+	Duration      *ProductStoreStateCommonResponseDuration `json:"duration,omitempty"`
+	Localizations *map[string]*struct {
+		// Description Localized product description.
+		//
+		// Example: Access premium content every month.
+		Description *string `json:"description"`
+
+		// Name Localized product display name.
+		//
+		// Example: Premium Monthly
+		Name string `json:"name"`
+	} `json:"localizations,omitempty"`
+	Pricing *struct {
+		TerritoryPrices *map[string]struct {
+			// AmountMicros Territory price amount in micros.
+			//
+			// Example: 9990000
+			AmountMicros int64 `json:"amount_micros"`
+
+			// Currency ISO currency code for this territory price.
+			//
+			// Example: USD
+			Currency *string `json:"currency,omitempty"`
+
+			// StartDate ISO-8601 date (YYYY-MM-DD) when this price takes effect. Present when the next effective price for the territory is scheduled in the future.
+			//
+			// Example: 2026-05-01
+			StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+			// SubscriptionPricePointID Optional App Store Connect price point identifier.
+			SubscriptionPricePointID *string `json:"subscription_price_point_id,omitempty"`
+		} `json:"territory_prices,omitempty"`
+	} `json:"pricing,omitempty"`
+
+	// Title Optional product title used by create-if-missing flows.
+	//
+	// Example: Premium Monthly
+	Title *string `json:"title,omitempty"`
+}
+
+// ProductStoreStateCommonResponseDuration Subscription duration. App Store product store state operations return this value using App Store Connect period names for backwards compatibility.
+//
+// Example: ONE_MONTH
+type ProductStoreStateCommonResponseDuration string
+
+// ProductStoreStatePlayStoreState Play Store specific desired state for a single plan item. Subscriptions use `base_plans` keyed by `base_plan_id`; one-time products use `purchase_options` keyed by `purchase_option_id`. Do not combine both maps in a single desired state.
+type ProductStoreStatePlayStoreState struct {
+	// Archived Whether the parent subscription is archived in Play Console. Must agree across plan items targeting the same `subscription_id`. Not supported for one-time products.
+	//
+	// Example: false
+	Archived *bool `json:"archived,omitempty"`
+
+	// BasePlans Configuration for each base plan keyed by `base_plan_id`. Only applies to subscriptions; one-time products use `purchase_options` instead. Plan-item granularity is `(subscription_id, base_plan_id)`, so this typically contains a single entry — the targeted base plan. May be omitted for plan items that only touch `common.*` or top-level fields (`tax_and_compliance`, `restricted_payment_countries`, `archived`, `regions_version`).
+	// Each value follows `PlayStoreBasePlanConfig`. The most important inner fields when creating a subscription are:
+	// - `state` (`ACTIVE` | `DRAFT` | `INACTIVE`, default `ACTIVE` on
+	//   create).
+	// - Exactly one billing plan type: `auto_renewing_base_plan_type`
+	//   (most common — requires `billing_period_duration`; optional
+	//   `grace_period_duration`, `account_hold_duration`,
+	//   `proration_mode`, `resubscribe_state`, `legacy_compatible`,
+	//   `legacy_compatible_subscription_offer_id`),
+	//   `prepaid_base_plan_type`, or `installments_base_plan_type`.
+	// - `regional_configs[<region>]` with
+	//   `new_subscriber_availability` and/or `price`
+	//   (`{ amount_micros, currency }`).
+	// - Optional `offer_tags` (array of strings) and `offers` (keyed by
+	//   `offer_id`). Each offer is `{ state (DRAFT|ACTIVE|INACTIVE),
+	//   phases: [ { recurrence_count, duration, regional_configs{ <region>:
+	//   { EXACTLY ONE of price / free: true / absolute_discount /
+	//   relative_discount } } } ], targeting?, offer_tags? }`. See the
+	//   `offers` field on `PlayStoreBasePlanConfig` for the full shape.
+	//
+	// Example: {"monthly":{"auto_renewing_base_plan_type":{"account_hold_duration":"P30D","billing_period_duration":"P1M","grace_period_duration":"P3D","legacy_compatible":false,"legacy_compatible_subscription_offer_id":null,"proration_mode":"SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE","resubscribe_state":"RESUBSCRIBE_STATE_ACTIVE"},"offer_tags":[],"offers":{},"regional_configs":{"US":{"new_subscriber_availability":true,"price":{"amount_micros":9990000,"currency":"USD"}}},"state":"ACTIVE"}}
+	BasePlans *map[string]PlayStoreBasePlanConfig `json:"base_plans,omitempty"`
+
+	// LatencyTolerance Latency tolerance hint for Google's monetization API (e.g. `LATENCY_TOLERANT_FRESHNESS` / `LATENCY_TOLERANT_LOW_LATENCY`).
+	//
+	// Example: PRODUCT_UPDATE_LATENCY_TOLERANCE_LATENCY_TOLERANT
+	LatencyTolerance *string `json:"latency_tolerance,omitempty"`
+
+	// PurchaseOptions Configuration for each one-time product purchase option keyed by `purchase_option_id`. Only applies to one-time products; subscriptions use `base_plans` instead. One-time product plan-item granularity is the product itself, so purchase options are managed inline on the product.
+	// Each value follows `PlayStorePurchaseOptionConfig`. Notable inner fields are:
+	// - `state` (`DRAFT` | `ACTIVE` | `INACTIVE` |
+	//   `INACTIVE_PUBLISHED`).
+	// - At most one of `buy_option` or `rent_option`; Google requires one
+	//   when creating a purchase option.
+	// - `regional_configs[<region>]` with `availability` and/or `price`
+	//   (`{ amount_micros, currency }`).
+	// - Optional `offer_tags`, purchase-option `tax_and_compliance`, and
+	//   `offers` keyed by `offer_id`.
+	//
+	// Example: {"buy":{"buy_option":{"legacy_compatible":true,"multi_quantity_enabled":false},"offer_tags":["one-time"],"offers":{},"regional_configs":{"US":{"availability":"AVAILABLE","price":{"amount_micros":4990000,"currency":"USD"}}},"state":"ACTIVE"}}
+	PurchaseOptions *map[string]PlayStorePurchaseOptionConfig `json:"purchase_options,omitempty"`
+
+	// RegionsVersion Google Play regions version used to interpret region codes. Optional; when omitted, the driver applies a sensible default.
+	//
+	// Example: 2025/03
+	RegionsVersion *string `json:"regions_version,omitempty"`
+
+	// RestrictedPaymentCountries Subscription-level list of region codes where payment is restricted. Lives on the parent subscription; must agree across plan items targeting the same `subscription_id`. Shared by request and response shapes.
+	RestrictedPaymentCountries *PlayStoreRestrictedPaymentCountriesConfig `json:"restricted_payment_countries,omitempty"`
+
+	// TaxAndCompliance Product-level tax and compliance settings. For subscriptions this lives on the parent subscription in Google's API and must agree across plan items targeting the same `subscription_id`. Shared by request and response shapes.
+	TaxAndCompliance *PlayStoreTaxAndComplianceConfig `json:"tax_and_compliance,omitempty"`
+}
+
+// ProductStoreStatePlayStoreStateResponse Play Store specific desired state as returned by the plan endpoints. Same shape as the request schema with relaxed required-field constraints; in particular the response may omit `base_plans`, `purchase_options`, or any store-level field if the plan item didn't touch it.
+type ProductStoreStatePlayStoreStateResponse struct {
+	// Archived Whether the parent subscription is archived in Play Console. Not supported for one-time products.
+	//
+	// Example: false
+	Archived *bool `json:"archived,omitempty"`
+
+	// BasePlans Configuration for each base plan keyed by `base_plan_id`. Only present for subscriptions; one-time products use `purchase_options` instead. May be empty or omitted in responses for plan items that only touch `common.*` fields.
+	// Each value follows `PlayStoreBasePlanConfig` — see that schema for the full inner shape. Notable inner fields: `state` (`ACTIVE` | `DRAFT` | `INACTIVE`), one of `auto_renewing_base_plan_type` (with `billing_period_duration` plus optional `grace_period_duration`, `account_hold_duration`, `proration_mode`, `resubscribe_state`, `legacy_compatible`, `legacy_compatible_subscription_offer_id`), `prepaid_base_plan_type`, or `installments_base_plan_type`, plus `regional_configs[<region>]`, `offer_tags`, and `offers`.
+	//
+	// Example: {"monthly":{"auto_renewing_base_plan_type":{"account_hold_duration":"P30D","billing_period_duration":"P1M","grace_period_duration":"P3D","legacy_compatible":false,"legacy_compatible_subscription_offer_id":null,"proration_mode":"SUBSCRIPTION_PRORATION_MODE_CHARGE_ON_NEXT_BILLING_DATE","resubscribe_state":"RESUBSCRIBE_STATE_ACTIVE"},"offer_tags":[],"offers":{},"regional_configs":{"US":{"new_subscriber_availability":true,"price":{"amount_micros":9990000,"currency":"USD"}}},"state":"ACTIVE"}}
+	BasePlans *map[string]PlayStoreBasePlanConfig `json:"base_plans,omitempty"`
+
+	// LatencyTolerance Latency tolerance hint for Google's monetization API.
+	//
+	// Example: PRODUCT_UPDATE_LATENCY_TOLERANCE_LATENCY_TOLERANT
+	LatencyTolerance *string `json:"latency_tolerance,omitempty"`
+
+	// PurchaseOptions Configuration for each one-time product purchase option keyed by `purchase_option_id`. Only present for one-time products; subscriptions use `base_plans` instead. May be empty or omitted in responses for plan items that only touch `common.*` fields.
+	//
+	// Example: {"buy":{"buy_option":{"legacy_compatible":true,"multi_quantity_enabled":false},"offer_tags":["one-time"],"offers":{},"regional_configs":{"US":{"availability":"AVAILABLE","price":{"amount_micros":4990000,"currency":"USD"}}},"state":"ACTIVE"}}
+	PurchaseOptions *map[string]PlayStorePurchaseOptionConfig `json:"purchase_options,omitempty"`
+
+	// RegionsVersion Google Play regions version used to interpret region codes.
+	//
+	// Example: 2025/03
+	RegionsVersion *string `json:"regions_version,omitempty"`
+
+	// RestrictedPaymentCountries Subscription-level list of region codes where payment is restricted. Lives on the parent subscription; must agree across plan items targeting the same `subscription_id`. Shared by request and response shapes.
+	RestrictedPaymentCountries *PlayStoreRestrictedPaymentCountriesConfig `json:"restricted_payment_countries,omitempty"`
+
+	// TaxAndCompliance Product-level tax and compliance settings. For subscriptions this lives on the parent subscription in Google's API and must agree across plan items targeting the same `subscription_id`. Shared by request and response shapes.
+	TaxAndCompliance *PlayStoreTaxAndComplianceConfig `json:"tax_and_compliance,omitempty"`
+}
 
 // ProductSubscriptionInput Subscription parameters for product creation. Only supported for simulated store products.
 type ProductSubscriptionInput struct {
@@ -45070,6 +48165,421 @@ type CreateProductInStore503JSONResponseBodyObject string
 // CreateProductInStore503JSONResponseBodyType defines parameters for CreateProductInStore.
 type CreateProductInStore503JSONResponseBodyType string
 
+// GetProductStoreState200JSONResponseBodyCommonDuration defines parameters for GetProductStoreState.
+type GetProductStoreState200JSONResponseBodyCommonDuration string
+
+// GetProductStoreState200JSONResponseBodyStore defines parameters for GetProductStoreState.
+type GetProductStoreState200JSONResponseBodyStore string
+
+// GetProductStoreState200JSONResponseBody_StoreState defines parameters for GetProductStoreState.
+type GetProductStoreState200JSONResponseBody_StoreState struct {
+	union json.RawMessage
+}
+
+// GetProductStoreState200JSONResponseBodyStoreStatusStatus defines parameters for GetProductStoreState.
+type GetProductStoreState200JSONResponseBodyStoreStatusStatus string
+
+// GetProductStoreState400JSONResponseBodyObject defines parameters for GetProductStoreState.
+type GetProductStoreState400JSONResponseBodyObject string
+
+// GetProductStoreState400JSONResponseBodyType defines parameters for GetProductStoreState.
+type GetProductStoreState400JSONResponseBodyType string
+
+// GetProductStoreState401JSONResponseBodyObject defines parameters for GetProductStoreState.
+type GetProductStoreState401JSONResponseBodyObject string
+
+// GetProductStoreState401JSONResponseBodyType defines parameters for GetProductStoreState.
+type GetProductStoreState401JSONResponseBodyType string
+
+// GetProductStoreState403JSONResponseBodyObject defines parameters for GetProductStoreState.
+type GetProductStoreState403JSONResponseBodyObject string
+
+// GetProductStoreState403JSONResponseBodyType defines parameters for GetProductStoreState.
+type GetProductStoreState403JSONResponseBodyType string
+
+// GetProductStoreState404JSONResponseBodyObject defines parameters for GetProductStoreState.
+type GetProductStoreState404JSONResponseBodyObject string
+
+// GetProductStoreState404JSONResponseBodyType defines parameters for GetProductStoreState.
+type GetProductStoreState404JSONResponseBodyType string
+
+// GetProductStoreState422JSONResponseBodyObject defines parameters for GetProductStoreState.
+type GetProductStoreState422JSONResponseBodyObject string
+
+// GetProductStoreState422JSONResponseBodyType defines parameters for GetProductStoreState.
+type GetProductStoreState422JSONResponseBodyType string
+
+// GetProductStoreState423JSONResponseBodyObject defines parameters for GetProductStoreState.
+type GetProductStoreState423JSONResponseBodyObject string
+
+// GetProductStoreState423JSONResponseBodyType defines parameters for GetProductStoreState.
+type GetProductStoreState423JSONResponseBodyType string
+
+// GetProductStoreState429JSONResponseBodyObject defines parameters for GetProductStoreState.
+type GetProductStoreState429JSONResponseBodyObject string
+
+// GetProductStoreState429JSONResponseBodyType defines parameters for GetProductStoreState.
+type GetProductStoreState429JSONResponseBodyType string
+
+// GetProductStoreState500JSONResponseBodyObject defines parameters for GetProductStoreState.
+type GetProductStoreState500JSONResponseBodyObject string
+
+// GetProductStoreState500JSONResponseBodyType defines parameters for GetProductStoreState.
+type GetProductStoreState500JSONResponseBodyType string
+
+// GetProductStoreState503JSONResponseBodyObject defines parameters for GetProductStoreState.
+type GetProductStoreState503JSONResponseBodyObject string
+
+// GetProductStoreState503JSONResponseBodyType defines parameters for GetProductStoreState.
+type GetProductStoreState503JSONResponseBodyType string
+
+// SetProductStoreStateJSONBody defines parameters for SetProductStoreState.
+type SetProductStoreStateJSONBody struct {
+	Common *struct {
+		Availability *struct {
+			// AvailableInNewTerritories Availability default for newly added territories. Optional; when omitted, the current App Store Connect value is preserved.
+			//
+			// Example: true
+			AvailableInNewTerritories *bool `json:"available_in_new_territories,omitempty"`
+
+			// Territories Territories where the product is available. True = available, false = remove.
+			Territories *map[string]bool `json:"territories,omitempty"`
+		} `json:"availability,omitempty"`
+
+		// Duration Subscription duration. Required for subscription creation in create-if-missing flows. Canonical ISO-like durations are preferred, but legacy App Store Connect period values are accepted for backwards compatibility.
+		//
+		// Example: ONE_MONTH
+		Duration      *SetProductStoreStateJSONBodyCommonDuration `json:"duration,omitempty"`
+		Localizations *map[string]*struct {
+			// Description Localized product description. App Store Connect limits: 45 characters for both subscriptions and in-app purchases.
+			//
+			// Example: Access premium content every month.
+			Description string `json:"description"`
+
+			// Name Localized product display name. App Store Connect limits: 30 characters for both subscriptions and in-app purchases.
+			//
+			// Example: Premium Monthly
+			Name string `json:"name"`
+		} `json:"localizations,omitempty"`
+		Pricing *struct {
+			TerritoryPrices *map[string]struct {
+				// AmountMicros Territory price amount in micros.
+				//
+				// Example: 9990000
+				AmountMicros int64 `json:"amount_micros"`
+
+				// Currency ISO currency code for this territory price.
+				//
+				// Example: USD
+				Currency *string `json:"currency,omitempty"`
+
+				// StartDate ISO-8601 date (YYYY-MM-DD) for a scheduled price change. Required for approved subscriptions — Apple does not allow modifying the current price of an approved subscription directly; a future start date must be provided to schedule the change. Omit for initial pricing of unapproved products. For in-app purchases, sets the start date on the price schedule entry.
+				//
+				// Example: 2026-04-01
+				StartDate *openapi_types.Date `json:"start_date,omitempty"`
+			} `json:"territory_prices,omitempty"`
+		} `json:"pricing,omitempty"`
+
+		// Title Optional product title used by create-if-missing flows.
+		//
+		// Example: Premium Monthly
+		Title *string `json:"title,omitempty"`
+	} `json:"common,omitempty"`
+
+	// Store The target store for this desired state.
+	//
+	// Example: app_store
+	Store SetProductStoreStateJSONBodyStore `json:"store"`
+
+	// StoreState Store-specific desired state. Must match the `store` discriminator.
+	StoreState *SetProductStoreStateJSONBody_StoreState `json:"store_state,omitempty"`
+}
+
+// SetProductStoreStateJSONBodyCommonDuration defines parameters for SetProductStoreState.
+type SetProductStoreStateJSONBodyCommonDuration string
+
+// SetProductStoreStateJSONBodyStore defines parameters for SetProductStoreState.
+type SetProductStoreStateJSONBodyStore string
+
+// SetProductStoreStateJSONBody_StoreState defines parameters for SetProductStoreState.
+type SetProductStoreStateJSONBody_StoreState struct {
+	union json.RawMessage
+}
+
+// SetProductStoreState202JSONResponseBodyStatus defines parameters for SetProductStoreState.
+type SetProductStoreState202JSONResponseBodyStatus string
+
+// SetProductStoreState400JSONResponseBodyObject defines parameters for SetProductStoreState.
+type SetProductStoreState400JSONResponseBodyObject string
+
+// SetProductStoreState400JSONResponseBodyType defines parameters for SetProductStoreState.
+type SetProductStoreState400JSONResponseBodyType string
+
+// SetProductStoreState401JSONResponseBodyObject defines parameters for SetProductStoreState.
+type SetProductStoreState401JSONResponseBodyObject string
+
+// SetProductStoreState401JSONResponseBodyType defines parameters for SetProductStoreState.
+type SetProductStoreState401JSONResponseBodyType string
+
+// SetProductStoreState403JSONResponseBodyObject defines parameters for SetProductStoreState.
+type SetProductStoreState403JSONResponseBodyObject string
+
+// SetProductStoreState403JSONResponseBodyType defines parameters for SetProductStoreState.
+type SetProductStoreState403JSONResponseBodyType string
+
+// SetProductStoreState404JSONResponseBodyObject defines parameters for SetProductStoreState.
+type SetProductStoreState404JSONResponseBodyObject string
+
+// SetProductStoreState404JSONResponseBodyType defines parameters for SetProductStoreState.
+type SetProductStoreState404JSONResponseBodyType string
+
+// SetProductStoreState409JSONResponseBodyObject defines parameters for SetProductStoreState.
+type SetProductStoreState409JSONResponseBodyObject string
+
+// SetProductStoreState409JSONResponseBodyType defines parameters for SetProductStoreState.
+type SetProductStoreState409JSONResponseBodyType string
+
+// SetProductStoreState422JSONResponseBodyObject defines parameters for SetProductStoreState.
+type SetProductStoreState422JSONResponseBodyObject string
+
+// SetProductStoreState422JSONResponseBodyType defines parameters for SetProductStoreState.
+type SetProductStoreState422JSONResponseBodyType string
+
+// SetProductStoreState423JSONResponseBodyObject defines parameters for SetProductStoreState.
+type SetProductStoreState423JSONResponseBodyObject string
+
+// SetProductStoreState423JSONResponseBodyType defines parameters for SetProductStoreState.
+type SetProductStoreState423JSONResponseBodyType string
+
+// SetProductStoreState429JSONResponseBodyObject defines parameters for SetProductStoreState.
+type SetProductStoreState429JSONResponseBodyObject string
+
+// SetProductStoreState429JSONResponseBodyType defines parameters for SetProductStoreState.
+type SetProductStoreState429JSONResponseBodyType string
+
+// SetProductStoreState500JSONResponseBodyObject defines parameters for SetProductStoreState.
+type SetProductStoreState500JSONResponseBodyObject string
+
+// SetProductStoreState500JSONResponseBodyType defines parameters for SetProductStoreState.
+type SetProductStoreState500JSONResponseBodyType string
+
+// SetProductStoreState503JSONResponseBodyObject defines parameters for SetProductStoreState.
+type SetProductStoreState503JSONResponseBodyObject string
+
+// SetProductStoreState503JSONResponseBodyType defines parameters for SetProductStoreState.
+type SetProductStoreState503JSONResponseBodyType string
+
+// EqualizeSubscriptionPricesJSONBody defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPricesJSONBody struct {
+	// BaseTerritory Base territory used to resolve the source price point from the
+	// territory's current App Store price (alpha-2 or alpha-3 code).
+	//
+	//
+	// Example: US
+	BaseTerritory string `json:"base_territory"`
+
+	// Store The target store for this operation.
+	//
+	// Example: app_store
+	Store EqualizeSubscriptionPricesJSONBodyStore `json:"store"`
+}
+
+// EqualizeSubscriptionPricesJSONBodyStore defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPricesJSONBodyStore string
+
+// EqualizeSubscriptionPrices202JSONResponseBodyStatus defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices202JSONResponseBodyStatus string
+
+// EqualizeSubscriptionPrices400JSONResponseBodyObject defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices400JSONResponseBodyObject string
+
+// EqualizeSubscriptionPrices400JSONResponseBodyType defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices400JSONResponseBodyType string
+
+// EqualizeSubscriptionPrices401JSONResponseBodyObject defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices401JSONResponseBodyObject string
+
+// EqualizeSubscriptionPrices401JSONResponseBodyType defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices401JSONResponseBodyType string
+
+// EqualizeSubscriptionPrices403JSONResponseBodyObject defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices403JSONResponseBodyObject string
+
+// EqualizeSubscriptionPrices403JSONResponseBodyType defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices403JSONResponseBodyType string
+
+// EqualizeSubscriptionPrices404JSONResponseBodyObject defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices404JSONResponseBodyObject string
+
+// EqualizeSubscriptionPrices404JSONResponseBodyType defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices404JSONResponseBodyType string
+
+// EqualizeSubscriptionPrices409JSONResponseBodyObject defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices409JSONResponseBodyObject string
+
+// EqualizeSubscriptionPrices409JSONResponseBodyType defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices409JSONResponseBodyType string
+
+// EqualizeSubscriptionPrices422JSONResponseBodyObject defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices422JSONResponseBodyObject string
+
+// EqualizeSubscriptionPrices422JSONResponseBodyType defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices422JSONResponseBodyType string
+
+// EqualizeSubscriptionPrices423JSONResponseBodyObject defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices423JSONResponseBodyObject string
+
+// EqualizeSubscriptionPrices423JSONResponseBodyType defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices423JSONResponseBodyType string
+
+// EqualizeSubscriptionPrices429JSONResponseBodyObject defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices429JSONResponseBodyObject string
+
+// EqualizeSubscriptionPrices429JSONResponseBodyType defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices429JSONResponseBodyType string
+
+// EqualizeSubscriptionPrices500JSONResponseBodyObject defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices500JSONResponseBodyObject string
+
+// EqualizeSubscriptionPrices500JSONResponseBodyType defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices500JSONResponseBodyType string
+
+// EqualizeSubscriptionPrices503JSONResponseBodyObject defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices503JSONResponseBodyObject string
+
+// EqualizeSubscriptionPrices503JSONResponseBodyType defines parameters for EqualizeSubscriptionPrices.
+type EqualizeSubscriptionPrices503JSONResponseBodyType string
+
+// UploadProductStoreStateScreenshotJSONBody defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshotJSONBody struct {
+	// FileSize Screenshot file size in bytes.
+	//
+	// Example: 125000
+	FileSize int64 `json:"file_size"`
+
+	// Filename Screenshot filename to reserve in App Store Connect.
+	//
+	// Example: review.png
+	Filename string `json:"filename"`
+}
+
+// UploadProductStoreStateScreenshot400JSONResponseBodyObject defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot400JSONResponseBodyObject string
+
+// UploadProductStoreStateScreenshot400JSONResponseBodyType defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot400JSONResponseBodyType string
+
+// UploadProductStoreStateScreenshot401JSONResponseBodyObject defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot401JSONResponseBodyObject string
+
+// UploadProductStoreStateScreenshot401JSONResponseBodyType defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot401JSONResponseBodyType string
+
+// UploadProductStoreStateScreenshot403JSONResponseBodyObject defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot403JSONResponseBodyObject string
+
+// UploadProductStoreStateScreenshot403JSONResponseBodyType defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot403JSONResponseBodyType string
+
+// UploadProductStoreStateScreenshot404JSONResponseBodyObject defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot404JSONResponseBodyObject string
+
+// UploadProductStoreStateScreenshot404JSONResponseBodyType defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot404JSONResponseBodyType string
+
+// UploadProductStoreStateScreenshot409JSONResponseBodyObject defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot409JSONResponseBodyObject string
+
+// UploadProductStoreStateScreenshot409JSONResponseBodyType defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot409JSONResponseBodyType string
+
+// UploadProductStoreStateScreenshot422JSONResponseBodyObject defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot422JSONResponseBodyObject string
+
+// UploadProductStoreStateScreenshot422JSONResponseBodyType defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot422JSONResponseBodyType string
+
+// UploadProductStoreStateScreenshot423JSONResponseBodyObject defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot423JSONResponseBodyObject string
+
+// UploadProductStoreStateScreenshot423JSONResponseBodyType defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot423JSONResponseBodyType string
+
+// UploadProductStoreStateScreenshot429JSONResponseBodyObject defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot429JSONResponseBodyObject string
+
+// UploadProductStoreStateScreenshot429JSONResponseBodyType defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot429JSONResponseBodyType string
+
+// UploadProductStoreStateScreenshot500JSONResponseBodyObject defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot500JSONResponseBodyObject string
+
+// UploadProductStoreStateScreenshot500JSONResponseBodyType defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot500JSONResponseBodyType string
+
+// UploadProductStoreStateScreenshot503JSONResponseBodyObject defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot503JSONResponseBodyObject string
+
+// UploadProductStoreStateScreenshot503JSONResponseBodyType defines parameters for UploadProductStoreStateScreenshot.
+type UploadProductStoreStateScreenshot503JSONResponseBodyType string
+
+// GetProductStoreStateOperation200JSONResponseBodyStatus defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation200JSONResponseBodyStatus string
+
+// GetProductStoreStateOperation400JSONResponseBodyObject defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation400JSONResponseBodyObject string
+
+// GetProductStoreStateOperation400JSONResponseBodyType defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation400JSONResponseBodyType string
+
+// GetProductStoreStateOperation401JSONResponseBodyObject defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation401JSONResponseBodyObject string
+
+// GetProductStoreStateOperation401JSONResponseBodyType defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation401JSONResponseBodyType string
+
+// GetProductStoreStateOperation403JSONResponseBodyObject defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation403JSONResponseBodyObject string
+
+// GetProductStoreStateOperation403JSONResponseBodyType defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation403JSONResponseBodyType string
+
+// GetProductStoreStateOperation404JSONResponseBodyObject defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation404JSONResponseBodyObject string
+
+// GetProductStoreStateOperation404JSONResponseBodyType defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation404JSONResponseBodyType string
+
+// GetProductStoreStateOperation422JSONResponseBodyObject defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation422JSONResponseBodyObject string
+
+// GetProductStoreStateOperation422JSONResponseBodyType defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation422JSONResponseBodyType string
+
+// GetProductStoreStateOperation423JSONResponseBodyObject defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation423JSONResponseBodyObject string
+
+// GetProductStoreStateOperation423JSONResponseBodyType defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation423JSONResponseBodyType string
+
+// GetProductStoreStateOperation429JSONResponseBodyObject defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation429JSONResponseBodyObject string
+
+// GetProductStoreStateOperation429JSONResponseBodyType defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation429JSONResponseBodyType string
+
+// GetProductStoreStateOperation500JSONResponseBodyObject defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation500JSONResponseBodyObject string
+
+// GetProductStoreStateOperation500JSONResponseBodyType defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation500JSONResponseBodyType string
+
+// GetProductStoreStateOperation503JSONResponseBodyObject defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation503JSONResponseBodyObject string
+
+// GetProductStoreStateOperation503JSONResponseBodyType defines parameters for GetProductStoreStateOperation.
+type GetProductStoreStateOperation503JSONResponseBodyType string
+
 // SearchPurchasesParams defines parameters for SearchPurchases.
 type SearchPurchasesParams struct {
 	// StorePurchaseIdentifier Store ID associated with the one-time purchase.
@@ -46342,6 +49852,15 @@ type UpdateProductJSONRequestBody UpdateProductJSONBody
 // CreateProductInStoreJSONRequestBody defines body for CreateProductInStore for application/json ContentType.
 type CreateProductInStoreJSONRequestBody CreateProductInStoreJSONBody
 
+// SetProductStoreStateJSONRequestBody defines body for SetProductStoreState for application/json ContentType.
+type SetProductStoreStateJSONRequestBody SetProductStoreStateJSONBody
+
+// EqualizeSubscriptionPricesJSONRequestBody defines body for EqualizeSubscriptionPrices for application/json ContentType.
+type EqualizeSubscriptionPricesJSONRequestBody EqualizeSubscriptionPricesJSONBody
+
+// UploadProductStoreStateScreenshotJSONRequestBody defines body for UploadProductStoreStateScreenshot for application/json ContentType.
+type UploadProductStoreStateScreenshotJSONRequestBody UploadProductStoreStateScreenshotJSONBody
+
 // ExtendSubscriptionJSONRequestBody defines body for ExtendSubscription for application/json ContentType.
 type ExtendSubscriptionJSONRequestBody ExtendSubscriptionJSONBody
 
@@ -47307,6 +50826,130 @@ func (t CreateProductInStoreJSONBody_StoreInformation) MarshalJSON() ([]byte, er
 }
 
 func (t *CreateProductInStoreJSONBody_StoreInformation) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsProductStoreStateAppStoreStateResponse returns the union data inside the GetProductStoreState200JSONResponseBody_StoreState as a ProductStoreStateAppStoreStateResponse
+func (t GetProductStoreState200JSONResponseBody_StoreState) AsProductStoreStateAppStoreStateResponse() (ProductStoreStateAppStoreStateResponse, error) {
+	var body ProductStoreStateAppStoreStateResponse
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProductStoreStateAppStoreStateResponse overwrites any union data inside the GetProductStoreState200JSONResponseBody_StoreState as the provided ProductStoreStateAppStoreStateResponse
+func (t *GetProductStoreState200JSONResponseBody_StoreState) FromProductStoreStateAppStoreStateResponse(v ProductStoreStateAppStoreStateResponse) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProductStoreStateAppStoreStateResponse performs a merge with any union data inside the GetProductStoreState200JSONResponseBody_StoreState, using the provided ProductStoreStateAppStoreStateResponse
+func (t *GetProductStoreState200JSONResponseBody_StoreState) MergeProductStoreStateAppStoreStateResponse(v ProductStoreStateAppStoreStateResponse) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsProductStoreStatePlayStoreStateResponse returns the union data inside the GetProductStoreState200JSONResponseBody_StoreState as a ProductStoreStatePlayStoreStateResponse
+func (t GetProductStoreState200JSONResponseBody_StoreState) AsProductStoreStatePlayStoreStateResponse() (ProductStoreStatePlayStoreStateResponse, error) {
+	var body ProductStoreStatePlayStoreStateResponse
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProductStoreStatePlayStoreStateResponse overwrites any union data inside the GetProductStoreState200JSONResponseBody_StoreState as the provided ProductStoreStatePlayStoreStateResponse
+func (t *GetProductStoreState200JSONResponseBody_StoreState) FromProductStoreStatePlayStoreStateResponse(v ProductStoreStatePlayStoreStateResponse) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProductStoreStatePlayStoreStateResponse performs a merge with any union data inside the GetProductStoreState200JSONResponseBody_StoreState, using the provided ProductStoreStatePlayStoreStateResponse
+func (t *GetProductStoreState200JSONResponseBody_StoreState) MergeProductStoreStatePlayStoreStateResponse(v ProductStoreStatePlayStoreStateResponse) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t GetProductStoreState200JSONResponseBody_StoreState) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *GetProductStoreState200JSONResponseBody_StoreState) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsProductStoreStateAppStoreState returns the union data inside the SetProductStoreStateJSONBody_StoreState as a ProductStoreStateAppStoreState
+func (t SetProductStoreStateJSONBody_StoreState) AsProductStoreStateAppStoreState() (ProductStoreStateAppStoreState, error) {
+	var body ProductStoreStateAppStoreState
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProductStoreStateAppStoreState overwrites any union data inside the SetProductStoreStateJSONBody_StoreState as the provided ProductStoreStateAppStoreState
+func (t *SetProductStoreStateJSONBody_StoreState) FromProductStoreStateAppStoreState(v ProductStoreStateAppStoreState) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProductStoreStateAppStoreState performs a merge with any union data inside the SetProductStoreStateJSONBody_StoreState, using the provided ProductStoreStateAppStoreState
+func (t *SetProductStoreStateJSONBody_StoreState) MergeProductStoreStateAppStoreState(v ProductStoreStateAppStoreState) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsProductStoreStatePlayStoreState returns the union data inside the SetProductStoreStateJSONBody_StoreState as a ProductStoreStatePlayStoreState
+func (t SetProductStoreStateJSONBody_StoreState) AsProductStoreStatePlayStoreState() (ProductStoreStatePlayStoreState, error) {
+	var body ProductStoreStatePlayStoreState
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProductStoreStatePlayStoreState overwrites any union data inside the SetProductStoreStateJSONBody_StoreState as the provided ProductStoreStatePlayStoreState
+func (t *SetProductStoreStateJSONBody_StoreState) FromProductStoreStatePlayStoreState(v ProductStoreStatePlayStoreState) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProductStoreStatePlayStoreState performs a merge with any union data inside the SetProductStoreStateJSONBody_StoreState, using the provided ProductStoreStatePlayStoreState
+func (t *SetProductStoreStateJSONBody_StoreState) MergeProductStoreStatePlayStoreState(v ProductStoreStatePlayStoreState) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t SetProductStoreStateJSONBody_StoreState) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *SetProductStoreStateJSONBody_StoreState) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }

--- a/scripts/preprocess-spec.py
+++ b/scripts/preprocess-spec.py
@@ -14,11 +14,28 @@ Rewrites them as:
       allOf:
         - { $ref: '#/components/schemas/SomeSchema' }
 
-Usage: python3 scripts/preprocess-spec.py INPUT OUTPUT
+It also merges any beta overlay specs (see DX-880) on top of the base spec
+before the fix runs, so endpoints the CLI uses that are absent from the public
+spec (the store_state family) are present for codegen and diffing. The merge is
+additive — the public spec always wins on conflicts — so the overlay only fills
+gaps.
+
+Usage: python3 scripts/preprocess-spec.py INPUT OUTPUT [OVERLAY ...]
 """
 
 import sys
 import yaml
+
+
+def merge_overlay(base, overlay):
+    """Add overlay paths + components into base, without overwriting existing
+    keys (the public spec is authoritative)."""
+    for path, item in overlay.get("paths", {}).items():
+        base.setdefault("paths", {}).setdefault(path, item)
+    for ctype, entries in overlay.get("components", {}).items():
+        dest = base.setdefault("components", {}).setdefault(ctype, {})
+        for name, node in entries.items():
+            dest.setdefault(name, node)
 
 
 def fix_nullable_allof(obj):
@@ -51,14 +68,19 @@ def fix_nullable_allof(obj):
 
 
 def main():
-    if len(sys.argv) != 3:
-        print(f"Usage: {sys.argv[0]} INPUT OUTPUT", file=sys.stderr)
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} INPUT OUTPUT [OVERLAY ...]", file=sys.stderr)
         sys.exit(1)
 
     input_path, output_path = sys.argv[1], sys.argv[2]
+    overlay_paths = sys.argv[3:]
 
     with open(input_path) as f:
         spec = yaml.safe_load(f)
+
+    for overlay_path in overlay_paths:
+        with open(overlay_path) as f:
+            merge_overlay(spec, yaml.safe_load(f))
 
     spec = fix_nullable_allof(spec)
 

--- a/scripts/seed-beta-overlay.py
+++ b/scripts/seed-beta-overlay.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Seed docs/specs/v2-beta-overlay.yaml from khepri's full dev OpenAPI spec.
+
+The public spec we fetch from docs is release-filtered and omits endpoints the
+CLI uses but that khepri marks `x-release-status: development` (the store_state
+family). This extracts just those paths — plus every component they reference,
+transitively — into a small overlay that preprocess-spec.py merges on top of the
+public spec at codegen/diff time.
+
+This is a *seeding* tool, not part of CI: run it once against a local checkout
+of khepri's dev spec, then hand-maintain the result. Re-run to reseed when the
+upstream store_state schema changes.
+
+    python3 scripts/seed-beta-overlay.py \
+        ../khepri/khepri/api/developer_api_v2/spec/public/openapi-dev.yaml \
+        docs/specs/v2-beta-overlay.yaml
+
+Which paths to pull is controlled by PATH_SUBSTRINGS below — keep it to the
+endpoints the CLI actually depends on.
+"""
+
+import re
+import sys
+import yaml
+
+# Only pull paths whose key contains one of these — the direct per-product
+# store_state endpoints the CLI's StoreStateService calls. (The store_state_plans
+# tree is intentionally left out for now; add it here if the CLI needs it.)
+PATH_SUBSTRINGS = ["/products/{product_id}/store_state"]
+
+REF_RE = re.compile(r"#/components/([A-Za-z0-9]+)/([A-Za-z0-9_.-]+)")
+
+
+def find_refs(obj):
+    """Yield (component_type, name) for every #/components/<type>/<name> ref."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k == "$ref" and isinstance(v, str):
+                m = REF_RE.search(v)
+                if m:
+                    yield m.group(1), m.group(2)
+            else:
+                yield from find_refs(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from find_refs(item)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} DEV_SPEC OVERLAY_OUT", file=sys.stderr)
+        sys.exit(1)
+    dev_path, out_path = sys.argv[1], sys.argv[2]
+
+    with open(dev_path) as f:
+        dev = yaml.safe_load(f)
+
+    paths = {
+        p: item
+        for p, item in dev.get("paths", {}).items()
+        if any(sub in p for sub in PATH_SUBSTRINGS)
+    }
+    if not paths:
+        print("no matching paths found — check PATH_SUBSTRINGS", file=sys.stderr)
+        sys.exit(1)
+
+    # Walk component refs transitively, starting from the selected paths.
+    dev_components = dev.get("components", {})
+    wanted = {}  # component_type -> set(names)
+    queue = list(find_refs(paths))
+    while queue:
+        ctype, name = queue.pop()
+        wanted.setdefault(ctype, set())
+        if name in wanted[ctype]:
+            continue
+        wanted[ctype].add(name)
+        node = dev_components.get(ctype, {}).get(name)
+        if node is not None:
+            queue.extend(find_refs(node))
+
+    components = {}
+    for ctype, names in sorted(wanted.items()):
+        components[ctype] = {
+            n: dev_components[ctype][n]
+            for n in sorted(names)
+            if n in dev_components.get(ctype, {})
+        }
+
+    overlay = {
+        "# NOTE": (
+            "Hand-maintained beta overlay — see DX-880. Seeded from khepri's "
+            "openapi-dev.yaml (x-release-status: development endpoints the CLI "
+            "uses). Merged onto the public spec by scripts/preprocess-spec.py. "
+            "Remove entries here once they graduate into the public spec."
+        ),
+        "openapi": dev.get("openapi", "3.0.0"),
+        "info": {"title": "RevenueCat v2 — beta overlay", "version": "overlay"},
+        "paths": paths,
+        "components": components,
+    }
+
+    with open(out_path, "w") as f:
+        yaml.dump(overlay, f, allow_unicode=True, sort_keys=False, default_flow_style=False)
+
+    schema_count = len(components.get("schemas", {}))
+    print(f"Wrote {out_path}: {len(paths)} paths, {schema_count} schemas")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The public v2 spec (from docs) is release-filtered and drops endpoints we actually call — the `store_state` family — because khepri marks them `x-release-status: development`.

This adds a small **hand-owned overlay** (`docs/specs/v2-beta-overlay.yaml`) that `preprocess-spec.py` merges onto the public spec before codegen. The merge is additive — the public spec always wins — so the overlay only fills gaps, and entries get deleted as endpoints graduate to public.

- `scripts/seed-beta-overlay.py` seeds it from khepri's `openapi-dev.yaml` (one-time; re-run to reseed). Result: 4 store_state paths + 24 schemas.
- `make gen` now generates the `store_state` schema types (`+3667/-24` in `types_gen.go`, purely additive).

This is the mechanism + the direct store_state endpoints. Follow-ups: migrate `store_state_direct.go` off its hand-written types onto the generated ones, add coverage-map entries, and auto-prune the overlay in the weekly spec-sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec and codegen pipeline changes only; no runtime behavior until generated types are adopted in client code.
> 
> **Overview**
> Adds a **hand-maintained beta overlay** (`docs/specs/v2-beta-overlay.yaml`) so development-only `store_state` APIs missing from the public v2 spec can still drive **oapi-codegen**.
> 
> **`make gen`** now passes that overlay into `preprocess-spec.py` after `v2-developer.yaml`. The merge is **additive** (public spec wins on conflicts), so the overlay only fills gaps until endpoints ship in the public spec.
> 
> The overlay currently defines **four product `store_state` paths** (get/set state, equalize subscription prices, operation polling, screenshot upload reservation) plus **shared components** (App Store / Play Store store-state shapes, Play billing schemas, standard error responses).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b3557694eadd74fe04944189d186ab27a9902e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->