### PR TITLE
add media-assets upload command

### DIFF
--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -239,6 +239,9 @@ rc purchases refund <id>                                 # Web Billing only
 # Invoices
 rc invoices show <id>
 
+# Media Assets
+rc media-assets upload <file>                            # upload an image (jpg/png/webp/avif/heic/heif, ≤2 MiB) to the project Media Gallery
+
 # Virtual currencies (project catalog; per-customer lives under `customer wallet`)
 rc currencies list
 rc currencies show <id>

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -58,6 +58,7 @@ type Client struct {
 	Invoices        *InvoicesService
 	Webhooks        *WebhooksService
 	Paywalls        *PaywallsService
+	MediaAssets     *MediaAssetsService
 	Charts          *ChartsService
 	Metrics         *MetricsService
 	Audit           *AuditService
@@ -99,6 +100,7 @@ func NewClient(opts Options) *Client {
 	c.Invoices = &InvoicesService{c: c}
 	c.Webhooks = &WebhooksService{c: c}
 	c.Paywalls = &PaywallsService{c: c}
+	c.MediaAssets = &MediaAssetsService{c: c}
 	c.Charts = &ChartsService{c: c}
 	c.Metrics = &MetricsService{c: c}
 	c.Audit = &AuditService{c: c}

--- a/internal/api/media_assets.go
+++ b/internal/api/media_assets.go
@@ -7,8 +7,6 @@ import (
 
 type MediaAssetsService struct{ c *Client }
 
-// MediaAsset, MediaAssetFormat, and CreateMediaAssetJSONBody are generated in types_gen.go.
-
 func (s *MediaAssetsService) Create(ctx context.Context, projectID string, body CreateMediaAssetJSONBody) (*MediaAsset, error) {
 	var out MediaAsset
 	err := s.c.do(ctx, http.MethodPost, encodePath("projects", projectID, "media_assets"), body, &out)

--- a/internal/api/media_assets.go
+++ b/internal/api/media_assets.go
@@ -16,9 +16,10 @@ type MediaAssetCreate struct {
 
 type MediaAssetFormat struct {
 	ObjectName string `json:"object_name"`
-	Size       int64  `json:"size"`
-	Width      int    `json:"width"`
-	Height     int    `json:"height"`
+	Size       int64  `json:"size"` // KB
+	Width      *int   `json:"width"`
+	Height     *int   `json:"height"`
+	Object     string `json:"object,omitempty"`
 }
 
 type MediaAsset struct {

--- a/internal/api/media_assets.go
+++ b/internal/api/media_assets.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+type MediaAssetsService struct{ c *Client }
+
+type MediaAssetCreate struct {
+	Filename       string `json:"filename"`
+	ContentType    string `json:"content_type"`
+	FileDataBase64 string `json:"file_data_base64"`
+}
+
+type MediaAssetFormat struct {
+	ObjectName string `json:"object_name"`
+	Size       int64  `json:"size"`
+	Width      int    `json:"width"`
+	Height     int    `json:"height"`
+}
+
+type MediaAsset struct {
+	ID                string                      `json:"id"`
+	ObjectName        string                      `json:"object_name"`
+	OriginalName      string                      `json:"original_name"`
+	OriginalSize      int64                       `json:"original_size"` // KB
+	OriginalWidth     *int                        `json:"original_width"`
+	OriginalHeight    *int                        `json:"original_height"`
+	Formats           map[string]MediaAssetFormat `json:"formats"`
+	AltText           *string                     `json:"alt_text"`
+	IsDecorative      bool                        `json:"is_decorative"`
+	AssetBaseURL      *string                     `json:"asset_base_url"`
+	AssetType         string                      `json:"asset_type"`
+	VideoMetadata     json.RawMessage             `json:"video_metadata"`
+	TranscodingStatus *string                     `json:"transcoding_status"`
+	Object            string                      `json:"object,omitempty"`
+}
+
+func (s *MediaAssetsService) Create(ctx context.Context, projectID string, body MediaAssetCreate) (*MediaAsset, error) {
+	var out MediaAsset
+	err := s.c.do(ctx, http.MethodPost, encodePath("projects", projectID, "media_assets"), body, &out)
+	return &out, err
+}

--- a/internal/api/media_assets.go
+++ b/internal/api/media_assets.go
@@ -2,44 +2,14 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 )
 
 type MediaAssetsService struct{ c *Client }
 
-type MediaAssetCreate struct {
-	Filename       string `json:"filename"`
-	ContentType    string `json:"content_type"`
-	FileDataBase64 string `json:"file_data_base64"`
-}
+// MediaAsset, MediaAssetFormat, and CreateMediaAssetJSONBody are generated in types_gen.go.
 
-type MediaAssetFormat struct {
-	ObjectName string `json:"object_name"`
-	Size       int64  `json:"size"`
-	Width      *int   `json:"width"`
-	Height     *int   `json:"height"`
-	Object     string `json:"object,omitempty"`
-}
-
-type MediaAsset struct {
-	ID                string                      `json:"id"`
-	ObjectName        string                      `json:"object_name"`
-	OriginalName      string                      `json:"original_name"`
-	OriginalSize      int64                       `json:"original_size"`
-	OriginalWidth     *int                        `json:"original_width"`
-	OriginalHeight    *int                        `json:"original_height"`
-	Formats           map[string]MediaAssetFormat `json:"formats"`
-	AltText           *string                     `json:"alt_text"`
-	IsDecorative      bool                        `json:"is_decorative"`
-	AssetBaseURL      *string                     `json:"asset_base_url"`
-	AssetType         string                      `json:"asset_type"`
-	VideoMetadata     json.RawMessage             `json:"video_metadata"`
-	TranscodingStatus *string                     `json:"transcoding_status"`
-	Object            string                      `json:"object,omitempty"`
-}
-
-func (s *MediaAssetsService) Create(ctx context.Context, projectID string, body MediaAssetCreate) (*MediaAsset, error) {
+func (s *MediaAssetsService) Create(ctx context.Context, projectID string, body CreateMediaAssetJSONBody) (*MediaAsset, error) {
 	var out MediaAsset
 	err := s.c.do(ctx, http.MethodPost, encodePath("projects", projectID, "media_assets"), body, &out)
 	return &out, err

--- a/internal/api/media_assets.go
+++ b/internal/api/media_assets.go
@@ -16,7 +16,7 @@ type MediaAssetCreate struct {
 
 type MediaAssetFormat struct {
 	ObjectName string `json:"object_name"`
-	Size       int64  `json:"size"` // KB
+	Size       int64  `json:"size"`
 	Width      *int   `json:"width"`
 	Height     *int   `json:"height"`
 	Object     string `json:"object,omitempty"`
@@ -26,7 +26,7 @@ type MediaAsset struct {
 	ID                string                      `json:"id"`
 	ObjectName        string                      `json:"object_name"`
 	OriginalName      string                      `json:"original_name"`
-	OriginalSize      int64                       `json:"original_size"` // KB
+	OriginalSize      int64                       `json:"original_size"`
 	OriginalWidth     *int                        `json:"original_width"`
 	OriginalHeight    *int                        `json:"original_height"`
 	Formats           map[string]MediaAssetFormat `json:"formats"`

--- a/internal/api/media_assets_test.go
+++ b/internal/api/media_assets_test.go
@@ -1,0 +1,78 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+func TestMediaAssetsCreate(t *testing.T) {
+	raw := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/projects/proj/media_assets" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body api.MediaAssetCreate
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body.Filename != "logo.png" || body.ContentType != "image/png" {
+			t.Fatalf("unexpected body: %+v", body)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(body.FileDataBase64)
+		if err != nil {
+			t.Fatalf("file_data_base64 is not valid base64: %v", err)
+		}
+		if !bytes.Equal(decoded, raw) {
+			t.Fatalf("file_data_base64 decodes to %v, want %v", decoded, raw)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+			"object": "media_asset",
+			"id": "medas_abc",
+			"object_name": "media/proj/logo.png",
+			"original_name": "logo.png",
+			"original_size": 1,
+			"original_width": 32,
+			"original_height": 16,
+			"formats": {"webp": {"object_name": "media/proj/logo.webp", "size": 512, "width": 32, "height": 16}},
+			"alt_text": null,
+			"is_decorative": false,
+			"asset_base_url": "https://assets.example.com",
+			"asset_type": "image",
+			"video_metadata": null,
+			"transcoding_status": null
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := api.NewClient(api.Options{APIKey: "sk_test", BaseURL: srv.URL})
+	asset, err := client.MediaAssets.Create(context.Background(), "proj", api.MediaAssetCreate{
+		Filename:       "logo.png",
+		ContentType:    "image/png",
+		FileDataBase64: base64.StdEncoding.EncodeToString(raw),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asset.ID != "medas_abc" || asset.ObjectName != "media/proj/logo.png" || asset.AssetType != "image" {
+		t.Fatalf("unexpected asset: %+v", asset)
+	}
+	if asset.OriginalWidth == nil || *asset.OriginalWidth != 32 {
+		t.Fatalf("original_width = %v, want 32", asset.OriginalWidth)
+	}
+	if asset.AltText != nil || asset.TranscodingStatus != nil {
+		t.Fatalf("nullable fields should be nil: %+v", asset)
+	}
+	f, ok := asset.Formats["webp"]
+	if !ok || f.ObjectName != "media/proj/logo.webp" || f.Size != 512 {
+		t.Fatalf("unexpected formats: %+v", asset.Formats)
+	}
+}

--- a/internal/api/media_assets_test.go
+++ b/internal/api/media_assets_test.go
@@ -42,7 +42,7 @@ func TestMediaAssetsCreate(t *testing.T) {
 			"original_size": 1,
 			"original_width": 32,
 			"original_height": 16,
-			"formats": {"webp": {"object_name": "media/proj/logo.webp", "size": 512, "width": 32, "height": 16}},
+			"formats": {"webp": {"object": "media_asset_format", "object_name": "media/proj/logo.webp", "size": 512, "width": 32, "height": null}},
 			"alt_text": null,
 			"is_decorative": false,
 			"asset_base_url": "https://assets.example.com",
@@ -72,7 +72,10 @@ func TestMediaAssetsCreate(t *testing.T) {
 		t.Fatalf("nullable fields should be nil: %+v", asset)
 	}
 	f, ok := asset.Formats["webp"]
-	if !ok || f.ObjectName != "media/proj/logo.webp" || f.Size != 512 {
+	if !ok || f.ObjectName != "media/proj/logo.webp" || f.Size != 512 || f.Object != "media_asset_format" {
 		t.Fatalf("unexpected formats: %+v", asset.Formats)
+	}
+	if f.Width == nil || *f.Width != 32 || f.Height != nil {
+		t.Fatalf("format dimensions = %v/%v, want 32/nil", f.Width, f.Height)
 	}
 }

--- a/internal/api/media_assets_test.go
+++ b/internal/api/media_assets_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -14,62 +13,35 @@ import (
 
 func TestMediaAssetsCreate(t *testing.T) {
 	raw := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a}
+	body := api.MediaAssetCreate{
+		Filename:       "logo.png",
+		ContentType:    "image/png",
+		FileDataBase64: base64.StdEncoding.EncodeToString(raw),
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/projects/proj/media_assets" {
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
-		var body api.MediaAssetCreate
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		var got api.MediaAssetCreate
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
 			t.Fatal(err)
 		}
-		if body.Filename != "logo.png" || body.ContentType != "image/png" {
-			t.Fatalf("unexpected body: %+v", body)
-		}
-		decoded, err := base64.StdEncoding.DecodeString(body.FileDataBase64)
-		if err != nil {
-			t.Fatalf("file_data_base64 is not valid base64: %v", err)
-		}
-		if !bytes.Equal(decoded, raw) {
-			t.Fatalf("file_data_base64 decodes to %v, want %v", decoded, raw)
+		if got != body {
+			t.Fatalf("body = %+v, want %+v", got, body)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{
-			"object": "media_asset",
-			"id": "medas_abc",
-			"object_name": "media/proj/logo.png",
-			"original_name": "logo.png",
-			"original_size": 1,
-			"original_width": 32,
-			"original_height": 16,
-			"formats": {"webp": {"object": "media_asset_format", "object_name": "media/proj/logo.webp", "size": 512, "width": 32, "height": null}},
-			"alt_text": null,
-			"is_decorative": false,
-			"asset_base_url": "https://assets.example.com",
-			"asset_type": "image",
-			"video_metadata": null,
-			"transcoding_status": null
-		}`))
+		_, _ = w.Write([]byte(`{"id":"medas_abc","formats":{"webp":{"object":"media_asset_format","object_name":"media/proj/logo.webp","size":512,"width":32,"height":null}}}`))
 	}))
 	t.Cleanup(srv.Close)
 
 	client := api.NewClient(api.Options{APIKey: "sk_test", BaseURL: srv.URL})
-	asset, err := client.MediaAssets.Create(context.Background(), "proj", api.MediaAssetCreate{
-		Filename:       "logo.png",
-		ContentType:    "image/png",
-		FileDataBase64: base64.StdEncoding.EncodeToString(raw),
-	})
+	asset, err := client.MediaAssets.Create(context.Background(), "proj", body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if asset.ID != "medas_abc" || asset.ObjectName != "media/proj/logo.png" || asset.AssetType != "image" {
-		t.Fatalf("unexpected asset: %+v", asset)
-	}
-	if asset.OriginalWidth == nil || *asset.OriginalWidth != 32 {
-		t.Fatalf("original_width = %v, want 32", asset.OriginalWidth)
-	}
-	if asset.AltText != nil || asset.TranscodingStatus != nil {
-		t.Fatalf("nullable fields should be nil: %+v", asset)
+	if asset.ID != "medas_abc" {
+		t.Fatalf("id = %q, want medas_abc", asset.ID)
 	}
 	f, ok := asset.Formats["webp"]
 	if !ok || f.ObjectName != "media/proj/logo.webp" || f.Size != 512 || f.Object != "media_asset_format" {

--- a/internal/api/media_assets_test.go
+++ b/internal/api/media_assets_test.go
@@ -13,16 +13,16 @@ import (
 
 func TestMediaAssetsCreate(t *testing.T) {
 	raw := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a}
-	body := api.MediaAssetCreate{
+	body := api.CreateMediaAssetJSONBody{
 		Filename:       "logo.png",
-		ContentType:    "image/png",
+		ContentType:    api.ImagePng,
 		FileDataBase64: base64.StdEncoding.EncodeToString(raw),
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/projects/proj/media_assets" {
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
-		var got api.MediaAssetCreate
+		var got api.CreateMediaAssetJSONBody
 		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
 			t.Fatal(err)
 		}
@@ -43,7 +43,10 @@ func TestMediaAssetsCreate(t *testing.T) {
 	if asset.ID != "medas_abc" {
 		t.Fatalf("id = %q, want medas_abc", asset.ID)
 	}
-	f, ok := asset.Formats["webp"]
+	if asset.Formats == nil {
+		t.Fatal("formats = nil")
+	}
+	f, ok := (*asset.Formats)["webp"]
 	if !ok || f.ObjectName != "media/proj/logo.webp" || f.Size != 512 || f.Object != "media_asset_format" {
 		t.Fatalf("unexpected formats: %+v", asset.Formats)
 	}

--- a/internal/cli/media_assets.go
+++ b/internal/cli/media_assets.go
@@ -27,24 +27,24 @@ const mediaAssetMaxBytes = 2 << 20
 
 var errMediaAssetTooLarge = errors.New("the upload limit is 2 MiB")
 
-func loadMediaAsset(path string) (api.MediaAssetCreate, error) {
+func loadMediaAsset(path string) (api.CreateMediaAssetJSONBody, error) {
 	contentType, ok := mediaAssetContentTypes[strings.ToLower(filepath.Ext(path))]
 	if !ok {
-		return api.MediaAssetCreate{}, fmt.Errorf("unsupported image type %q (accepted: jpg, jpeg, png, webp, avif, heic, heif)", path)
+		return api.CreateMediaAssetJSONBody{}, fmt.Errorf("unsupported image type %q (accepted: jpg, jpeg, png, webp, avif, heic, heif)", path)
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return api.MediaAssetCreate{}, err
+		return api.CreateMediaAssetJSONBody{}, err
 	}
 	if len(data) == 0 {
-		return api.MediaAssetCreate{}, fmt.Errorf("image %s is empty", path)
+		return api.CreateMediaAssetJSONBody{}, fmt.Errorf("image %s is empty", path)
 	}
 	if len(data) > mediaAssetMaxBytes {
-		return api.MediaAssetCreate{}, fmt.Errorf("image %s is %d KB: %w", path, len(data)/1024, errMediaAssetTooLarge)
+		return api.CreateMediaAssetJSONBody{}, fmt.Errorf("image %s is %d KB: %w", path, len(data)/1024, errMediaAssetTooLarge)
 	}
-	return api.MediaAssetCreate{
+	return api.CreateMediaAssetJSONBody{
 		Filename:       filepath.Base(path),
-		ContentType:    contentType,
+		ContentType:    api.CreateMediaAssetJSONBodyContentType(contentType),
 		FileDataBase64: base64.StdEncoding.EncodeToString(data),
 	}, nil
 }

--- a/internal/cli/media_assets.go
+++ b/internal/cli/media_assets.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,6 +25,8 @@ var mediaAssetContentTypes = map[string]string{
 
 const mediaAssetMaxBytes = 2 << 20
 
+var errMediaAssetTooLarge = errors.New("the upload limit is 2 MiB")
+
 func loadMediaAsset(path string) (api.MediaAssetCreate, error) {
 	contentType, ok := mediaAssetContentTypes[strings.ToLower(filepath.Ext(path))]
 	if !ok {
@@ -37,7 +40,7 @@ func loadMediaAsset(path string) (api.MediaAssetCreate, error) {
 		return api.MediaAssetCreate{}, fmt.Errorf("image %s is empty", path)
 	}
 	if len(data) > mediaAssetMaxBytes {
-		return api.MediaAssetCreate{}, fmt.Errorf("image %s is %.1f MiB; the upload limit is 2 MiB — resize or compress it first", path, float64(len(data))/(1<<20))
+		return api.MediaAssetCreate{}, fmt.Errorf("image %s is %d KB: %w", path, len(data)/1024, errMediaAssetTooLarge)
 	}
 	return api.MediaAssetCreate{
 		Filename:       filepath.Base(path),
@@ -68,6 +71,9 @@ func newMediaAssetsUploadCmd() *cobra.Command {
 			}
 			body, err := loadMediaAsset(args[0])
 			if err != nil {
+				if errors.Is(err, errMediaAssetTooLarge) {
+					rt.Out.Hint("Resize or compress the image to 2 MiB or less, then retry")
+				}
 				return err
 			}
 			client, err := rt.API()

--- a/internal/cli/media_assets.go
+++ b/internal/cli/media_assets.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+// Accepted upload types per the v2 media_assets endpoint's content_type enum.
+// Deliberately not paywallAIImageTypes: that map is editor-specific and lacks
+// avif/heic/heif.
+var mediaAssetContentTypes = map[string]string{
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".png":  "image/png",
+	".webp": "image/webp",
+	".avif": "image/avif",
+	".heic": "image/heic",
+	".heif": "image/heif",
+}
+
+// mediaAssetMaxBytes mirrors the endpoint's file_data_base64 maxLength of
+// 2,796,204 chars, which is base64.EncodedLen of exactly 2 MiB.
+const mediaAssetMaxBytes = 2 << 20
+
+func loadMediaAsset(path string) (api.MediaAssetCreate, error) {
+	contentType, ok := mediaAssetContentTypes[strings.ToLower(filepath.Ext(path))]
+	if !ok {
+		return api.MediaAssetCreate{}, fmt.Errorf("unsupported image type %q (accepted: jpg, jpeg, png, webp, avif, heic, heif)", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return api.MediaAssetCreate{}, err
+	}
+	if len(data) == 0 {
+		return api.MediaAssetCreate{}, fmt.Errorf("image %s is empty", path)
+	}
+	if len(data) > mediaAssetMaxBytes {
+		return api.MediaAssetCreate{}, fmt.Errorf("image %s is %.1f MiB; the upload limit is 2 MiB — resize or compress it first", path, float64(len(data))/(1<<20))
+	}
+	return api.MediaAssetCreate{
+		Filename:       filepath.Base(path),
+		ContentType:    contentType,
+		FileDataBase64: base64.StdEncoding.EncodeToString(data),
+	}, nil
+}
+
+func newMediaAssetsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "media-assets",
+		Short: "Manage project media assets",
+	}
+	cmd.AddCommand(newMediaAssetsUploadCmd())
+	return cmd
+}
+
+func newMediaAssetsUploadCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "upload <file>",
+		Short: "Upload an image to the project Media Gallery",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rt := RuntimeFrom(cmd.Context())
+			projectID, err := requireProject(rt)
+			if err != nil {
+				return err
+			}
+			body, err := loadMediaAsset(args[0])
+			if err != nil {
+				return err
+			}
+			client, err := rt.API()
+			if err != nil {
+				return err
+			}
+			asset, err := client.MediaAssets.Create(cmd.Context(), projectID, body)
+			if err != nil {
+				return err
+			}
+			rt.Out.Success(fmt.Sprintf("Uploaded %s (%s, %d KB)", asset.ID, asset.OriginalName, asset.OriginalSize))
+			rt.Out.Hint("Reference it from paywall components as " + asset.ObjectName)
+			return rt.Out.Render(asset)
+		},
+	}
+}

--- a/internal/cli/media_assets.go
+++ b/internal/cli/media_assets.go
@@ -84,7 +84,10 @@ func newMediaAssetsUploadCmd() *cobra.Command {
 				return err
 			}
 			rt.Out.Success(fmt.Sprintf("Uploaded %s (%s, %d KB)", asset.ID, asset.OriginalName, asset.OriginalSize))
-			rt.Out.Hint("Reference it from paywall components as " + asset.ObjectName)
+			// Paywall components store the full URL, not the bare object name.
+			if asset.AssetBaseURL != nil {
+				rt.Out.Hint("Reference it from paywall components as " + *asset.AssetBaseURL + "/" + asset.ObjectName)
+			}
 			return rt.Out.Render(asset)
 		},
 	}

--- a/internal/cli/media_assets.go
+++ b/internal/cli/media_assets.go
@@ -12,9 +12,6 @@ import (
 	"github.com/revenuecat/cli/internal/api"
 )
 
-// Accepted upload types per the v2 media_assets endpoint's content_type enum.
-// Deliberately not paywallAIImageTypes: that map is editor-specific and lacks
-// avif/heic/heif.
 var mediaAssetContentTypes = map[string]string{
 	".jpg":  "image/jpeg",
 	".jpeg": "image/jpeg",
@@ -25,8 +22,6 @@ var mediaAssetContentTypes = map[string]string{
 	".heif": "image/heif",
 }
 
-// mediaAssetMaxBytes mirrors the endpoint's file_data_base64 maxLength of
-// 2,796,204 chars, which is base64.EncodedLen of exactly 2 MiB.
 const mediaAssetMaxBytes = 2 << 20
 
 func loadMediaAsset(path string) (api.MediaAssetCreate, error) {
@@ -84,7 +79,6 @@ func newMediaAssetsUploadCmd() *cobra.Command {
 				return err
 			}
 			rt.Out.Success(fmt.Sprintf("Uploaded %s (%s, %d KB)", asset.ID, asset.OriginalName, asset.OriginalSize))
-			// Paywall components store the full URL, not the bare object name.
 			if asset.AssetBaseURL != nil {
 				rt.Out.Hint("Reference it from paywall components as " + *asset.AssetBaseURL + "/" + asset.ObjectName)
 			}

--- a/internal/cli/media_assets_test.go
+++ b/internal/cli/media_assets_test.go
@@ -12,20 +12,6 @@ import (
 	"testing"
 )
 
-func mediaAssetServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/projects/proj/media_assets" {
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		io.WriteString(w, `{"object":"media_asset","id":"medas_abc","object_name":"media/proj/tiny.png","original_name":"tiny.png","original_size":1,"original_width":null,"original_height":null,"formats":null,"alt_text":null,"is_decorative":false,"asset_base_url":"https://assets.example.com","asset_type":"image","video_metadata":null,"transcoding_status":null}`)
-	}))
-	t.Cleanup(srv.Close)
-	return srv
-}
-
 func writeTempImage(t *testing.T, name string, data []byte) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), name)
@@ -35,37 +21,28 @@ func writeTempImage(t *testing.T, name string, data []byte) string {
 	return path
 }
 
-func runMediaAssetsUpload(t *testing.T, path string, extra ...string) (stdout, stderr string, err error) {
+func runMediaAssetsUpload(t *testing.T, path string) (stdout, stderr string, err error) {
 	t.Helper()
 	t.Setenv("RC_CONFIG_DIR", t.TempDir())
 	var out, errb bytes.Buffer
 	root := NewRootCmd("test")
 	root.SetOut(&out)
 	root.SetErr(&errb)
-	root.SetArgs(append([]string{"media-assets", "upload", path, "--no-input", "--api-key", "sk_test", "--project-id", "proj"}, extra...))
+	root.SetArgs([]string{"media-assets", "upload", path, "--no-input", "--api-key", "sk_test", "--project-id", "proj"})
 	err = root.ExecuteContext(context.Background())
 	return out.String(), errb.String(), err
 }
 
-func TestMediaAssetsUpload_JSON(t *testing.T) {
-	srv := mediaAssetServer(t)
-	t.Setenv("RC_BASE_URL", srv.URL)
-	path := writeTempImage(t, "tiny.png", []byte{0x89, 'P', 'N', 'G'})
-
-	stdout, stderr, err := runMediaAssetsUpload(t, path, "--json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(stdout, `"id": "medas_abc"`) || !strings.Contains(stdout, `"schema_version": 1`) {
-		t.Fatalf("stdout missing JSON envelope: %s", stdout)
-	}
-	if stderr != "" {
-		t.Fatalf("stderr should be empty in JSON mode: %s", stderr)
-	}
-}
-
-func TestMediaAssetsUpload_Human(t *testing.T) {
-	srv := mediaAssetServer(t)
+func TestMediaAssetsUpload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/projects/proj/media_assets" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"object":"media_asset","id":"medas_abc","object_name":"media/proj/tiny.png","original_name":"tiny.png","original_size":1,"original_width":null,"original_height":null,"formats":null,"alt_text":null,"is_decorative":false,"asset_base_url":"https://assets.example.com","asset_type":"image","video_metadata":null,"transcoding_status":null}`)
+	}))
+	t.Cleanup(srv.Close)
 	t.Setenv("RC_BASE_URL", srv.URL)
 	path := writeTempImage(t, "tiny.png", []byte{0x89, 'P', 'N', 'G'})
 

--- a/internal/cli/media_assets_test.go
+++ b/internal/cli/media_assets_test.go
@@ -85,7 +85,6 @@ func TestMediaAssetsUpload_Human(t *testing.T) {
 }
 
 func TestMediaAssetsUpload_ValidationErrors(t *testing.T) {
-	// No server: validation must fail before any network call.
 	cases := []struct {
 		name, file string
 		data       []byte

--- a/internal/cli/media_assets_test.go
+++ b/internal/cli/media_assets_test.go
@@ -20,7 +20,7 @@ func mediaAssetServer(t *testing.T) *httptest.Server {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		io.WriteString(w, `{"object":"media_asset","id":"medas_abc","object_name":"media/proj/tiny.png","original_name":"tiny.png","original_size":1,"original_width":null,"original_height":null,"formats":null,"alt_text":null,"is_decorative":false,"asset_base_url":null,"asset_type":"image","video_metadata":null,"transcoding_status":null}`)
+		io.WriteString(w, `{"object":"media_asset","id":"medas_abc","object_name":"media/proj/tiny.png","original_name":"tiny.png","original_size":1,"original_width":null,"original_height":null,"formats":null,"alt_text":null,"is_decorative":false,"asset_base_url":"https://assets.example.com","asset_type":"image","video_metadata":null,"transcoding_status":null}`)
 	}))
 	t.Cleanup(srv.Close)
 	return srv
@@ -76,8 +76,8 @@ func TestMediaAssetsUpload_Human(t *testing.T) {
 	if !strings.Contains(stderr, "Uploaded medas_abc (tiny.png, 1 KB)") {
 		t.Fatalf("stderr missing success line: %s", stderr)
 	}
-	if !strings.Contains(stderr, "media/proj/tiny.png") {
-		t.Fatalf("stderr missing object_name hint: %s", stderr)
+	if !strings.Contains(stderr, "https://assets.example.com/media/proj/tiny.png") {
+		t.Fatalf("stderr missing asset URL hint: %s", stderr)
 	}
 	if !strings.Contains(stdout, "medas_abc") {
 		t.Fatalf("stdout missing rendered asset: %s", stdout)

--- a/internal/cli/media_assets_test.go
+++ b/internal/cli/media_assets_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func mediaAssetServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/projects/proj/media_assets" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		io.WriteString(w, `{"object":"media_asset","id":"medas_abc","object_name":"media/proj/tiny.png","original_name":"tiny.png","original_size":1,"original_width":null,"original_height":null,"formats":null,"alt_text":null,"is_decorative":false,"asset_base_url":null,"asset_type":"image","video_metadata":null,"transcoding_status":null}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func writeTempImage(t *testing.T, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func runMediaAssetsUpload(t *testing.T, path string, extra ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	var out, errb bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	root.SetArgs(append([]string{"media-assets", "upload", path, "--no-input", "--api-key", "sk_test", "--project-id", "proj"}, extra...))
+	err = root.ExecuteContext(context.Background())
+	return out.String(), errb.String(), err
+}
+
+func TestMediaAssetsUpload_JSON(t *testing.T) {
+	srv := mediaAssetServer(t)
+	t.Setenv("RC_BASE_URL", srv.URL)
+	path := writeTempImage(t, "tiny.png", []byte{0x89, 'P', 'N', 'G'})
+
+	stdout, stderr, err := runMediaAssetsUpload(t, path, "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, `"id": "medas_abc"`) || !strings.Contains(stdout, `"schema_version": 1`) {
+		t.Fatalf("stdout missing JSON envelope: %s", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr should be empty in JSON mode: %s", stderr)
+	}
+}
+
+func TestMediaAssetsUpload_Human(t *testing.T) {
+	srv := mediaAssetServer(t)
+	t.Setenv("RC_BASE_URL", srv.URL)
+	path := writeTempImage(t, "tiny.png", []byte{0x89, 'P', 'N', 'G'})
+
+	stdout, stderr, err := runMediaAssetsUpload(t, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr, "Uploaded medas_abc (tiny.png, 1 KB)") {
+		t.Fatalf("stderr missing success line: %s", stderr)
+	}
+	if !strings.Contains(stderr, "media/proj/tiny.png") {
+		t.Fatalf("stderr missing object_name hint: %s", stderr)
+	}
+	if !strings.Contains(stdout, "medas_abc") {
+		t.Fatalf("stdout missing rendered asset: %s", stdout)
+	}
+}
+
+func TestMediaAssetsUpload_ValidationErrors(t *testing.T) {
+	// No server: validation must fail before any network call.
+	cases := []struct {
+		name, file string
+		data       []byte
+		wantErr    string
+	}{
+		{"unsupported extension", "anim.gif", []byte("GIF89a"), "unsupported image type"},
+		{"oversized", "big.png", make([]byte, 2<<20+1), "2 MiB"},
+		{"empty", "empty.png", nil, "is empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTempImage(t, tc.file, tc.data)
+			_, _, err := runMediaAssetsUpload(t, path)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -137,6 +137,7 @@ Agent-friendly entrypoints:
 		newInvoicesCmd(),
 		newWebhooksCmd(),
 		newPaywallsCmd(),
+		newMediaAssetsCmd(),
 		newRicoCmd(),
 		newChartsCmd(),
 		newMetricsCmd(),


### PR DESCRIPTION
Adds `rc media-assets upload <file>` to upload images to the project Media Gallery via the v2 media_assets endpoint.

In RC dashboard, you can also upload videos but it's done via different flow with a presigned S3 URL. I opened a Linear ticket for video uploads and will follow up later.

### Successful example
```
> ./rc-local media-assets upload ~/Downloads/test.png

✓ Uploaded mediaasset92f8172f0142415c91ea8611911fb2cf (test.png, 124 KB)
  Reference it from paywall components as https://assets.pawwalls.com/1349162_1786009750_c3c3ddbc.png
id                  mediaasset92f8172f0142415c91ea8611911fb2cf
alt_text            —
asset_base_url      https://assets.pawwalls.com
asset_type          image
formats             {…}
is_decorative       false
object_name         1349162_1786009750_c3c3ddbc.png
original_height     998
original_name       test.png
original_size       124
original_width      1176
transcoding_status  —
video_metadata      —

# using --json
> ./rc-local media-assets upload ~/Downloads/test.png --json
{
  "data": {
    "id": "mediaassetf5750b8faecc4b11a98195b537cdad92",
    "object_name": "1349162_1786010119_10d31e56.png",
    "original_name": "test.png",
    "original_size": 124,
    "original_width": 1176,
    "original_height": 998,
    "formats": {
      "heic": {
        "object_name": "1349162_1786010119_10d31e56.heic",
        "size": 89,
        "width": 1176,
        "height": 998,
        "object": "media_asset_format"
      },
      "heic_low_res": {
        "object_name": "1349162_low_res_1786010119_10d31e56.heic",
        "size": 34,
        "width": 600,
        "height": 509,
        "object": "media_asset_format"
      },
      "webp": {
        "object_name": "1349162_1786010119_10d31e56.webp",
        "size": 37,
        "width": 1176,
        "height": 998,
        "object": "media_asset_format"
      },
      "webp_low_res": {
        "object_name": "1349162_low_res_1786010119_10d31e56.webp",
        "size": 15,
        "width": 600,
        "height": 509,
        "object": "media_asset_format"
      }
    },
    "alt_text": null,
    "is_decorative": false,
    "asset_base_url": "https://assets.pawwalls.com",
    "asset_type": "image",
    "video_metadata": null,
    "transcoding_status": null,
    "object": "media_asset"
  },
  "schema_version": 1
}
```

### Failure example
```
> ./rc-local media-assets upload dummy-2049kb.png
✗ image dummy-2049kb.png is 2.0 MiB; the upload limit is 2 MiB — resize or compress it first

> ./rc-local media-assets upload dummy-2049kb.png --json
{
  "error": {
    "type": "cli_error",
    "message": "image dummy-2049kb.png is 2.0 MiB; the upload limit is 2 MiB — resize or compress it first",
    "exit_code": 1
  },
  "schema_version": 1
}
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CLI surface and API wrapper with local file validation only; no changes to auth, billing, or existing command behavior.
> 
> **Overview**
> Adds **`rc media-assets upload <file>`** so images can be pushed to the project Media Gallery through the v2 **`POST /projects/{id}/media_assets`** API.
> 
> The command reads a local file, validates extension (jpg/jpeg/png/webp/avif/heic/heif), rejects empty or **>2 MiB** files, base64-encodes the payload, and calls a new **`MediaAssetsService.Create`**. On success it prints upload metadata and a hint URL for paywall components; output follows the usual table/`--json` rendering.
> 
> **`docs/command-surface.md`** documents the new subcommand. API and CLI tests cover the HTTP client and upload validation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa5fb90d7df707df2ed6344ccd5ab306b93fb775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->