### PR TITLE
add rc media-assets list command

### DIFF
--- a/docs/specs/cli-coverage.yaml
+++ b/docs/specs/cli-coverage.yaml
@@ -160,6 +160,12 @@ endpoints:
   - method: DELETE
     path: /projects/{project_id}/paywalls/{paywall_id}
 
+  # Media assets
+  - method: GET
+    path: /projects/{project_id}/media_assets
+  - method: POST
+    path: /projects/{project_id}/media_assets
+
   # Webhooks
   - method: GET
     path: /projects/{project_id}/integrations/webhooks

--- a/internal/api/media_assets.go
+++ b/internal/api/media_assets.go
@@ -3,12 +3,44 @@ package api
 import (
 	"context"
 	"net/http"
+	"net/url"
+	"strconv"
 )
 
 type MediaAssetsService struct{ c *Client }
 
+type ListMediaAssetsOptions struct {
+	Limit         int
+	StartingAfter string
+}
+
+func (o *ListMediaAssetsOptions) query() string {
+	if o == nil {
+		return ""
+	}
+	v := url.Values{}
+	if o.Limit > 0 {
+		v.Set("limit", strconv.Itoa(o.Limit))
+	}
+	if o.StartingAfter != "" {
+		v.Set("starting_after", o.StartingAfter)
+	}
+	if len(v) == 0 {
+		return ""
+	}
+	return "?" + v.Encode()
+}
+
+func (s *MediaAssetsService) List(ctx context.Context, projectID string, opts *ListMediaAssetsOptions) (*Page[MediaAsset], error) {
+	var out Page[MediaAsset]
+	if err := s.c.do(ctx, http.MethodGet, pathMediaAssets(projectID)+opts.query(), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 func (s *MediaAssetsService) Create(ctx context.Context, projectID string, body CreateMediaAssetJSONBody) (*MediaAsset, error) {
 	var out MediaAsset
-	err := s.c.do(ctx, http.MethodPost, encodePath("projects", projectID, "media_assets"), body, &out)
+	err := s.c.do(ctx, http.MethodPost, pathMediaAssets(projectID), body, &out)
 	return &out, err
 }

--- a/internal/api/media_assets_test.go
+++ b/internal/api/media_assets_test.go
@@ -11,6 +11,36 @@ import (
 	"github.com/revenuecat/cli/internal/api"
 )
 
+func TestMediaAssetsList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/projects/proj/media_assets" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if q := r.URL.Query(); q.Get("limit") != "5" || q.Get("starting_after") != "medas_prev" {
+			t.Fatalf("unexpected query: %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","items":[{"id":"medas_abc","object_name":"media/proj/hero.png","original_name":"hero.png","original_width":1024,"original_height":768,"asset_base_url":"https://assets.example.com","asset_type":"image"}],"next_page":"/v2/projects/proj/media_assets?starting_after=medas_abc","url":"/v2/projects/proj/media_assets"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := api.NewClient(api.Options{APIKey: "sk_test", BaseURL: srv.URL})
+	page, err := client.MediaAssets.List(context.Background(), "proj", &api.ListMediaAssetsOptions{Limit: 5, StartingAfter: "medas_prev"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(page.Items))
+	}
+	a := page.Items[0]
+	if a.ID != "medas_abc" || a.OriginalName != "hero.png" || a.OriginalWidth == nil || *a.OriginalWidth != 1024 {
+		t.Fatalf("unexpected asset: %+v", a)
+	}
+	if page.NextPage == "" {
+		t.Fatal("next_page not decoded")
+	}
+}
+
 func TestMediaAssetsCreate(t *testing.T) {
 	raw := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a}
 	body := api.CreateMediaAssetJSONBody{

--- a/internal/api/paths_gen.go
+++ b/internal/api/paths_gen.go
@@ -130,6 +130,10 @@ func pathIntegrationsWebhooks(projectID string) string {
 	return encodePath("projects", projectID, "integrations", "webhooks")
 }
 
+func pathMediaAssets(projectID string) string {
+	return encodePath("projects", projectID, "media_assets")
+}
+
 func pathMetricsOverview(projectID string) string {
 	return encodePath("projects", projectID, "metrics", "overview")
 }

--- a/internal/cli/media_assets.go
+++ b/internal/cli/media_assets.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/revenuecat/cli/internal/api"
+	"github.com/revenuecat/cli/internal/output"
 )
 
 var mediaAssetContentTypes = map[string]string{
@@ -54,7 +55,63 @@ func newMediaAssetsCmd() *cobra.Command {
 		Use:   "media-assets",
 		Short: "Manage project media assets",
 	}
-	cmd.AddCommand(newMediaAssetsUploadCmd())
+	cmd.AddCommand(newMediaAssetsUploadCmd(), newMediaAssetsListCmd())
+	return cmd
+}
+
+func newMediaAssetsListCmd() *cobra.Command {
+	var limit int
+	var cursor string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List media assets in the project Media Gallery",
+		Example: `  rc media-assets list
+  rc media-assets list --json | jq '.data.items[].id'`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rt := RuntimeFrom(cmd.Context())
+			projectID, err := requireProject(rt)
+			if err != nil {
+				return err
+			}
+			client, err := rt.API()
+			if err != nil {
+				return err
+			}
+			page, err := client.MediaAssets.List(cmd.Context(), projectID, &api.ListMediaAssetsOptions{
+				Limit:         limit,
+				StartingAfter: cursor,
+			})
+			if err != nil {
+				return err
+			}
+
+			rows := make([][]string, 0, len(page.Items))
+			for _, a := range page.Items {
+				dimensions := ""
+				if a.OriginalWidth != nil && a.OriginalHeight != nil {
+					dimensions = fmt.Sprintf("%dx%d", *a.OriginalWidth, *a.OriginalHeight)
+				}
+				reference := a.ObjectName
+				if a.AssetBaseURL != nil {
+					reference = *a.AssetBaseURL + "/" + a.ObjectName
+				}
+				rows = append(rows, []string{a.ID, a.OriginalName, dimensions, string(a.AssetType), reference})
+			}
+			if err := rt.Out.RenderTable(output.Table{
+				Columns: []string{"ID", "NAME", "DIMENSIONS", "TYPE", "REFERENCE"},
+				Rows:    rows,
+				Raw:     page,
+			}); err != nil {
+				return err
+			}
+			if page.NextPage != "" && !rt.Globals.JSON && len(page.Items) > 0 {
+				rt.Out.Info(fmt.Sprintf("more results — pass --cursor %s for the next page", page.Items[len(page.Items)-1].ID))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 0, "max results per page (server default if unset)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "media asset ID to start after (pagination)")
 	return cmd
 }
 

--- a/internal/cli/media_assets_test.go
+++ b/internal/cli/media_assets_test.go
@@ -61,6 +61,52 @@ func TestMediaAssetsUpload(t *testing.T) {
 	}
 }
 
+func runMediaAssetsList(t *testing.T, extra ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	var out, errb bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	args := []string{"media-assets", "list", "--no-input", "--api-key", "sk_test", "--project-id", "proj"}
+	root.SetArgs(append(args, extra...))
+	err = root.ExecuteContext(context.Background())
+	return out.String(), errb.String(), err
+}
+
+func TestMediaAssetsList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/projects/proj/media_assets" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"object":"list","items":[{"id":"medas_abc","object_name":"media/proj/hero.png","original_name":"hero.png","original_width":1024,"original_height":768,"asset_base_url":"https://assets.example.com","asset_type":"image"}],"next_page":"/v2/projects/proj/media_assets?starting_after=medas_abc","url":"/v2/projects/proj/media_assets"}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("RC_BASE_URL", srv.URL)
+
+	stdout, stderr, err := runMediaAssetsList(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"medas_abc", "hero.png", "1024x768", "https://assets.example.com/media/proj/hero.png"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q: %s", want, stdout)
+		}
+	}
+	if !strings.Contains(stderr, "--cursor medas_abc") {
+		t.Fatalf("stderr missing pagination hint: %s", stderr)
+	}
+
+	stdout, _, err = runMediaAssetsList(t, "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, `"next_page"`) {
+		t.Fatalf("json output missing envelope: %s", stdout)
+	}
+}
+
 func TestMediaAssetsUpload_ValidationErrors(t *testing.T) {
 	cases := []struct {
 		name, file string


### PR DESCRIPTION
Adds `rc media-assets list` to fetch and display media assets from the project Media Gallery, with `--limit` and `--cursor` flags for pagination.

```
> ./rc-local media-assets list --help
List media assets in the project Media Gallery

Usage:
  rc media-assets list [flags]

Examples:
  rc media-assets list
  rc media-assets list --json | jq '.data.items[].id'

Flags:
      --cursor string   media asset ID to start after (pagination)
  -h, --help            help for list
      --limit int       max results per page (server default if unset)

Global Flags:
      --all                 also show experimental commands in --help
      --api-key string      RevenueCat API key (overrides profile; or set RC_API_KEY)
      --format string       jq expression applied to --json output (e.g. '.data.items[].id')
      --json                emit machine-readable JSON output
      --no-color            disable ANSI color (also honors NO_COLOR)
      --no-input            disable interactive prompts; fail if input is required
      --profile string      configuration profile to use (default: active profile)
      --project-id string   RevenueCat project ID (overrides profile; or set RC_PROJECT_ID)
  -q, --quiet               suppress non-essential output
  -y, --yes                 assume yes for confirmation prompts

> ./rc-local media-assets list --limit 2 --json
{
  "data": {
    "items": [
      {
        "alt_text": null,
        "asset_base_url": "https://assets.pawwalls.com",
        "asset_type": "image",
        "formats": {
          "heic": {
            "height": 1024,
            "object": "media_asset_format",
            "object_name": "1395867_1785409846_2543564b.heic",
            "size": 351,
            "width": 1024
          },
          "heic_low_res": {
            "height": 600,
            "object": "media_asset_format",
            "object_name": "1395867_low_res_1785409846_2543564b.heic",
            "size": 148,
            "width": 600
          },
          "webp": {
            "height": 1024,
            "object": "media_asset_format",
            "object_name": "1395867_1785409846_2543564b.webp",
            "size": 97,
            "width": 1024
          },
          "webp_low_res": {
            "height": 600,
            "object": "media_asset_format",
            "object_name": "1395867_low_res_1785409846_2543564b.webp",
            "size": 44,
            "width": 600
          }
        },
        "id": "mediaasset0324cbf4bfe046dca78264b1abd4b29d",
        "is_decorative": false,
        "object": "media_asset",
        "object_name": "1395867_1785409846_2543564b.webp",
        "original_height": 1024,
        "original_name": "ecdac6570ba34ca38e40090af53fa200.webp",
        "original_size": 97,
        "original_width": 1024,
        "transcoding_status": null,
        "video_metadata": null
      },
      {
        "alt_text": null,
        "asset_base_url": "https://assets.pawwalls.com",
        "asset_type": "image",
        "formats": {
          "heic": {
            "height": 1024,
            "object": "media_asset_format",
            "object_name": "1395867_1785246595_25217939.heic",
            "size": 598,
            "width": 1024
          },
          "heic_low_res": {
            "height": 600,
            "object": "media_asset_format",
            "object_name": "1395867_low_res_1785246595_25217939.heic",
            "size": 235,
            "width": 600
          },
          "webp": {
            "height": 1024,
            "object": "media_asset_format",
            "object_name": "1395867_1785246595_25217939.webp",
            "size": 224,
            "width": 1024
          },
          "webp_low_res": {
            "height": 600,
            "object": "media_asset_format",
            "object_name": "1395867_low_res_1785246595_25217939.webp",
            "size": 88,
            "width": 600
          }
        },
        "id": "mediaasset16d6b8e7c4ec4bd88095d2a71085b432",
        "is_decorative": false,
        "object": "media_asset",
        "object_name": "1395867_1785246595_25217939.webp",
        "original_height": 1024,
        "original_name": "c641a826034f40dd9325a0434a5e1542.webp",
        "original_size": 224,
        "original_width": 1024,
        "transcoding_status": null,
        "video_metadata": null
      }
    ],
    "next_page": "https://api.revenuecat.com/v2/projects/proj275ac756/media_assets?starting_after=mediaasset16d6b8e7c4ec4bd88095d2a71085b432\u0026limit=2",
    "object": "list",
    "url": "https://api.revenuecat.com/v2/projects/proj275ac756/media_assets"
  },
  "schema_version": 1
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only listing with no auth or data mutation; implementation mirrors existing paginated list APIs and CLI patterns.
> 
> **Overview**
> Adds **`rc media-assets list`** so the Media Gallery can be browsed from the CLI, with **`--limit`** and **`--cursor`** pagination matching other list commands.
> 
> The API client gains **`MediaAssets.List`** (paginated `Page[MediaAsset]`) and **`pathMediaAssets`**; **`Create`** now uses that path helper. Table output shows ID, name, dimensions, type, and a full asset reference URL when `asset_base_url` is present; interactive mode prints a **`--cursor`** hint when `next_page` is set. **`docs/specs/cli-coverage.yaml`** records the GET media assets endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a1480087dcff414a4092ef4950fe688bee8b5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->