### PR TITLE
paywalls: make picker labels distinguishable

### DIFF
--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -155,13 +155,28 @@ func paywallPickerItems(ctx context.Context, client *api.Client, projectID strin
 	}
 	items := make([]PickerItem, len(page.Items))
 	for i, paywall := range page.Items {
-		label := paywall.Name
-		if label == "" {
-			label = paywall.ID
-		}
-		items[i] = PickerItem{ID: paywall.ID, Label: label}
+		items[i] = PickerItem{ID: paywall.ID, Label: paywallPickerLabel(paywall)}
 	}
 	return items, nil
+}
+
+// paywallPickerLabel folds offering, date, and publish state into the label:
+// paywall names are usually the default "Untitled Paywall", so the name alone
+// can't tell rows apart.
+func paywallPickerLabel(p api.Paywall) string {
+	name := p.Name
+	if name == "" {
+		name = p.ID
+	}
+	offering := "standalone"
+	if p.OfferingID != "" {
+		offering = p.OfferingID
+	}
+	status := "draft"
+	if p.PublishedAt != nil {
+		status = "published"
+	}
+	return fmt.Sprintf("%s · %s · %s · %s", name, offering, formatMillis(int64(p.CreatedAt)), status)
 }
 
 func formatPublishedAt(publishedAt *api.Millis) string {

--- a/internal/cli/paywalls_picker_test.go
+++ b/internal/cli/paywalls_picker_test.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+func TestPaywallPickerLabel(t *testing.T) {
+	const created = 1700000000000
+	pub := api.Millis(created)
+
+	named := paywallPickerLabel(api.Paywall{ID: "pw1", Name: "Hero", OfferingID: "ofrng_x", CreatedAt: created})
+	for _, want := range []string{"Hero", "ofrng_x", "draft"} {
+		if !strings.Contains(named, want) {
+			t.Fatalf("named label %q missing %q", named, want)
+		}
+	}
+
+	unnamed := paywallPickerLabel(api.Paywall{ID: "pw2", CreatedAt: created, PublishedAt: &pub})
+	for _, want := range []string{"pw2", "standalone", "published"} {
+		if !strings.Contains(unnamed, want) {
+			t.Fatalf("unnamed label %q missing %q", unnamed, want)
+		}
+	}
+
+	if named == unnamed {
+		t.Fatal("distinct paywalls must produce distinct labels")
+	}
+}


### PR DESCRIPTION
Paywall pickers (`rc paywalls edit/show/publish/delete`, and the new npx generate/edit flow) showed a pile of identical **"Untitled Paywall"** rows — paywall names are usually the server default, or empty (in which case it fell back to the raw ID). You couldn't tell them apart.

Now each row folds in the fields the API already returns, so they're distinguishable:

```
Hero Paywall · ofrng_default · 2026-08-05 · draft
Untitled Paywall · standalone · 2026-08-03 · published
```

I checked the other resource pickers — offerings/packages/entitlements key off lookup keys, webhooks off URL, products/apps off display name + type, Rico off conversation summary — so they already distinguish. This is a paywall-only issue, so it's a one-function change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only display logic for paywall pickers; no API, auth, or customer-facing runtime changes.
> 
> **Overview**
> Paywall interactive pickers (edit, show, publish, delete, etc.) now show **richer row labels** instead of repeating **Untitled Paywall** or a bare ID.
> 
> A new `paywallPickerLabel` helper builds each label from name (or ID fallback), offering ID (or `standalone`), formatted `CreatedAt`, and draft vs published state—matching how the list table already surfaces those fields.
> 
> `paywallPickerItems` delegates label construction to that helper. `TestPaywallPickerLabel` covers named vs unnamed paywalls and asserts distinct paywalls get distinct labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0ce60aa1f0164ede0156ac3a68ff499189e03c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->