### PR TITLE
paywalls: survive a dropped editor stream

### DIFF
--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -761,7 +761,6 @@ func TestPaywallsGenerate_MidStreamDropCheckpoints(t *testing.T) {
 		t.Fatalf("want mid-stream drop error, got %v", err)
 	}
 
-	// The snapshot was checkpointed to disk, so the work is recoverable.
 	payload, rerr := os.ReadFile(sessionPath)
 	if rerr != nil {
 		t.Fatalf("session not checkpointed: %v", rerr)

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -725,3 +725,56 @@ func TestPaywallsEdit_RequiresSessionOrID(t *testing.T) {
 		t.Fatalf("err = %v", err)
 	}
 }
+
+func TestPaywallsGenerate_MidStreamDropCheckpoints(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/paywalls"):
+			io.WriteString(w, `{"id":"pw_new","offering_id":"ofrng_default","created_at":1720000000000,"published_at":null}`)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/paywalls/pw_new"):
+			io.WriteString(w, paywallResponseJSON(`"ofrng_default"`, 3))
+		default:
+			t.Errorf("unexpected API request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(apiServer.Close)
+
+	// Editor streams one snapshot, then closes without run.completed (a drop).
+	paywallAIServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "data: {\"type\":\"run.started\",\"session_id\":\"sess1\"}\n\n")
+		io.WriteString(w, "data: {\"type\":\"turn.snapshot\",\"session_id\":\"sess1\",\"paywall\":{\"default_locale\":\"en_US\",\"offering_id\":null,\"components_config\":{\"stack\":true},\"components_localizations\":{\"en_US\":{}}},\"activity\":[{\"id\":\"a1\",\"type\":\"tool\",\"tool_name\":\"edit_components\",\"status\":\"success\",\"display\":{\"text\":\"Built hero\"}}],\"__unstable_session_items\":[{\"k\":1}]}\n\n")
+	}))
+	t.Cleanup(paywallAIServer.Close)
+
+	t.Setenv("RC_BASE_URL", apiServer.URL)
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", paywallAIServer.URL)
+
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	_, _, err := runAgentCmd(t,
+		"paywalls", "generate", "--offering-id", "ofrng_default", "--name", "Drop test",
+		"--prompt", "a paywall", "--session", sessionPath, "--project-id", "proj1",
+		"--no-input", "--api-key", "sk_test",
+	)
+	if err == nil || !strings.Contains(err.Error(), "stream ended before the run finished") {
+		t.Fatalf("want mid-stream drop error, got %v", err)
+	}
+
+	// The snapshot was checkpointed to disk, so the work is recoverable.
+	payload, rerr := os.ReadFile(sessionPath)
+	if rerr != nil {
+		t.Fatalf("session not checkpointed: %v", rerr)
+	}
+	var session map[string]any
+	if err := json.Unmarshal(payload, &session); err != nil {
+		t.Fatal(err)
+	}
+	if session["paywall_id"] != "pw_new" {
+		t.Fatalf("session paywall_id = %v", session["paywall_id"])
+	}
+	items, ok := session["__unstable_session_items"].([]any)
+	if !ok || len(items) == 0 || items[0].(map[string]any)["k"] != 1.0 {
+		t.Fatalf("snapshot not checkpointed: %v", session["__unstable_session_items"])
+	}
+}

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -492,7 +492,6 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 			session.SessionID = event.SessionID
 		case paywallai.EventTurnSnapshot:
 			reportedActivity = reportPaywallAIActivity(rt, event.Activity, reportedActivity)
-			// checkpoint so a dropped stream can be resumed
 			applySessionEvent(session, event)
 			if err := savePaywallAISession(opts.sessionPath, session); err == nil {
 				checkpointed = true
@@ -506,8 +505,6 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 	}
 }
 
-// applySessionEvent folds an editor event's paywall/session state into the
-// session. The editor may echo offering_id as null, so the CLI's is kept.
 func applySessionEvent(session *paywallAISession, event *paywallai.Event) {
 	if event.SessionID != "" {
 		session.SessionID = event.SessionID
@@ -516,6 +513,7 @@ func applySessionEvent(session *paywallAISession, event *paywallai.Event) {
 		session.TraceID = event.TraceID
 	}
 	if event.Paywall != nil {
+		// the editor echoes offering_id as null; keep the CLI's
 		offeringID := session.Paywall.OfferingID
 		session.Paywall = *event.Paywall
 		if session.Paywall.OfferingID == nil {
@@ -530,8 +528,6 @@ func applySessionEvent(session *paywallAISession, event *paywallai.Event) {
 	}
 }
 
-// streamDropError turns a mid-stream failure into an actionable message,
-// pointing at the checkpointed session when one was saved.
 func streamDropError(opts paywallAIOptions, checkpointed bool, err error) error {
 	base := fmt.Errorf("the Paywall AI editor stream ended before the run finished: %w", err)
 	if checkpointed {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -482,19 +481,22 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 	defer stream.Close()
 
 	reportedActivity := 0
+	checkpointed := false
 	for {
 		event, err := stream.Next()
-		if err == io.EOF {
-			return fmt.Errorf("the Paywalls AI Editor closed the stream without completing the run")
-		}
 		if err != nil {
-			return err
+			return streamDropError(opts, checkpointed, err)
 		}
 		switch event.Type {
 		case paywallai.EventRunStarted:
 			session.SessionID = event.SessionID
 		case paywallai.EventTurnSnapshot:
 			reportedActivity = reportPaywallAIActivity(rt, event.Activity, reportedActivity)
+			// checkpoint so a dropped stream can be resumed
+			applySessionEvent(session, event)
+			if err := savePaywallAISession(opts.sessionPath, session); err == nil {
+				checkpointed = true
+			}
 		case paywallai.EventRunFailed:
 			return fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message)
 		case paywallai.EventRunCompleted:
@@ -504,12 +506,16 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 	}
 }
 
-func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, session *paywallAISession, event *paywallai.Event) error {
-	session.SessionID = event.SessionID
-	session.TraceID = event.TraceID
+// applySessionEvent folds an editor event's paywall/session state into the
+// session. The editor may echo offering_id as null, so the CLI's is kept.
+func applySessionEvent(session *paywallAISession, event *paywallai.Event) {
+	if event.SessionID != "" {
+		session.SessionID = event.SessionID
+	}
+	if event.TraceID != "" {
+		session.TraceID = event.TraceID
+	}
 	if event.Paywall != nil {
-		// The AI editor doesn't manage offering attachment and may echo
-		// offering_id as null — keep what the CLI established.
 		offeringID := session.Paywall.OfferingID
 		session.Paywall = *event.Paywall
 		if session.Paywall.OfferingID == nil {
@@ -522,6 +528,20 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 	if len(event.AppContext) > 0 {
 		session.AppContext = event.AppContext
 	}
+}
+
+// streamDropError turns a mid-stream failure into an actionable message,
+// pointing at the checkpointed session when one was saved.
+func streamDropError(opts paywallAIOptions, checkpointed bool, err error) error {
+	base := fmt.Errorf("the Paywall AI editor stream ended before the run finished: %w", err)
+	if checkpointed {
+		return WithHint(base, "Progress so far is saved — continue with: rc paywalls edit --session "+opts.sessionPath)
+	}
+	return WithHint(base, "Nothing was saved yet — re-run the command to try again.")
+}
+
+func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, session *paywallAISession, event *paywallai.Event) error {
+	applySessionEvent(session, event)
 	if err := savePaywallAISession(opts.sessionPath, session); err != nil {
 		return err
 	}

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -97,15 +97,16 @@ const minimalComponentsConfig = `{
 const minimalUIConfig = `{"fonts": {}, "presets": {"saved_colors": []}}`
 
 type paywallAIOptions struct {
-	context     string
-	attachments []string
-	prompt      string
-	offeringID  string
-	name        string
-	sessionPath string
-	images      []string
-	baseURL     string
-	timeout     time.Duration
+	context      string
+	attachments  []string
+	prompt       string
+	offeringID   string
+	name         string
+	sessionPath  string
+	images       []string
+	baseURL      string
+	timeout      time.Duration
+	createdDraft bool
 }
 
 func newPaywallsGenerateCmd() *cobra.Command {
@@ -210,6 +211,11 @@ run rc paywalls publish.`,
 				if err != nil {
 					return err
 				}
+			}
+			opts.createdDraft = true
+			// save up front so a drop before the first checkpoint still leaves a resumable session
+			if err := savePaywallAISession(opts.sessionPath, session); err != nil {
+				return err
 			}
 			return runPaywallAI(cmd.Context(), rt, opts, session)
 		},
@@ -529,9 +535,12 @@ func applySessionEvent(session *paywallAISession, event *paywallai.Event) {
 
 func paywallRecoveryHint(opts paywallAIOptions, checkpointed bool) string {
 	if checkpointed {
-		return "Progress so far is saved — continue with: rc paywalls edit --session " + opts.sessionPath
+		return "Progress so far is saved. Continue with: rc paywalls edit --session " + opts.sessionPath
 	}
-	return "Nothing was saved yet — re-run the command to try again."
+	if opts.createdDraft {
+		return "The draft was created. Continue editing it with: rc paywalls edit --session " + opts.sessionPath
+	}
+	return "Nothing was saved yet. Re-run the command to try again."
 }
 
 func streamDropError(opts paywallAIOptions, checkpointed bool, err error) error {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -509,9 +509,8 @@ func applySessionEvent(session *paywallAISession, event *paywallai.Event) {
 	if event.SessionID != "" {
 		session.SessionID = event.SessionID
 	}
-	if event.TraceID != "" {
-		session.TraceID = event.TraceID
-	}
+	// snapshot omits TraceID; clear a prior run's stale trace rather than keep it
+	session.TraceID = event.TraceID
 	if event.Paywall != nil {
 		// the editor echoes offering_id as null; keep the CLI's
 		offeringID := session.Paywall.OfferingID

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -497,7 +497,7 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 				checkpointed = true
 			}
 		case paywallai.EventRunFailed:
-			return fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message)
+			return WithHint(fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message), paywallRecoveryHint(opts, checkpointed))
 		case paywallai.EventRunCompleted:
 			reportPaywallAIActivity(rt, event.Activity, reportedActivity)
 			return finishPaywallAI(ctx, rt, opts, session, event)
@@ -528,12 +528,15 @@ func applySessionEvent(session *paywallAISession, event *paywallai.Event) {
 	}
 }
 
-func streamDropError(opts paywallAIOptions, checkpointed bool, err error) error {
-	base := fmt.Errorf("the Paywall AI editor stream ended before the run finished: %w", err)
+func paywallRecoveryHint(opts paywallAIOptions, checkpointed bool) string {
 	if checkpointed {
-		return WithHint(base, "Progress so far is saved — continue with: rc paywalls edit --session "+opts.sessionPath)
+		return "Progress so far is saved — continue with: rc paywalls edit --session " + opts.sessionPath
 	}
-	return WithHint(base, "Nothing was saved yet — re-run the command to try again.")
+	return "Nothing was saved yet — re-run the command to try again."
+}
+
+func streamDropError(opts paywallAIOptions, checkpointed bool, err error) error {
+	return WithHint(fmt.Errorf("the Paywall AI editor stream ended before the run finished: %w", err), paywallRecoveryHint(opts, checkpointed))
 }
 
 func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, session *paywallAISession, event *paywallai.Event) error {

--- a/internal/cli/paywalls_stream_test.go
+++ b/internal/cli/paywalls_stream_test.go
@@ -44,7 +44,13 @@ func TestStreamDropError(t *testing.T) {
 	}
 
 	none := streamDropError(paywallAIOptions{}, false, underlying)
-	if h := hintFor(none); !strings.Contains(h, "re-run") {
+	if h := hintFor(none); !strings.Contains(h, "Re-run") {
 		t.Fatalf("no-checkpoint hint = %q", h)
+	}
+
+	// generate created a draft before the drop: recover via edit, not re-run
+	created := streamDropError(paywallAIOptions{sessionPath: "/tmp/s.paywall.json", createdDraft: true}, false, underlying)
+	if h := hintFor(created); !strings.Contains(h, "edit --session /tmp/s.paywall.json") {
+		t.Fatalf("created-draft hint = %q", h)
 	}
 }

--- a/internal/cli/paywalls_stream_test.go
+++ b/internal/cli/paywalls_stream_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/paywallai"
+)
+
+func TestApplySessionEvent_PreservesOffering(t *testing.T) {
+	off := "ofrng_x"
+	session := &paywallAISession{}
+	session.Paywall.OfferingID = &off
+
+	applySessionEvent(session, &paywallai.Event{
+		SessionID:    "sess1",
+		TraceID:      "tr1",
+		Paywall:      &paywallai.PaywallData{DefaultLocale: "en_US"}, // OfferingID nil, as the editor echoes it
+		SessionItems: json.RawMessage(`[{"k":1}]`),
+	})
+
+	if session.SessionID != "sess1" || session.TraceID != "tr1" {
+		t.Fatalf("ids not applied: %+v", session)
+	}
+	if session.Paywall.OfferingID == nil || *session.Paywall.OfferingID != "ofrng_x" {
+		t.Fatalf("offering not preserved: %v", session.Paywall.OfferingID)
+	}
+	if string(session.SessionItems) != `[{"k":1}]` {
+		t.Fatalf("session items = %s", session.SessionItems)
+	}
+}
+
+func TestStreamDropError(t *testing.T) {
+	underlying := errors.New("stream ID 1; INTERNAL_ERROR; received from peer")
+
+	saved := streamDropError(paywallAIOptions{sessionPath: "/tmp/s.paywall.json"}, true, underlying)
+	if !errors.Is(saved, underlying) {
+		t.Fatalf("underlying error not wrapped: %v", saved)
+	}
+	if h := hintFor(saved); !strings.Contains(h, "edit --session /tmp/s.paywall.json") {
+		t.Fatalf("checkpointed hint = %q", h)
+	}
+
+	none := streamDropError(paywallAIOptions{}, false, underlying)
+	if h := hintFor(none); !strings.Contains(h, "re-run") {
+		t.Fatalf("no-checkpoint hint = %q", h)
+	}
+}


### PR DESCRIPTION
The Paywall AI editor's SSE stream can reset before the run finishes (backend-side — DX-883). Previously the design was only persisted on the terminal `run.completed` event, so a mid-stream drop lost **everything** and printed a raw `stream error: … INTERNAL_ERROR` string.

Now:
- **Checkpoint** the session on each `turn.snapshot`, so partial progress is saved and recoverable.
- On a mid-stream failure, return an **actionable** error — "Progress so far is saved — continue with: `rc paywalls edit --session <path>`" — instead of the raw http2 error (or "re-run" if nothing was saved yet).

Extracted `applySessionEvent` (shared by the checkpoint + the completed handler). Unit-tests cover offering-preservation on checkpoint and the drop-error hint. This is the CLI-side half of DX-882; the backend not resetting the stream is DX-883.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only affect paywall AI generate/edit streaming and session persistence; behavior on successful runs is largely the same aside from extra checkpoint writes, but failed streams now leave partial state that users must recover correctly.
> 
> **Overview**
> When the Paywalls AI editor SSE stream dies mid-run, the CLI no longer loses the whole turn. It **checkpoints** the session file on each `turn.snapshot`, saves an initial session right after `paywalls generate` creates a draft, and routes stream/`run.failed` errors through **`streamDropError`** with **`paywallRecoveryHint`** (continue via `rc paywalls edit --session …`, re-run, or edit the created draft).
> 
> Session updates from stream events are centralized in **`applySessionEvent`** (offering ID preserved when the editor echoes null; stale trace cleared on snapshots). Tests cover mid-stream drops, hint text, and offering preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b7f151e07fbb2879295a1bbb17b6f5e7402e21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->