### PR TITLE
Fix store-state screenshot upload path

### DIFF
--- a/docs/specs/cli-coverage.yaml
+++ b/docs/specs/cli-coverage.yaml
@@ -214,15 +214,16 @@ endpoints:
   - method: GET
     path: /projects/{project_id}/audit_logs
 
-  # Store state (development-status; provided by the beta overlay). The
-  # screenshot_upload path and the dynamic plans/{plan_id}/actions/{action} call
-  # are intentionally omitted — see internal/api/store_state_*.go.
+  # Store state (development-status; provided by the beta overlay). The dynamic
+  # plans/{plan_id}/actions/{action} call is omitted — see store_state_plans.go.
   - method: GET
     path: /projects/{project_id}/products/{product_id}/store_state
   - method: POST
     path: /projects/{project_id}/products/{product_id}/store_state
   - method: GET
     path: /projects/{project_id}/products/{product_id}/store_state/{operation_id}
+  - method: POST
+    path: /projects/{project_id}/products/{product_id}/store_state/screenshot_upload
   - method: POST
     path: /projects/{project_id}/store_state/plans
   - method: GET

--- a/internal/api/paths_gen.go
+++ b/internal/api/paths_gen.go
@@ -218,6 +218,10 @@ func pathProductStoreStateOperation(projectID string, productID string, operatio
 	return encodePath("projects", projectID, "products", productID, "store_state", operationID)
 }
 
+func pathProductStoreStateScreenshotUpload(projectID string, productID string) string {
+	return encodePath("projects", projectID, "products", productID, "store_state", "screenshot_upload")
+}
+
 func pathProductTestStorePrices(projectID string, productID string) string {
 	return encodePath("projects", projectID, "products", productID, "test_store_prices")
 }

--- a/internal/api/store_state_direct.go
+++ b/internal/api/store_state_direct.go
@@ -93,10 +93,7 @@ func (s *StoreStateService) Get(ctx context.Context, projectID, productID string
 func (s *StoreStateService) ReserveScreenshotUpload(ctx context.Context, projectID, productID, filename string, fileSize int64) (*ScreenshotUploadReservation, error) {
 	var out ScreenshotUploadReservation
 	body := map[string]any{"filename": filename, "file_size": fileSize}
-	// Inline path pending verification: the backend spec has this as
-	// store_state/screenshot_upload (two segments); this sends one. Left as-is
-	// so this change stays behavior-preserving — the path fix is tracked separately.
-	err := s.c.do(ctx, http.MethodPost, encodePath("projects", projectID, "products", productID, "store_state_screenshot_upload"), body, &out)
+	err := s.c.do(ctx, http.MethodPost, pathProductStoreStateScreenshotUpload(projectID, productID), body, &out)
 	return &out, err
 }
 


### PR DESCRIPTION
`rc` store-state screenshot upload was POSTing to `.../products/{id}/store_state_screenshot_upload` (one segment), but the real route is `.../products/{id}/store_state/screenshot_upload` (two). The upload was hitting a path that doesn't exist.

Verified against the backend's dev spec. Fix points the method at the generated builder for the correct path.

Stacked on #69.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live HTTP path for store-state screenshot reservations; wrong path was already broken, but this alters App Store Connect upload behavior for CLI users.
> 
> **Overview**
> **Store-state screenshot uploads** were POSTing to a non-existent path (`.../store_state_screenshot_upload` as one segment). The client now uses the generated builder for `.../store_state/screenshot_upload`, matching the backend route.
> 
> `docs/specs/cli-coverage.yaml` now **lists** that POST endpoint and narrows the store-state comment (only the dynamic plan action route stays omitted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e23796ba24500214bc3e3c4b625dcece1a6bc93d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->