### PR TITLE
add rc fonts list command

### DIFF
--- a/docs/specs/cli-coverage.yaml
+++ b/docs/specs/cli-coverage.yaml
@@ -166,6 +166,12 @@ endpoints:
   - method: POST
     path: /projects/{project_id}/media_assets
 
+  # Fonts
+  - method: GET
+    path: /projects/{project_id}/fonts
+  - method: POST
+    path: /projects/{project_id}/fonts
+
   # Webhooks
   - method: GET
     path: /projects/{project_id}/integrations/webhooks

--- a/internal/api/fonts.go
+++ b/internal/api/fonts.go
@@ -3,9 +3,33 @@ package api
 import (
 	"context"
 	"net/http"
+	"net/url"
+	"strconv"
 )
 
 type FontsService struct{ c *Client }
+
+type ListFontsOptions struct {
+	Limit         int
+	StartingAfter string
+}
+
+func (o *ListFontsOptions) query() string {
+	if o == nil {
+		return ""
+	}
+	v := url.Values{}
+	if o.Limit > 0 {
+		v.Set("limit", strconv.Itoa(o.Limit))
+	}
+	if o.StartingAfter != "" {
+		v.Set("starting_after", o.StartingAfter)
+	}
+	if len(v) == 0 {
+		return ""
+	}
+	return "?" + v.Encode()
+}
 
 type FontCreate struct {
 	Filename       string `json:"filename"`
@@ -22,6 +46,14 @@ type Font struct {
 	URL        string `json:"url"`
 	FontKey    string `json:"font_key"`
 	Object     string `json:"object,omitempty"`
+}
+
+func (s *FontsService) List(ctx context.Context, projectID string, opts *ListFontsOptions) (*Page[Font], error) {
+	var out Page[Font]
+	if err := s.c.do(ctx, http.MethodGet, encodePath("projects", projectID, "fonts")+opts.query(), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
 }
 
 func (s *FontsService) Create(ctx context.Context, projectID string, body FontCreate) (*Font, error) {

--- a/internal/cli/fonts.go
+++ b/internal/cli/fonts.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/revenuecat/cli/internal/api"
+	"github.com/revenuecat/cli/internal/output"
 )
 
 var fontContentTypes = map[string]string{
@@ -49,7 +51,55 @@ func newFontsCmd() *cobra.Command {
 		Use:   "fonts",
 		Short: "Manage project fonts",
 	}
-	cmd.AddCommand(newFontsUploadCmd())
+	cmd.AddCommand(newFontsUploadCmd(), newFontsListCmd())
+	return cmd
+}
+
+func newFontsListCmd() *cobra.Command {
+	var limit int
+	var cursor string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List fonts uploaded to the project",
+		Example: `  rc fonts list
+  rc fonts list --json | jq '.data.items[].font_key'`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rt := RuntimeFrom(cmd.Context())
+			projectID, err := requireProject(rt)
+			if err != nil {
+				return err
+			}
+			client, err := rt.API()
+			if err != nil {
+				return err
+			}
+			page, err := client.Fonts.List(cmd.Context(), projectID, &api.ListFontsOptions{
+				Limit:         limit,
+				StartingAfter: cursor,
+			})
+			if err != nil {
+				return err
+			}
+
+			rows := make([][]string, 0, len(page.Items))
+			for _, f := range page.Items {
+				rows = append(rows, []string{f.ID, f.Name, f.FamilyName, f.Style, strconv.Itoa(f.Weight), f.FontKey})
+			}
+			if err := rt.Out.RenderTable(output.Table{
+				Columns: []string{"ID", "NAME", "FAMILY", "STYLE", "WEIGHT", "FONT KEY"},
+				Rows:    rows,
+				Raw:     page,
+			}); err != nil {
+				return err
+			}
+			if page.NextPage != "" && !rt.Globals.JSON && len(page.Items) > 0 {
+				rt.Out.Info(fmt.Sprintf("more results — pass --cursor %s for the next page", page.Items[len(page.Items)-1].ID))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 0, "max results per page (server default if unset)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "font ID to start after (pagination)")
 	return cmd
 }
 
@@ -77,6 +127,10 @@ func newFontsUploadCmd() *cobra.Command {
 			}
 			font, err := client.Fonts.Create(cmd.Context(), projectID, body)
 			if err != nil {
+				var apiErr *api.APIError
+				if errors.As(err, &apiErr) && apiErr.Status == 409 {
+					rt.Out.Hint("This font style is already uploaded — run `rc fonts list` to find it and reference it by its font key")
+				}
 				return err
 			}
 			rt.Out.Success(fmt.Sprintf("Uploaded %s (%s, %s %d)", font.ID, font.Name, font.Style, font.Weight))

--- a/internal/cli/fonts_test.go
+++ b/internal/cli/fonts_test.go
@@ -50,6 +50,71 @@ func TestFontsUpload(t *testing.T) {
 	}
 }
 
+func TestFontsUpload_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, `{"type":"resource_already_exists","message":"A font with this style already exists for this project"}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("RC_BASE_URL", srv.URL)
+	path := writeTempImage(t, "inter-bold.ttf", []byte{0x00, 0x01, 0x00, 0x00})
+
+	_, stderr, err := runFontsUpload(t, path)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr, "rc fonts list") {
+		t.Fatalf("stderr missing fonts list hint: %s", stderr)
+	}
+}
+
+func runFontsList(t *testing.T, extra ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	var out, errb bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	args := []string{"fonts", "list", "--no-input", "--api-key", "sk_test", "--project-id", "proj"}
+	root.SetArgs(append(args, extra...))
+	err = root.ExecuteContext(context.Background())
+	return out.String(), errb.String(), err
+}
+
+func TestFontsList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/projects/proj/fonts" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"object":"list","items":[{"object":"font","id":"font_abc","name":"Inter Bold","family_name":"Inter","style":"bold","weight":700,"url":"https://assets.example.com/fonts/inter-bold.ttf","font_key":"RCFM:abc123"}],"next_page":"/v2/projects/proj/fonts?starting_after=font_abc","url":"/v2/projects/proj/fonts"}`)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("RC_BASE_URL", srv.URL)
+
+	stdout, stderr, err := runFontsList(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"font_abc", "Inter Bold", "Inter", "bold", "700", "RCFM:abc123"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q: %s", want, stdout)
+		}
+	}
+	if !strings.Contains(stderr, "--cursor font_abc") {
+		t.Fatalf("stderr missing pagination hint: %s", stderr)
+	}
+
+	stdout, _, err = runFontsList(t, "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, `"next_page"`) {
+		t.Fatalf("json output missing envelope: %s", stdout)
+	}
+}
+
 func TestFontsUpload_ValidationErrors(t *testing.T) {
 	cases := []struct {
 		name, file string

--- a/scripts/gen-paths.py
+++ b/scripts/gen-paths.py
@@ -25,7 +25,7 @@ INITIALISMS = {"id": "ID", "url": "URL", "api": "API", "urls": "URLs"}
 # is generated. Remove an entry once the endpoint lands in the spec (or overlay).
 NON_SPEC_PATHS = {
     "/projects/{project_id}/invoices/{invoice_id}",  # rc invoices get — not in public v2 spec
-    "/projects/{project_id}/fonts",  # rc fonts — public in khepri, not yet in published spec
+    "/projects/{project_id}/fonts",  # rc fonts — live in the backend, not yet in published spec
 }
 
 

--- a/scripts/gen-paths.py
+++ b/scripts/gen-paths.py
@@ -25,6 +25,7 @@ INITIALISMS = {"id": "ID", "url": "URL", "api": "API", "urls": "URLs"}
 # is generated. Remove an entry once the endpoint lands in the spec (or overlay).
 NON_SPEC_PATHS = {
     "/projects/{project_id}/invoices/{invoice_id}",  # rc invoices get — not in public v2 spec
+    "/projects/{project_id}/fonts",  # rc fonts — public in khepri, not yet in published spec
 }
 
 


### PR DESCRIPTION
Adds `rc fonts list` to list fonts uploaded to a project, with `--limit` and `--cursor` pagination flags, and a 409 hint on `rc fonts upload` pointing users to `rc fonts list`.

```
> ./rc-local fonts li
st
✓ Project                    proj275ac756
ID                                    NAME                   FAMILY          STYLE   WEIGHT  FONT KEY
font2ae5b8c0b28e46b0a6685fc58982359f  Montserrat-Regular     Montserrat      normal  400     RCFM:1395867_font2ae5b8c0b28e46b0a6685fc58982359f:Montserrat-Regular
font3df994a91d084e85a24cebbc75dddac0  MarseilleFree-Regular  Marseille Free  normal  400     RCFM:1395867_font3df994a91d084e85a24cebbc75dddac0:MarseilleFree-Regular


> ./rc-local fonts list --json

{
  "data": {
    "items": [
      {
        "id": "font2ae5b8c0b28e46b0a6685fc58982359f",
        "name": "Montserrat-Regular",
        "family_name": "Montserrat",
        "style": "normal",
        "weight": 400,
        "url": "https://fonts.pawwalls.com/1349454_faddc0c8_d6a88ae07b3c64fe2b3f.ttf",
        "font_key": "RCFM:1395867_font2ae5b8c0b28e46b0a6685fc58982359f:Montserrat-Regular",
        "object": "font"
      },
      {
        "id": "font3df994a91d084e85a24cebbc75dddac0",
        "name": "MarseilleFree-Regular",
        "family_name": "Marseille Free",
        "style": "normal",
        "weight": 400,
        "url": "https://fonts.pawwalls.com/1395867_ba675186_4a11be1a96a4faa76f05.ttf",
        "font_key": "RCFM:1395867_font3df994a91d084e85a24cebbc75dddac0:MarseilleFree-Regular",
        "object": "font"
      }
    ],
    "object": "list",
    "url": "https://api.revenuecat.com/v2/projects/proj275ac756/fonts"
  },
  "schema_version": 1
}
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI and API list support following established pagination patterns; no changes to auth or critical business paths.
> 
> **Overview**
> Adds **`rc fonts list`** so users can see uploaded project fonts (ID, name, family, style, weight, font key) in a table or via **`--json`**, with **`--limit`** and **`--cursor`** pagination and a hint when more pages exist.
> 
> The API client gains **`Fonts.List`** with the same pagination query pattern as other list endpoints. CLI coverage documents GET/POST fonts; **`gen-paths.py`** treats the fonts route as **non-spec** until it appears in the published OpenAPI spec.
> 
> **`rc fonts upload`** now shows a hint on **409** conflicts to run **`rc fonts list`** and use the existing font key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead466c65047182a24677b7215824d23ffe6d01d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->