### PR TITLE
paywalls: interactive generate/edit picker on npx launches

### DIFF
--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -96,7 +96,7 @@ names; there's no list endpoint.
 # Onboarding entry points (the two scoped npx surfaces)
 rc setup                                                 # PUNTED: one-shot agent-driven bootstrap; hidden until DX-tested
 rc capital setup                                         # RevenueCat Capital = App Store Connect key flow (wraps apps apple setup)
-rc                                                       # bare rc in a TTY -> guided setup; --help elsewhere; --all reveals every command
+rc                                                       # bare rc -> getting-started help; --all reveals every command
 
 # Auth / meta
 rc auth login                                            # browser OAuth or API key; offers MCP-token import on npx runs; rc login is a hidden alias
@@ -206,6 +206,7 @@ rc products store apply <plan-id>                        # apply that same revie
 rc products store discard <plan-id>                      # discard without applying; requires confirmation/--yes
 
 # Paywalls
+rc paywalls                                              # help; under npx a TTY shows a generate/edit picker (npm launcher sets RC_GUIDED — paywalls-only for now)
 rc paywalls list
 rc paywalls show <id>
 rc paywalls generate [--offering-id <id>] --prompt "..." # create a paywall; standalone unless --offering-id attaches it to an offering

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/revenuecat/cli/internal/api"
 	"github.com/revenuecat/cli/internal/output"
+	"github.com/revenuecat/cli/internal/tui"
 )
 
 func newPaywallsCmd() *cobra.Command {
@@ -17,6 +18,29 @@ func newPaywallsCmd() *cobra.Command {
 		Use:     "paywalls",
 		Aliases: []string{"paywall"},
 		Short:   "Create and inspect paywalls",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rt := RuntimeFrom(cmd.Context())
+			if !guidedMode() || rt.Globals.NoInput || !tui.IsInteractive() {
+				return cmd.Help()
+			}
+			if err := ensureAuthInteractive(cmd); err != nil {
+				return err
+			}
+			action, err := decide(rt, "What would you like to do?", nil, []Choice[string]{
+				{Value: "generate", Label: "Generate a paywall with AI", Flag: "rc paywalls generate"},
+				{Value: "edit", Label: "Edit an existing paywall with AI", Flag: "rc paywalls edit"},
+			})
+			if err != nil {
+				return err
+			}
+			for _, sub := range cmd.Commands() {
+				if sub.Name() == action {
+					sub.SetContext(cmd.Context())
+					return sub.RunE(sub, nil)
+				}
+			}
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(
 		newPaywallsListCmd(),
@@ -29,6 +53,21 @@ func newPaywallsCmd() *cobra.Command {
 		newPaywallsDeleteCmd(),
 	)
 	return cmd
+}
+
+// ensureAuthInteractive runs the login flow when no credential is stored yet.
+func ensureAuthInteractive(cmd *cobra.Command) error {
+	rt := RuntimeFrom(cmd.Context())
+	if rt.Config.BearerToken() != "" {
+		return nil
+	}
+	rt.Out.Hint("You're not logged in yet — let's do that first.")
+	login, _, err := cmd.Root().Find([]string{"auth", "login"})
+	if err != nil || login == nil {
+		return ErrNotAuthenticated
+	}
+	login.SetContext(cmd.Context())
+	return login.RunE(login, nil)
 }
 
 func newPaywallsListCmd() *cobra.Command {

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -20,7 +20,7 @@ func newPaywallsCmd() *cobra.Command {
 		Short:   "Create and inspect paywalls",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
-			if !guidedMode() || rt.Globals.NoInput || !tui.IsInteractive() {
+			if !guidedMode() || rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
 				return cmd.Help()
 			}
 			if err := ensureAuthInteractive(cmd); err != nil {

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -35,6 +35,8 @@ func newPaywallsCmd() *cobra.Command {
 			}
 			for _, sub := range cmd.Commands() {
 				if sub.Name() == action {
+					// Calls RunE directly (no cobra arg parsing); generate and
+					// edit both support no-arg interactive entry.
 					sub.SetContext(cmd.Context())
 					return sub.RunE(sub, nil)
 				}

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -35,8 +35,6 @@ func newPaywallsCmd() *cobra.Command {
 			}
 			for _, sub := range cmd.Commands() {
 				if sub.Name() == action {
-					// Calls RunE directly (no cobra arg parsing); generate and
-					// edit both support no-arg interactive entry.
 					sub.SetContext(cmd.Context())
 					return sub.RunE(sub, nil)
 				}

--- a/internal/cli/paywalls_test.go
+++ b/internal/cli/paywalls_test.go
@@ -5,17 +5,21 @@ import (
 	"testing"
 )
 
-// Bare `rc paywalls` under --no-input must keep printing help (scriptable),
-// never drop into the picker — even with guided mode (npx) on.
-func TestPaywalls_NoInputShowsHelp(t *testing.T) {
-	t.Setenv("RC_GUIDED", "1")
-	stdout, _, err := runCmd(t, "paywalls", "--no-input")
-	if err != nil {
-		t.Fatalf("err = %v", err)
-	}
-	for _, want := range []string{"Available Commands", "generate", "edit"} {
-		if !strings.Contains(stdout, want) {
-			t.Fatalf("expected help to contain %q, got:\n%s", want, stdout)
-		}
+// Bare `rc paywalls` must keep printing help (scriptable) under --no-input or
+// --json, never dropping into the picker — even with guided mode (npx) on.
+func TestPaywalls_NonInteractiveShowsHelp(t *testing.T) {
+	for _, flag := range []string{"--no-input", "--json"} {
+		t.Run(flag, func(t *testing.T) {
+			t.Setenv("RC_GUIDED", "1")
+			stdout, _, err := runCmd(t, "paywalls", flag)
+			if err != nil {
+				t.Fatalf("err = %v", err)
+			}
+			for _, want := range []string{"Available Commands", "generate", "edit"} {
+				if !strings.Contains(stdout, want) {
+					t.Fatalf("expected help to contain %q, got:\n%s", want, stdout)
+				}
+			}
+		})
 	}
 }

--- a/internal/cli/paywalls_test.go
+++ b/internal/cli/paywalls_test.go
@@ -1,0 +1,21 @@
+package cli_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// Bare `rc paywalls` under --no-input must keep printing help (scriptable),
+// never drop into the picker — even with guided mode (npx) on.
+func TestPaywalls_NoInputShowsHelp(t *testing.T) {
+	t.Setenv("RC_GUIDED", "1")
+	stdout, _, err := runCmd(t, "paywalls", "--no-input")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	for _, want := range []string{"Available Commands", "generate", "edit"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected help to contain %q, got:\n%s", want, stdout)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -205,9 +205,7 @@ func suggestFlag(cmd *cobra.Command, err error) error {
 	return fmt.Errorf("%s (did you mean --%s?)", msg, best)
 }
 
-// guidedMode reports whether to prefer interactive prompts over terse help. The
-// npm launcher sets RC_GUIDED for npx (ephemeral) runs; an installed rc leaves
-// it unset.
+// guidedMode is set by the npm launcher for npx runs (RC_GUIDED).
 func guidedMode() bool {
 	return os.Getenv("RC_GUIDED") != ""
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -201,4 +203,11 @@ func suggestFlag(cmd *cobra.Command, err error) error {
 		return err
 	}
 	return fmt.Errorf("%s (did you mean --%s?)", msg, best)
+}
+
+// guidedMode reports whether to prefer interactive prompts over terse help. The
+// npm launcher sets RC_GUIDED for npx (ephemeral) runs; an installed rc leaves
+// it unset.
+func guidedMode() bool {
+	return os.Getenv("RC_GUIDED") != ""
 }

--- a/npm/cli/bin/rc.js
+++ b/npm/cli/bin/rc.js
@@ -6,9 +6,7 @@
 const { execFileSync } = require("child_process");
 const path = require("path");
 
-// npx runs the package from npm's ephemeral `_npx` cache rather than a real
-// install. That user typically wants a one-off, guided experience, so signal
-// the binary to prefer interactive prompts over terse help.
+// True when launched via npx (npm's ephemeral `_npx` cache), not a real install.
 function runViaNpx() {
   return __dirname.includes(`${path.sep}_npx${path.sep}`) || process.env.npm_command === "exec";
 }

--- a/npm/cli/bin/rc.js
+++ b/npm/cli/bin/rc.js
@@ -4,6 +4,14 @@
 // and hands over execution. No JavaScript runs beyond this dispatch.
 "use strict";
 const { execFileSync } = require("child_process");
+const path = require("path");
+
+// npx runs the package from npm's ephemeral `_npx` cache rather than a real
+// install. That user typically wants a one-off, guided experience, so signal
+// the binary to prefer interactive prompts over terse help.
+function runViaNpx() {
+  return __dirname.includes(`${path.sep}_npx${path.sep}`) || process.env.npm_command === "exec";
+}
 
 function binaryPath() {
   const key = `${process.platform}-${process.arch}`;
@@ -25,8 +33,9 @@ function binaryPath() {
   }
 }
 
+const env = runViaNpx() ? { ...process.env, RC_GUIDED: "1" } : process.env;
 try {
-  execFileSync(binaryPath(), process.argv.slice(2), { stdio: "inherit" });
+  execFileSync(binaryPath(), process.argv.slice(2), { stdio: "inherit", env });
 } catch (err) {
   if (typeof err.status === "number") process.exit(err.status);
   throw err;


### PR DESCRIPTION
Bare `rc paywalls` stays consistent with every other namespace: it prints help. But **npx runs get an interactive Generate / Edit picker** instead — that user isn't set up for the CLI, and choosing `generate` vs `edit` upfront (two near-identical commands) is a poor first experience. The picker routes into the chosen flow and logs in first if there's no credential yet.

How it tells them apart: the npm launcher (`bin/rc.js`) detects an npx run (it executes from npm's ephemeral `_npx` cache) and sets `RC_GUIDED=1`. An installed `rc` — brew, `npm i -g`, build-from-source — leaves it unset.

So:
- `npx @revenuecat/cli paywalls` → Generate/Edit picker (guided)
- `rc paywalls` (installed) → help, like `customers`, `products`, etc.
- `--no-input` / piped / non-TTY → help, always (scripts + agents unchanged)

This ships in the real release, not just the bug-bash build. Reuses the existing `decide` picker helper; test locks that guided mode never overrides `--no-input`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX change to paywalls entry and npm launcher env; scriptable paths explicitly preserved and covered by a test.
> 
> **Overview**
> **npx** users running bare `rc paywalls` in an interactive TTY now get a **Generate / Edit** picker instead of static help, routing into `generate` or `edit` and prompting login via `ensureAuthInteractive` when no credential is stored.
> 
> The npm launcher sets **`RC_GUIDED=1`** when the binary runs from npm’s `_npx` cache or `npm exec`; **`guidedMode()`** in the CLI gates the picker. Installed `rc`, **`--no-input`**, **`--json`**, and non-interactive sessions still print help—unchanged for scripts and agents.
> 
> Docs update the command tree and bare `rc` getting-started note; a test locks guided mode behind **`--no-input`** and **`--json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e8f11ea9e5716c5f9dfa3a567d5423e2c78fa18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->