### PR TITLE
Send custom HTTP headers on every request via RC_HEADERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,18 @@ without raw API calls.
 | `--no-color` | Disable ANSI color (also respects `$NO_COLOR`) |
 | `--format <expr>` | jq expression applied to `--json` output |
 
+## Custom request headers
+
+`RC_HEADERS` sends extra HTTP headers on every RevenueCat request (v2 API, Rico,
+and the Paywall AI editor) — newline-separated `Name: Value` pairs. Use it to
+route or tag traffic without baking anything into the binary:
+
+```bash
+RC_HEADERS=$'X-Some-Header: value' rc offerings list
+```
+
+One header per line; supplied headers override the CLI's defaults.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/revenuecat/cli/internal/httpx"
 )
 
 const DefaultBaseURL = "https://api.revenuecat.com/v2"
@@ -29,6 +31,10 @@ type Options struct {
 	BaseURL    string
 	HTTPClient *http.Client
 	UserAgent  string
+	// ExtraHeaders are sent on every request, overriding the defaults. Sourced
+	// from RC_HEADERS so operators can route or tag requests without the header
+	// name living in the binary.
+	ExtraHeaders http.Header
 }
 
 type cacheEntry struct {
@@ -37,11 +43,12 @@ type cacheEntry struct {
 }
 
 type Client struct {
-	baseURL   *url.URL
-	apiKey    string
-	http      *http.Client
-	userAgent string
-	cache     sync.Map // url string → cacheEntry; GET-only, session-scoped
+	baseURL      *url.URL
+	apiKey       string
+	http         *http.Client
+	userAgent    string
+	extraHeaders http.Header
+	cache        sync.Map // url string → cacheEntry; GET-only, session-scoped
 
 	Projects        *ProjectsService
 	Customers       *CustomersService
@@ -83,7 +90,7 @@ func NewClient(opts Options) *Client {
 	if ua == "" {
 		ua = "revenuecat-cli/dev"
 	}
-	c := &Client{baseURL: u, apiKey: opts.APIKey, http: hc, userAgent: ua}
+	c := &Client{baseURL: u, apiKey: opts.APIKey, http: hc, userAgent: ua, extraHeaders: opts.ExtraHeaders}
 	c.Projects = &ProjectsService{c: c}
 	c.Customers = &CustomersService{c: c}
 	c.Entitlements = &EntitlementsService{c: c}
@@ -130,6 +137,7 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any) err
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	httpx.Apply(req, c.extraHeaders)
 
 	// ETag cache: send If-None-Match on repeat GETs.
 	if method == http.MethodGet {
@@ -237,6 +245,7 @@ func (c *Client) Raw(ctx context.Context, method, path string, body []byte) ([]b
 	if len(body) > 0 {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	httpx.Apply(req, c.extraHeaders)
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, 0, err

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -27,13 +27,10 @@ import (
 const DefaultBaseURL = "https://api.revenuecat.com/v2"
 
 type Options struct {
-	APIKey     string
-	BaseURL    string
-	HTTPClient *http.Client
-	UserAgent  string
-	// ExtraHeaders are sent on every request, overriding the defaults. Sourced
-	// from RC_HEADERS so operators can route or tag requests without the header
-	// name living in the binary.
+	APIKey       string
+	BaseURL      string
+	HTTPClient   *http.Client
+	UserAgent    string
 	ExtraHeaders http.Header
 }
 

--- a/internal/api/headers_test.go
+++ b/internal/api/headers_test.go
@@ -12,7 +12,7 @@ import (
 func TestExtraHeadersSentOnEveryRequest(t *testing.T) {
 	var got string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		got = r.Header.Get("X-RC-Route")
+		got = r.Header.Get("X-Example-Header")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{}`))
 	}))
@@ -21,13 +21,13 @@ func TestExtraHeadersSentOnEveryRequest(t *testing.T) {
 	c := api.NewClient(api.Options{
 		APIKey:       "sk_test",
 		BaseURL:      srv.URL,
-		ExtraHeaders: http.Header{"X-Rc-Route": []string{"canary-1"}},
+		ExtraHeaders: http.Header{"X-Example-Header": []string{"example-value"}},
 	})
 
 	if _, _, err := c.Raw(context.Background(), http.MethodGet, "/anything", nil); err != nil {
 		t.Fatal(err)
 	}
-	if got != "canary-1" {
-		t.Errorf("Raw: X-RC-Route = %q, want canary-1", got)
+	if got != "example-value" {
+		t.Errorf("Raw: X-Example-Header = %q, want example-value", got)
 	}
 }

--- a/internal/api/headers_test.go
+++ b/internal/api/headers_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/revenuecat/cli/internal/api"
 )
 
-// ExtraHeaders (sourced from RC_HEADERS) must ride on every request, including
-// the Raw passthrough used by `rc api`.
 func TestExtraHeadersSentOnEveryRequest(t *testing.T) {
 	var got string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/headers_test.go
+++ b/internal/api/headers_test.go
@@ -1,0 +1,35 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+// ExtraHeaders (sourced from RC_HEADERS) must ride on every request, including
+// the Raw passthrough used by `rc api`.
+func TestExtraHeadersSentOnEveryRequest(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("X-RC-Route")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := api.NewClient(api.Options{
+		APIKey:       "sk_test",
+		BaseURL:      srv.URL,
+		ExtraHeaders: http.Header{"X-Rc-Route": []string{"canary-1"}},
+	})
+
+	if _, _, err := c.Raw(context.Background(), http.MethodGet, "/anything", nil); err != nil {
+		t.Fatal(err)
+	}
+	if got != "canary-1" {
+		t.Errorf("Raw: X-RC-Route = %q, want canary-1", got)
+	}
+}

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -755,9 +755,10 @@ func paywallAIClient(rt *Runtime, baseURL string) (*paywallai.Client, error) {
 		return nil, err
 	}
 	return paywallai.NewClient(paywallai.Options{
-		BaseURL:   baseURL,
-		Token:     agentAuthToken(rt),
-		UserAgent: userAgent(rt.Globals.Version),
+		BaseURL:      baseURL,
+		Token:        agentAuthToken(rt),
+		UserAgent:    userAgent(rt.Globals.Version),
+		ExtraHeaders: customHeaders(),
 	}), nil
 }
 

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -664,9 +664,10 @@ func ricoClient(rt *Runtime, baseURL string) (*rico.Client, error) {
 		return nil, err
 	}
 	return rico.NewClient(rico.Options{
-		BaseURL:   baseURL,
-		Token:     agentAuthToken(rt),
-		UserAgent: userAgent(rt.Globals.Version),
+		BaseURL:      baseURL,
+		Token:        agentAuthToken(rt),
+		UserAgent:    userAgent(rt.Globals.Version),
+		ExtraHeaders: customHeaders(),
 	}), nil
 }
 

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -90,9 +90,6 @@ func (r *Runtime) API() (*api.Client, error) {
 	return r.client, nil
 }
 
-// customHeaders reads RC_HEADERS (newline-separated "Name: Value" pairs) into
-// headers sent on every RevenueCat request. Lets an operator route or tag
-// traffic without the header name being compiled into the binary.
 func customHeaders() http.Header {
 	return httpx.ParseHeaders(os.Getenv("RC_HEADERS"))
 }

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"runtime"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/revenuecat/cli/internal/api"
 	"github.com/revenuecat/cli/internal/config"
+	"github.com/revenuecat/cli/internal/httpx"
 	"github.com/revenuecat/cli/internal/output"
 )
 
@@ -80,11 +82,19 @@ func (r *Runtime) API() (*api.Client, error) {
 		}
 	}
 	r.client = api.NewClient(api.Options{
-		APIKey:    r.Config.BearerToken(), // works for both API keys and OAuth tokens
-		BaseURL:   r.Config.BaseURL,
-		UserAgent: userAgent(r.Globals.Version),
+		APIKey:       r.Config.BearerToken(), // works for both API keys and OAuth tokens
+		BaseURL:      r.Config.BaseURL,
+		UserAgent:    userAgent(r.Globals.Version),
+		ExtraHeaders: customHeaders(),
 	})
 	return r.client, nil
+}
+
+// customHeaders reads RC_HEADERS (newline-separated "Name: Value" pairs) into
+// headers sent on every RevenueCat request. Lets an operator route or tag
+// traffic without the header name being compiled into the binary.
+func customHeaders() http.Header {
+	return httpx.ParseHeaders(os.Getenv("RC_HEADERS"))
 }
 
 // silentRefresh attempts to refresh the OAuth token without surfacing errors —

--- a/internal/httpx/headers.go
+++ b/internal/httpx/headers.go
@@ -6,12 +6,8 @@ import (
 	"strings"
 )
 
-// ParseHeaders reads newline-separated "Name: Value" pairs — e.g. from the
-// RC_HEADERS env var — into an http.Header. Blank lines and lines without a
-// colon are skipped; names and values are trimmed. Later duplicates win.
-//
-// This lets an operator send arbitrary headers on every request without the
-// header name being baked into the binary (RC_HEADERS=$'X-Some-Header: value').
+// ParseHeaders parses newline-separated "Name: Value" pairs into an http.Header,
+// skipping blank or colon-less lines. Returns nil when none are found.
 func ParseHeaders(s string) http.Header {
 	h := http.Header{}
 	for _, line := range strings.Split(s, "\n") {
@@ -28,9 +24,7 @@ func ParseHeaders(s string) http.Header {
 	return h
 }
 
-// Apply sets every header in h onto req, overriding any existing value. Callers
-// invoke it after setting the standard headers so operator-supplied headers take
-// precedence.
+// Apply sets each header from h on req, overriding existing values.
 func Apply(req *http.Request, h http.Header) {
 	for name, values := range h {
 		for i, v := range values {

--- a/internal/httpx/headers.go
+++ b/internal/httpx/headers.go
@@ -1,0 +1,44 @@
+// Package httpx holds small HTTP helpers shared across the CLI's API clients.
+package httpx
+
+import (
+	"net/http"
+	"strings"
+)
+
+// ParseHeaders reads newline-separated "Name: Value" pairs — e.g. from the
+// RC_HEADERS env var — into an http.Header. Blank lines and lines without a
+// colon are skipped; names and values are trimmed. Later duplicates win.
+//
+// This lets an operator send arbitrary headers on every request without the
+// header name being baked into the binary (RC_HEADERS=$'X-Some-Header: value').
+func ParseHeaders(s string) http.Header {
+	h := http.Header{}
+	for _, line := range strings.Split(s, "\n") {
+		name, value, ok := strings.Cut(line, ":")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" {
+			continue
+		}
+		h.Set(name, strings.TrimSpace(value))
+	}
+	if len(h) == 0 {
+		return nil
+	}
+	return h
+}
+
+// Apply sets every header in h onto req, overriding any existing value. Callers
+// invoke it after setting the standard headers so operator-supplied headers take
+// precedence.
+func Apply(req *http.Request, h http.Header) {
+	for name, values := range h {
+		for i, v := range values {
+			if i == 0 {
+				req.Header.Set(name, v)
+			} else {
+				req.Header.Add(name, v)
+			}
+		}
+	}
+}

--- a/internal/httpx/headers_test.go
+++ b/internal/httpx/headers_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestParseHeaders(t *testing.T) {
-	got := httpx.ParseHeaders("X-RC-Route: canary-1\n  X-Trace : abc \n\nnot-a-header\nX-Empty:")
-	if v := got.Get("X-Rc-Route"); v != "canary-1" {
-		t.Errorf("X-RC-Route = %q, want canary-1", v)
+	got := httpx.ParseHeaders("X-Example-Header: example-value\n  X-Trace : abc \n\nnot-a-header\nX-Empty:")
+	if v := got.Get("X-Example-Header"); v != "example-value" {
+		t.Errorf("X-Example-Header = %q, want example-value", v)
 	}
 	if v := got.Get("X-Trace"); v != "abc" {
 		t.Errorf("X-Trace = %q, want abc (trimmed)", v)
@@ -33,24 +33,24 @@ func TestParseHeadersEmptyIsNil(t *testing.T) {
 }
 
 func TestApplyOverridesAndSendsOnRequest(t *testing.T) {
-	var gotRoute, gotAuth string
+	var gotHeader, gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotRoute = r.Header.Get("X-RC-Route")
+		gotHeader = r.Header.Get("X-Example-Header")
 		gotAuth = r.Header.Get("Authorization")
 	}))
 	t.Cleanup(srv.Close)
 
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	req.Header.Set("Authorization", "Bearer default")
-	httpx.Apply(req, httpx.ParseHeaders("X-RC-Route: canary-1\nAuthorization: Bearer override"))
+	httpx.Apply(req, httpx.ParseHeaders("X-Example-Header: example-value\nAuthorization: Bearer override"))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
 	resp.Body.Close()
 
-	if gotRoute != "canary-1" {
-		t.Errorf("X-RC-Route = %q, want canary-1", gotRoute)
+	if gotHeader != "example-value" {
+		t.Errorf("X-Example-Header = %q, want example-value", gotHeader)
 	}
 	if gotAuth != "Bearer override" {
 		t.Errorf("Authorization = %q, want the applied header to override the default", gotAuth)

--- a/internal/httpx/headers_test.go
+++ b/internal/httpx/headers_test.go
@@ -1,0 +1,67 @@
+package httpx_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/httpx"
+)
+
+func TestParseHeaders(t *testing.T) {
+	got := httpx.ParseHeaders("X-RC-Route: canary-1\n  X-Trace : abc \n\nnot-a-header\nX-Empty:")
+	if v := got.Get("X-Rc-Route"); v != "canary-1" {
+		t.Errorf("X-RC-Route = %q, want canary-1", v)
+	}
+	if v := got.Get("X-Trace"); v != "abc" {
+		t.Errorf("X-Trace = %q, want abc (trimmed)", v)
+	}
+	if _, ok := got["Not-A-Header"]; ok {
+		t.Error("line without a colon must be skipped")
+	}
+	if v, ok := got["X-Empty"]; !ok || v[0] != "" {
+		t.Errorf("empty value should still set the header, got %v", got["X-Empty"])
+	}
+}
+
+func TestParseHeadersEmptyIsNil(t *testing.T) {
+	for _, in := range []string{"", "   ", "\n\n", "no colons here"} {
+		if h := httpx.ParseHeaders(in); h != nil {
+			t.Errorf("ParseHeaders(%q) = %v, want nil", in, h)
+		}
+	}
+}
+
+func TestApplyOverridesAndSendsOnRequest(t *testing.T) {
+	var gotRoute, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRoute = r.Header.Get("X-RC-Route")
+		gotAuth = r.Header.Get("Authorization")
+	}))
+	t.Cleanup(srv.Close)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer default")
+	httpx.Apply(req, httpx.ParseHeaders("X-RC-Route: canary-1\nAuthorization: Bearer override"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if gotRoute != "canary-1" {
+		t.Errorf("X-RC-Route = %q, want canary-1", gotRoute)
+	}
+	if gotAuth != "Bearer override" {
+		t.Errorf("Authorization = %q, want the applied header to override the default", gotAuth)
+	}
+}
+
+func TestApplyNilIsNoop(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.Header.Set("Authorization", "Bearer keep")
+	httpx.Apply(req, nil)
+	if req.Header.Get("Authorization") != "Bearer keep" {
+		t.Error("Apply(nil) must not disturb existing headers")
+	}
+}

--- a/internal/paywallai/paywallai.go
+++ b/internal/paywallai/paywallai.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/revenuecat/cli/internal/httpx"
 	"github.com/revenuecat/cli/internal/sse"
 )
 
@@ -103,11 +104,12 @@ func (e *Event) Terminal() bool {
 }
 
 type Client struct {
-	baseURL   string
-	token     string
-	userAgent string
-	rest      *http.Client
-	stream    *http.Client
+	baseURL      string
+	token        string
+	userAgent    string
+	extraHeaders http.Header
+	rest         *http.Client
+	stream       *http.Client
 }
 
 type Options struct {
@@ -116,6 +118,8 @@ type Options struct {
 	UserAgent string
 	// HTTPClient overrides both REST and streaming transports (tests).
 	HTTPClient *http.Client
+	// ExtraHeaders are sent on every request (from RC_HEADERS).
+	ExtraHeaders http.Header
 }
 
 func NewClient(opts Options) *Client {
@@ -132,11 +136,12 @@ func NewClient(opts Options) *Client {
 		stream = &http.Client{} // editor runs stream for minutes; ctx cancels
 	}
 	return &Client{
-		baseURL:   baseURL,
-		token:     opts.Token,
-		userAgent: opts.UserAgent,
-		rest:      rest,
-		stream:    stream,
+		baseURL:      baseURL,
+		token:        opts.Token,
+		userAgent:    opts.UserAgent,
+		extraHeaders: opts.ExtraHeaders,
+		rest:         rest,
+		stream:       stream,
 	}
 }
 
@@ -167,6 +172,7 @@ func (c *Client) newRequest(ctx context.Context, path string, body any) (*http.R
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
 	}
+	httpx.Apply(req, c.extraHeaders)
 	return req, nil
 }
 

--- a/internal/paywallai/paywallai.go
+++ b/internal/paywallai/paywallai.go
@@ -117,8 +117,7 @@ type Options struct {
 	Token     string
 	UserAgent string
 	// HTTPClient overrides both REST and streaming transports (tests).
-	HTTPClient *http.Client
-	// ExtraHeaders are sent on every request (from RC_HEADERS).
+	HTTPClient   *http.Client
 	ExtraHeaders http.Header
 }
 

--- a/internal/rico/client.go
+++ b/internal/rico/client.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/revenuecat/cli/internal/httpx"
 	"github.com/revenuecat/cli/internal/sse"
 )
 
@@ -24,11 +25,12 @@ const DefaultBaseURL = "https://rico.revenuecat.com"
 const conversationAlphabet = "6789BCDFGHJKLMNPQRTWbcdfghjkmnpqrtwz"
 
 type Client struct {
-	baseURL   string
-	token     string
-	userAgent string
-	rest      *http.Client
-	stream    *http.Client
+	baseURL      string
+	token        string
+	userAgent    string
+	extraHeaders http.Header
+	rest         *http.Client
+	stream       *http.Client
 }
 
 type Options struct {
@@ -37,6 +39,8 @@ type Options struct {
 	UserAgent string
 	// HTTPClient overrides both REST and streaming transports (tests).
 	HTTPClient *http.Client
+	// ExtraHeaders are sent on every request (from RC_HEADERS).
+	ExtraHeaders http.Header
 }
 
 func NewClient(opts Options) *Client {
@@ -55,11 +59,12 @@ func NewClient(opts Options) *Client {
 		stream = &http.Client{}
 	}
 	return &Client{
-		baseURL:   baseURL,
-		token:     opts.Token,
-		userAgent: opts.UserAgent,
-		rest:      rest,
-		stream:    stream,
+		baseURL:      baseURL,
+		token:        opts.Token,
+		userAgent:    opts.UserAgent,
+		extraHeaders: opts.ExtraHeaders,
+		rest:         rest,
+		stream:       stream,
 	}
 }
 
@@ -115,6 +120,7 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body any) 
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
 	}
+	httpx.Apply(req, c.extraHeaders)
 	return req, nil
 }
 

--- a/internal/rico/client.go
+++ b/internal/rico/client.go
@@ -38,8 +38,7 @@ type Options struct {
 	Token     string
 	UserAgent string
 	// HTTPClient overrides both REST and streaming transports (tests).
-	HTTPClient *http.Client
-	// ExtraHeaders are sent on every request (from RC_HEADERS).
+	HTTPClient   *http.Client
 	ExtraHeaders http.Header
 }
 


### PR DESCRIPTION
`RC_HEADERS` sends arbitrary HTTP headers on every RevenueCat request — the v2 API, Rico, and the Paywall AI editor. Newline-separated `Name: Value` pairs:

```bash
RC_HEADERS=$'X-Some-Header: value' rc offerings list
```

The point: the header **name** lives in your env, not in the binary — so you can route or tag traffic without any named header hardcoded in a public repo.

Parsing is in `internal/httpx` (`ParseHeaders`/`Apply`); runtime reads the env once and threads it through each client's `Options`. Supplied headers override the CLI's defaults.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Custom headers override built-in ones (e.g. Authorization), so misconfigured RC_HEADERS could break auth or send unintended credentials; scope is all HTTP traffic from the CLI when the env is set.
> 
> **Overview**
> Adds **`RC_HEADERS`** so newline-separated `Name: Value` pairs are attached to every outbound call from the v2 API client, Rico, and the Paywall AI editor—useful for routing or tagging traffic without hardcoding header names in the binary.
> 
> A new **`internal/httpx`** package parses the env string (`ParseHeaders`) and applies headers on each request (`Apply`), with **applied headers overriding** defaults (including `Authorization` when set). Runtime wires **`customHeaders()`** from `RC_HEADERS` into `api.Options` and the Rico/Paywall AI client factories. README documents usage and behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7235cd7d302bc1b49c21c2aadefa51f5d524df47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->