### PR TITLE
cli: bare rc shows a getting-started screen

### DIFF
--- a/internal/cli/home.go
+++ b/internal/cli/home.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/revenuecat/cli/internal/output"
+)
+
+// writeHomeScreen renders the bare-`rc` landing screen. It reads only local
+// config — never the network — so bare `rc` stays instant, and tailors itself
+// to where the user is: setup steps when logged out, things to actually do
+// once authenticated.
+func writeHomeScreen(w io.Writer, rt *Runtime) {
+	paint := rt.Out.Paint
+	cmd := func(s string) string { return paint(output.ToneCommand, s) }
+	desc := func(s string) string { return paint(output.ToneDim, s) }
+	label := func(s string) string { return paint(output.ToneTitle, s) }
+
+	var b strings.Builder
+	b.WriteString(paint(output.ToneAccent, "▍ rc") + desc("  the RevenueCat CLI") + "\n\n")
+
+	more := "\n" + label("More:") + "\n" + homeActions(paint, [][2]string{
+		{"rc --help", "every command"},
+		{"rc <command> --help", "details for any command"},
+	})
+
+	authed := rt.Config.BearerToken() != ""
+	switch {
+	case !authed:
+		b.WriteString(label("New here? Two steps to get going:") + "\n")
+		b.WriteString("  " + cmd("1") + "  " + cmd("rc auth login") + "     " + desc("log in (browser or API key)") + "\n")
+		b.WriteString("  " + cmd("2") + "  " + cmd("rc projects use") + "   " + desc("pick a project") + "\n\n")
+		b.WriteString(label("Then try:") + "\n")
+		b.WriteString(homeActions(paint, exploreActions))
+
+	case rt.Config.ProjectID == "":
+		b.WriteString(paint(output.ToneSuccess, "✓ ") + loggedInAs(rt) + "\n\n")
+		b.WriteString(label("Next — pick a project so commands know where to run:") + "\n")
+		b.WriteString(homeActions(paint, [][2]string{{"rc projects use", "choose a default project"}}))
+		b.WriteString("\n" + label("Then:") + "\n")
+		b.WriteString(homeActions(paint, exploreActions))
+
+	default:
+		b.WriteString(paint(output.ToneSuccess, "✓ ") + loggedInAs(rt) +
+			desc(" · project "+rt.Config.ProjectID) + "\n\n")
+		b.WriteString(label("Do something:") + "\n")
+		b.WriteString(homeActions(paint, exploreActions))
+	}
+
+	b.WriteString(more)
+	fmt.Fprint(w, b.String())
+}
+
+var exploreActions = [][2]string{
+	{"rc paywalls", "design a paywall with AI"},
+	{"rc customer show <id>", "look up a customer"},
+	{"rc charts show mrr", "see your MRR"},
+}
+
+// loggedInAs is the identity line: cached email/name when known, otherwise a
+// plain confirmation (an API-key login carries no cached identity).
+func loggedInAs(rt *Runtime) string {
+	if id := rt.Config.AccountEmail; id != "" {
+		return "Logged in as " + id
+	}
+	if id := rt.Config.AccountName; id != "" {
+		return "Logged in as " + id
+	}
+	return "Logged in"
+}
+
+// homeActions renders command/description pairs as an aligned two-column
+// block: the command in the interaction accent, the description dimmed.
+func homeActions(paint func(output.Tone, string) string, rows [][2]string) string {
+	width := 0
+	for _, r := range rows {
+		if len(r[0]) > width {
+			width = len(r[0])
+		}
+	}
+	var b strings.Builder
+	for _, r := range rows {
+		pad := strings.Repeat(" ", width-len(r[0]))
+		b.WriteString("  " + paint(output.ToneCommand, r[0]) + pad + "  " + paint(output.ToneDim, r[1]) + "\n")
+	}
+	return b.String()
+}

--- a/internal/cli/home.go
+++ b/internal/cli/home.go
@@ -13,8 +13,7 @@ type homeGroup struct {
 	rows  [][2]string // {command, description}
 }
 
-// homeMap is the curated command catalog shown once authenticated — a
-// discoverable slice of the surface, not the full tree (that's `rc --help`).
+// homeMap is the curated command catalog shown once authenticated.
 var homeMap = []homeGroup{
 	{"Build", [][2]string{
 		{"rc offerings list", "offerings & their packages"},
@@ -33,10 +32,7 @@ var homeMap = []homeGroup{
 	}},
 }
 
-// writeHomeScreen renders the bare-`rc` landing screen. It reads only local
-// config — never the network — so bare `rc` stays instant, and tailors itself
-// to where the user is: setup steps when logged out, a project nudge and the
-// full command map once authenticated.
+// writeHomeScreen renders the bare-`rc` landing screen from local config only.
 func writeHomeScreen(w io.Writer, rt *Runtime) {
 	paint := rt.Out.Paint
 	label := func(s string) string { return paint(output.ToneTitle, s) }
@@ -58,8 +54,6 @@ func writeHomeScreen(w io.Writer, rt *Runtime) {
 			b.WriteString("\n")
 		}
 
-		// The hero: paywalls is the reason to reach for the CLI, so feature it
-		// on its own with both entry points rather than as one row in a group.
 		b.WriteString(paint(output.ToneAccent, "✨ Paywalls — design with AI") + "\n")
 		b.WriteString(homeRows(paint, [][2]string{
 			{"rc paywalls generate", "start from a prompt"},
@@ -89,8 +83,7 @@ func writeHomeScreen(w io.Writer, rt *Runtime) {
 	fmt.Fprint(w, b.String())
 }
 
-// homePanel is the boxed status header: identity, project, and a dashboard
-// deep-link when they're known.
+// homePanel is the boxed status header: identity, project, dashboard link.
 func homePanel(rt *Runtime) string {
 	paint := rt.Out.Paint
 	lines := []string{paint(output.ToneAccent, "rc · RevenueCat")}
@@ -123,10 +116,8 @@ func accountIdentity(rt *Runtime) string {
 	return rt.Config.AccountName
 }
 
-// homeRows renders command/description pairs as an aligned two-column block:
-// the command in the interaction accent (with <placeholders> dimmed so they
-// read as fill-ins), the description dimmed. Pass width to align the
-// description column across several blocks; 0 fits each block on its own.
+// homeRows renders command/description pairs as an aligned two-column block.
+// width aligns the description column across blocks; 0 fits each on its own.
 func homeRows(paint func(output.Tone, string) string, rows [][2]string, width int) string {
 	for _, r := range rows {
 		if len(r[0]) > width {

--- a/internal/cli/home.go
+++ b/internal/cli/home.go
@@ -17,9 +17,9 @@ type homeGroup struct {
 // discoverable slice of the surface, not the full tree (that's `rc --help`).
 var homeMap = []homeGroup{
 	{"Build", [][2]string{
-		{"rc paywalls", "design a paywall with AI ✨"},
 		{"rc offerings list", "offerings & their packages"},
 		{"rc products list", "products across your stores"},
+		{"rc entitlements list", "entitlements & their products"},
 	}},
 	{"Inspect", [][2]string{
 		{"rc customer show <id>", "a full customer view"},
@@ -57,6 +57,16 @@ func writeHomeScreen(w io.Writer, rt *Runtime) {
 			b.WriteString(homeRows(paint, [][2]string{{"rc projects use", "choose a default project"}}, 0))
 			b.WriteString("\n")
 		}
+
+		// The hero: paywalls is the reason to reach for the CLI, so feature it
+		// on its own with both entry points rather than as one row in a group.
+		b.WriteString(paint(output.ToneAccent, "✨ Paywalls — design with AI") + "\n")
+		b.WriteString(homeRows(paint, [][2]string{
+			{"rc paywalls generate", "start from a prompt"},
+			{"rc paywalls edit", "refine an existing paywall"},
+		}, 0))
+		b.WriteString("\n")
+
 		mapWidth := 0
 		for _, g := range homeMap {
 			for _, r := range g.rows {

--- a/internal/cli/home.go
+++ b/internal/cli/home.go
@@ -8,73 +8,116 @@ import (
 	"github.com/revenuecat/cli/internal/output"
 )
 
+type homeGroup struct {
+	title string
+	rows  [][2]string // {command, description}
+}
+
+// homeMap is the curated command catalog shown once authenticated — a
+// discoverable slice of the surface, not the full tree (that's `rc --help`).
+var homeMap = []homeGroup{
+	{"Build", [][2]string{
+		{"rc paywalls", "design a paywall with AI ✨"},
+		{"rc offerings list", "offerings & their packages"},
+		{"rc products list", "products across your stores"},
+	}},
+	{"Inspect", [][2]string{
+		{"rc customer show <id>", "a full customer view"},
+		{"rc charts show mrr", "MRR, actives, conversion"},
+		{"rc metrics", "project overview at a glance"},
+	}},
+	{"Automate & set up", [][2]string{
+		{"rc apps", "connect App Store & Google Play"},
+		{"rc skills install", "AI workflows for coding agents"},
+		{"rc rico chat", "ask RevenueCat's AI ✨"},
+	}},
+}
+
 // writeHomeScreen renders the bare-`rc` landing screen. It reads only local
 // config — never the network — so bare `rc` stays instant, and tailors itself
-// to where the user is: setup steps when logged out, things to actually do
-// once authenticated.
+// to where the user is: setup steps when logged out, a project nudge and the
+// full command map once authenticated.
 func writeHomeScreen(w io.Writer, rt *Runtime) {
 	paint := rt.Out.Paint
-	cmd := func(s string) string { return paint(output.ToneCommand, s) }
-	desc := func(s string) string { return paint(output.ToneDim, s) }
 	label := func(s string) string { return paint(output.ToneTitle, s) }
 
 	var b strings.Builder
-	b.WriteString(paint(output.ToneAccent, "▍ rc") + desc("  the RevenueCat CLI") + "\n\n")
-
-	more := "\n" + label("More:") + "\n" + homeActions(paint, [][2]string{
-		{"rc --help", "every command"},
-		{"rc <command> --help", "details for any command"},
-	})
+	b.WriteString(homePanel(rt) + "\n\n")
 
 	authed := rt.Config.BearerToken() != ""
 	switch {
 	case !authed:
 		b.WriteString(label("New here? Two steps to get going:") + "\n")
-		b.WriteString("  " + cmd("1") + "  " + cmd("rc auth login") + "     " + desc("log in (browser or API key)") + "\n")
-		b.WriteString("  " + cmd("2") + "  " + cmd("rc projects use") + "   " + desc("pick a project") + "\n\n")
-		b.WriteString(label("Then try:") + "\n")
-		b.WriteString(homeActions(paint, exploreActions))
-
-	case rt.Config.ProjectID == "":
-		b.WriteString(paint(output.ToneSuccess, "✓ ") + loggedInAs(rt) + "\n\n")
-		b.WriteString(label("Next — pick a project so commands know where to run:") + "\n")
-		b.WriteString(homeActions(paint, [][2]string{{"rc projects use", "choose a default project"}}))
-		b.WriteString("\n" + label("Then:") + "\n")
-		b.WriteString(homeActions(paint, exploreActions))
+		b.WriteString("  " + paint(output.ToneCommand, "1  rc auth login") + "     " + paint(output.ToneDim, "log in (browser or API key)") + "\n")
+		b.WriteString("  " + paint(output.ToneCommand, "2  rc projects use") + "   " + paint(output.ToneDim, "pick a project") + "\n")
 
 	default:
-		b.WriteString(paint(output.ToneSuccess, "✓ ") + loggedInAs(rt) +
-			desc(" · project "+rt.Config.ProjectID) + "\n\n")
-		b.WriteString(label("Do something:") + "\n")
-		b.WriteString(homeActions(paint, exploreActions))
+		if rt.Config.ProjectID == "" {
+			b.WriteString(label("Pick a project so commands know where to run:") + "\n")
+			b.WriteString(homeRows(paint, [][2]string{{"rc projects use", "choose a default project"}}, 0))
+			b.WriteString("\n")
+		}
+		mapWidth := 0
+		for _, g := range homeMap {
+			for _, r := range g.rows {
+				if len(r[0]) > mapWidth {
+					mapWidth = len(r[0])
+				}
+			}
+		}
+		for i, g := range homeMap {
+			if i > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(label(g.title) + "\n")
+			b.WriteString(homeRows(paint, g.rows, mapWidth))
+		}
 	}
 
-	b.WriteString(more)
+	b.WriteString("\n" + paint(output.ToneDim, "rc --help") + " for everything · " +
+		paint(output.ToneDim, "rc <command> --help") + " for details\n")
 	fmt.Fprint(w, b.String())
 }
 
-var exploreActions = [][2]string{
-	{"rc paywalls", "design a paywall with AI"},
-	{"rc customer show <id>", "look up a customer"},
-	{"rc charts show mrr", "see your MRR"},
+// homePanel is the boxed status header: identity, project, and a dashboard
+// deep-link when they're known.
+func homePanel(rt *Runtime) string {
+	paint := rt.Out.Paint
+	lines := []string{paint(output.ToneAccent, "rc · RevenueCat")}
+
+	if rt.Config.BearerToken() == "" {
+		lines = append(lines, paint(output.ToneDim, "not logged in"))
+		return rt.Out.Panel(lines...)
+	}
+
+	identity := accountIdentity(rt)
+	if identity == "" {
+		identity = "logged in"
+	}
+	lines = append(lines, paint(output.ToneSuccess, "✓ ")+identity)
+
+	if rt.Config.ProjectID != "" {
+		lines = append(lines,
+			paint(output.ToneDim, "project "+rt.Config.ProjectID),
+			paint(output.ToneLink, "https://app.revenuecat.com/projects/"+dashboardProjectID(rt.Config.ProjectID)))
+	} else {
+		lines = append(lines, paint(output.ToneDim, "no project selected"))
+	}
+	return rt.Out.Panel(lines...)
 }
 
-// loggedInAs is the identity line: cached email/name when known, otherwise a
-// plain confirmation (an API-key login carries no cached identity).
-func loggedInAs(rt *Runtime) string {
+func accountIdentity(rt *Runtime) string {
 	if id := rt.Config.AccountEmail; id != "" {
-		return "Logged in as " + id
+		return id
 	}
-	if id := rt.Config.AccountName; id != "" {
-		return "Logged in as " + id
-	}
-	return "Logged in"
+	return rt.Config.AccountName
 }
 
-// homeActions renders command/description pairs as an aligned two-column
-// block: the command in the interaction accent, the description dimmed.
-func homeActions(paint func(output.Tone, string) string, rows [][2]string) string {
-	width := 0
+// homeRows renders command/description pairs as an aligned two-column block:
+// the command in the interaction accent (with <placeholders> dimmed so they
+// read as fill-ins), the description dimmed. Pass width to align the
+// description column across several blocks; 0 fits each block on its own.
+func homeRows(paint func(output.Tone, string) string, rows [][2]string, width int) string {
 	for _, r := range rows {
 		if len(r[0]) > width {
 			width = len(r[0])
@@ -83,7 +126,28 @@ func homeActions(paint func(output.Tone, string) string, rows [][2]string) strin
 	var b strings.Builder
 	for _, r := range rows {
 		pad := strings.Repeat(" ", width-len(r[0]))
-		b.WriteString("  " + paint(output.ToneCommand, r[0]) + pad + "  " + paint(output.ToneDim, r[1]) + "\n")
+		b.WriteString("  " + paintCommand(paint, r[0]) + pad + "  " + paint(output.ToneDim, r[1]) + "\n")
 	}
 	return b.String()
+}
+
+// paintCommand colors a command string, dimming any <...> placeholder segments.
+func paintCommand(paint func(output.Tone, string) string, s string) string {
+	var b strings.Builder
+	for {
+		i := strings.IndexByte(s, '<')
+		if i < 0 {
+			b.WriteString(paint(output.ToneCommand, s))
+			return b.String()
+		}
+		j := strings.IndexByte(s[i:], '>')
+		if j < 0 {
+			b.WriteString(paint(output.ToneCommand, s))
+			return b.String()
+		}
+		j += i
+		b.WriteString(paint(output.ToneCommand, s[:i]))
+		b.WriteString(paint(output.ToneDim, s[i:j+1]))
+		s = s[j+1:]
+	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,22 +30,6 @@ type Globals struct {
 	Version   string
 }
 
-const gettingStarted = `rc — the RevenueCat CLI
-
-New here? Two steps:
-  rc auth login          log in (browser or API key)
-  rc projects use        pick a project
-
-Try it:
-  rc paywalls            design a paywall with AI
-  rc customer show <id>  look up a customer
-  rc charts show mrr     see your MRR
-
-More:
-  rc --help              all commands
-  rc <command> --help    details for any command
-`
-
 func NewRootCmd(version string) *cobra.Command {
 	g := &Globals{Version: version}
 
@@ -130,9 +114,9 @@ Agent-friendly entrypoints:
 	whoamiAlias.Use = "whoami"
 	whoamiAlias.Hidden = true
 
-	// bare rc → getting-started; rc --help lists every command
+	// bare rc → state-aware getting-started; rc --help lists every command
 	root.RunE = func(cmd *cobra.Command, _ []string) error {
-		fmt.Fprint(cmd.OutOrStdout(), gettingStarted)
+		writeHomeScreen(cmd.OutOrStdout(), RuntimeFrom(cmd.Context()))
 		return nil
 	}
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,6 +30,22 @@ type Globals struct {
 	Version   string
 }
 
+const gettingStarted = `rc — the RevenueCat CLI
+
+New here? Two steps:
+  rc auth login          log in (browser or API key)
+  rc projects use        pick a project
+
+Try it:
+  rc paywalls            design a paywall with AI
+  rc customer show <id>  look up a customer
+  rc charts show mrr     see your MRR
+
+More:
+  rc --help              all commands
+  rc <command> --help    details for any command
+`
+
 func NewRootCmd(version string) *cobra.Command {
 	g := &Globals{Version: version}
 
@@ -114,10 +130,10 @@ Agent-friendly entrypoints:
 	whoamiAlias.Use = "whoami"
 	whoamiAlias.Hidden = true
 
-	// Bare `rc` shows help, which leads with the getting-started intro. The
-	// guided setup orchestrator is still available explicitly as `rc setup`.
-	root.RunE = func(cmd *cobra.Command, args []string) error {
-		return cmd.Help()
+	// bare rc → getting-started; rc --help lists every command
+	root.RunE = func(cmd *cobra.Command, _ []string) error {
+		fmt.Fprint(cmd.OutOrStdout(), gettingStarted)
+		return nil
 	}
 
 	root.AddCommand(

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -114,8 +114,13 @@ Agent-friendly entrypoints:
 	whoamiAlias.Use = "whoami"
 	whoamiAlias.Hidden = true
 
-	// bare rc → state-aware getting-started; rc --help lists every command
+	// bare rc → state-aware getting-started; rc --help lists every command.
+	// `rc --all` means "show me everything", so fall through to help (where
+	// --all reveals experimental commands) rather than the home screen.
 	root.RunE = func(cmd *cobra.Command, _ []string) error {
+		if RuntimeFrom(cmd.Context()).Globals.ShowAll {
+			return cmd.Help()
+		}
 		writeHomeScreen(cmd.OutOrStdout(), RuntimeFrom(cmd.Context()))
 		return nil
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -115,8 +115,7 @@ Agent-friendly entrypoints:
 	whoamiAlias.Hidden = true
 
 	// bare rc → state-aware getting-started; rc --help lists every command.
-	// `rc --all` means "show me everything", so fall through to help (where
-	// --all reveals experimental commands) rather than the home screen.
+	// --all falls through to help instead of the home screen
 	root.RunE = func(cmd *cobra.Command, _ []string) error {
 		if RuntimeFrom(cmd.Context()).Globals.ShowAll {
 			return cmd.Help()

--- a/internal/cli/root_gettingstarted_test.go
+++ b/internal/cli/root_gettingstarted_test.go
@@ -15,8 +15,7 @@ func TestBareRC_LoggedOut_ShowsSetupSteps(t *testing.T) {
 			t.Fatalf("logged-out home missing %q:\n%s", want, out)
 		}
 	}
-	// Logged out doesn't show the command map (commands need auth) or the
-	// full cobra dump.
+	// logged out shows neither the command map nor the full cobra dump
 	if strings.Contains(out, "Build") || strings.Contains(out, "Available Commands") {
 		t.Fatalf("logged-out home should stay lean:\n%s", out)
 	}
@@ -38,8 +37,7 @@ func TestBareRC_AllShowsFullHelpNotHome(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// `rc --all` falls through to help (the full grouped command list), which
-	// is what the help footer points at — not the home screen.
+	// --all falls through to help, not the home screen
 	for _, want := range []string{"Getting started", "customer", "paywalls"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("rc --all should show the full command list, missing %q:\n%s", want, out)

--- a/internal/cli/root_gettingstarted_test.go
+++ b/internal/cli/root_gettingstarted_test.go
@@ -21,13 +21,15 @@ func TestBareRC_LoggedOut_ShowsSetupSteps(t *testing.T) {
 		t.Fatalf("logged-out home should stay lean:\n%s", out)
 	}
 
-	// --help still lists the full command surface.
+	// --help still lists the full command surface (grouped into sections).
 	help, _, err := runCmd(t, "--help")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(help, "Available Commands") {
-		t.Fatalf("rc --help should list commands:\n%s", help)
+	for _, want := range []string{"customer", "paywalls", "webhooks"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("rc --help should list command %q:\n%s", want, help)
+		}
 	}
 }
 

--- a/internal/cli/root_gettingstarted_test.go
+++ b/internal/cli/root_gettingstarted_test.go
@@ -10,16 +10,15 @@ func TestBareRC_LoggedOut_ShowsSetupSteps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"New here?", "rc auth login", "rc projects use", "rc paywalls", "rc --help"} {
+	for _, want := range []string{"rc · RevenueCat", "not logged in", "New here?", "rc auth login", "rc projects use"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("logged-out home missing %q:\n%s", want, out)
 		}
 	}
-	if strings.Contains(out, "Logged in") {
-		t.Fatalf("logged-out home should not claim a session:\n%s", out)
-	}
-	if strings.Contains(out, "Available Commands") {
-		t.Fatalf("bare rc should not dump the full command list:\n%s", out)
+	// Logged out doesn't show the command map (commands need auth) or the
+	// full cobra dump.
+	if strings.Contains(out, "Build") || strings.Contains(out, "Available Commands") {
+		t.Fatalf("logged-out home should stay lean:\n%s", out)
 	}
 
 	// --help still lists the full command surface.
@@ -37,7 +36,7 @@ func TestBareRC_LoggedInNoProject_NudgesProject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"Logged in", "pick a project", "rc projects use", "rc paywalls"} {
+	for _, want := range []string{"logged in", "no project selected", "Pick a project", "rc projects use", "Build", "rc paywalls"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("logged-in/no-project home missing %q:\n%s", want, out)
 		}
@@ -47,17 +46,22 @@ func TestBareRC_LoggedInNoProject_NudgesProject(t *testing.T) {
 	}
 }
 
-func TestBareRC_LoggedInWithProject_ShowsThingsToDo(t *testing.T) {
+func TestBareRC_LoggedInWithProject_ShowsCommandMap(t *testing.T) {
 	out, _, err := runCmd(t, "--no-color", "--api-key", "sk_test", "--project-id", "proj_abc")
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"Logged in", "project proj_abc", "Do something", "rc paywalls"} {
+	for _, want := range []string{
+		"project proj_abc",
+		"app.revenuecat.com/projects/abc", // dashboard deep-link (prefix stripped)
+		"Build", "Inspect", "Automate & set up",
+		"rc paywalls", "rc customer show <id>",
+	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("logged-in/project home missing %q:\n%s", want, out)
 		}
 	}
-	if strings.Contains(out, "New here?") || strings.Contains(out, "pick a project") {
+	if strings.Contains(out, "New here?") || strings.Contains(out, "Pick a project") {
 		t.Fatalf("home with an active project should not nudge setup:\n%s", out)
 	}
 }

--- a/internal/cli/root_gettingstarted_test.go
+++ b/internal/cli/root_gettingstarted_test.go
@@ -5,15 +5,18 @@ import (
 	"testing"
 )
 
-func TestBareRC_ShowsGettingStartedNotFullList(t *testing.T) {
-	out, _, err := runCmd(t)
+func TestBareRC_LoggedOut_ShowsSetupSteps(t *testing.T) {
+	out, _, err := runCmd(t, "--no-color")
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"New here?", "rc auth login", "rc paywalls", "rc --help"} {
+	for _, want := range []string{"New here?", "rc auth login", "rc projects use", "rc paywalls", "rc --help"} {
 		if !strings.Contains(out, want) {
-			t.Fatalf("bare rc missing %q:\n%s", want, out)
+			t.Fatalf("logged-out home missing %q:\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "Logged in") {
+		t.Fatalf("logged-out home should not claim a session:\n%s", out)
 	}
 	if strings.Contains(out, "Available Commands") {
 		t.Fatalf("bare rc should not dump the full command list:\n%s", out)
@@ -26,5 +29,35 @@ func TestBareRC_ShowsGettingStartedNotFullList(t *testing.T) {
 	}
 	if !strings.Contains(help, "Available Commands") {
 		t.Fatalf("rc --help should list commands:\n%s", help)
+	}
+}
+
+func TestBareRC_LoggedInNoProject_NudgesProject(t *testing.T) {
+	out, _, err := runCmd(t, "--no-color", "--api-key", "sk_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Logged in", "pick a project", "rc projects use", "rc paywalls"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("logged-in/no-project home missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "New here?") {
+		t.Fatalf("authenticated home should not show first-run steps:\n%s", out)
+	}
+}
+
+func TestBareRC_LoggedInWithProject_ShowsThingsToDo(t *testing.T) {
+	out, _, err := runCmd(t, "--no-color", "--api-key", "sk_test", "--project-id", "proj_abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Logged in", "project proj_abc", "Do something", "rc paywalls"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("logged-in/project home missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "New here?") || strings.Contains(out, "pick a project") {
+		t.Fatalf("home with an active project should not nudge setup:\n%s", out)
 	}
 }

--- a/internal/cli/root_gettingstarted_test.go
+++ b/internal/cli/root_gettingstarted_test.go
@@ -36,7 +36,7 @@ func TestBareRC_LoggedInNoProject_NudgesProject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"logged in", "no project selected", "Pick a project", "rc projects use", "Build", "rc paywalls"} {
+	for _, want := range []string{"logged in", "no project selected", "Pick a project", "rc projects use", "Build", "rc paywalls generate"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("logged-in/no-project home missing %q:\n%s", want, out)
 		}
@@ -55,7 +55,8 @@ func TestBareRC_LoggedInWithProject_ShowsCommandMap(t *testing.T) {
 		"project proj_abc",
 		"app.revenuecat.com/projects/abc", // dashboard deep-link (prefix stripped)
 		"Build", "Inspect", "Automate & set up",
-		"rc paywalls", "rc customer show <id>",
+		"✨ Paywalls — design with AI", "rc paywalls generate", "rc paywalls edit",
+		"rc customer show <id>",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("logged-in/project home missing %q:\n%s", want, out)

--- a/internal/cli/root_gettingstarted_test.go
+++ b/internal/cli/root_gettingstarted_test.go
@@ -1,0 +1,30 @@
+package cli_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBareRC_ShowsGettingStartedNotFullList(t *testing.T) {
+	out, _, err := runCmd(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"New here?", "rc auth login", "rc paywalls", "rc --help"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("bare rc missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Available Commands") {
+		t.Fatalf("bare rc should not dump the full command list:\n%s", out)
+	}
+
+	// --help still lists the full command surface.
+	help, _, err := runCmd(t, "--help")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(help, "Available Commands") {
+		t.Fatalf("rc --help should list commands:\n%s", help)
+	}
+}

--- a/internal/cli/root_gettingstarted_test.go
+++ b/internal/cli/root_gettingstarted_test.go
@@ -33,6 +33,23 @@ func TestBareRC_LoggedOut_ShowsSetupSteps(t *testing.T) {
 	}
 }
 
+func TestBareRC_AllShowsFullHelpNotHome(t *testing.T) {
+	out, _, err := runCmd(t, "--all", "--no-color")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// `rc --all` falls through to help (the full grouped command list), which
+	// is what the help footer points at — not the home screen.
+	for _, want := range []string{"Getting started", "customer", "paywalls"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("rc --all should show the full command list, missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "New here?") {
+		t.Fatalf("rc --all should not show the home screen:\n%s", out)
+	}
+}
+
 func TestBareRC_LoggedInNoProject_NudgesProject(t *testing.T) {
 	out, _, err := runCmd(t, "--no-color", "--api-key", "sk_test")
 	if err != nil {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -68,8 +68,7 @@ func NewRenderer(stdout, stderr io.Writer, jsonMode, noColor, quiet bool, format
 
 func (r *Renderer) IsJSON() bool { return r.json }
 
-// Tone names a semantic style for callers that compose their own output,
-// keeping lipgloss out of those callers.
+// Tone is a semantic style for callers that compose their own output.
 type Tone int
 
 const (
@@ -81,8 +80,7 @@ const (
 	ToneLink                // a URL to open
 )
 
-// Paint renders text in the given tone, or returns it unstyled when color is
-// disabled — the single color gate for composed output.
+// Paint renders text in the given tone, unstyled when color is disabled.
 func (r *Renderer) Paint(t Tone, text string) string {
 	var s lipgloss.Style
 	switch t {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -68,10 +68,8 @@ func NewRenderer(stdout, stderr io.Writer, jsonMode, noColor, quiet bool, format
 
 func (r *Renderer) IsJSON() bool { return r.json }
 
-// Tone names a semantic style for callers that compose their own multi-line
-// output (e.g. the bare-`rc` home screen) instead of going through the
-// Info/Title helpers. It keeps lipgloss out of those callers so all color
-// stays in this package.
+// Tone names a semantic style for callers that compose their own output,
+// keeping lipgloss out of those callers.
 type Tone int
 
 const (
@@ -105,9 +103,7 @@ func (r *Renderer) Paint(t Tone, text string) string {
 }
 
 // Panel wraps pre-styled lines in a rounded border box sized to fit its
-// content. Callers style the lines (via Paint); Panel only draws the frame,
-// so all color decisions stay in one place. The frame is drawn uncolored
-// when color is disabled.
+// content. The frame is drawn uncolored when color is disabled.
 func (r *Renderer) Panel(lines ...string) string {
 	box := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
 	if !r.noColor {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -68,6 +68,39 @@ func NewRenderer(stdout, stderr io.Writer, jsonMode, noColor, quiet bool, format
 
 func (r *Renderer) IsJSON() bool { return r.json }
 
+// Tone names a semantic style for callers that compose their own multi-line
+// output (e.g. the bare-`rc` home screen) instead of going through the
+// Info/Title helpers. It keeps lipgloss out of those callers so all color
+// stays in this package.
+type Tone int
+
+const (
+	ToneAccent  Tone = iota // brand landmark (bar, identity)
+	ToneTitle               // bold section label
+	ToneDim                 // secondary/description text
+	ToneSuccess             // affirmative (logged in)
+	ToneCommand             // a command the user can type
+)
+
+// Paint renders text in the given tone, or returns it unstyled when color is
+// disabled — the single color gate for composed output.
+func (r *Renderer) Paint(t Tone, text string) string {
+	var s lipgloss.Style
+	switch t {
+	case ToneAccent:
+		s = StyleAccent
+	case ToneTitle:
+		s = StyleTitle
+	case ToneSuccess:
+		s = StyleSuccess
+	case ToneCommand:
+		s = StyleCommand
+	default:
+		s = StyleDim
+	}
+	return r.style(s, text)
+}
+
 // style returns either the styled rendering of s, or s unmodified when colors
 // are disabled. This is the single place we make that choice — every styled
 // write goes through here.

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -80,6 +80,7 @@ const (
 	ToneDim                 // secondary/description text
 	ToneSuccess             // affirmative (logged in)
 	ToneCommand             // a command the user can type
+	ToneLink                // a URL to open
 )
 
 // Paint renders text in the given tone, or returns it unstyled when color is
@@ -95,10 +96,24 @@ func (r *Renderer) Paint(t Tone, text string) string {
 		s = StyleSuccess
 	case ToneCommand:
 		s = StyleCommand
+	case ToneLink:
+		s = StyleInfo
 	default:
 		s = StyleDim
 	}
 	return r.style(s, text)
+}
+
+// Panel wraps pre-styled lines in a rounded border box sized to fit its
+// content. Callers style the lines (via Paint); Panel only draws the frame,
+// so all color decisions stay in one place. The frame is drawn uncolored
+// when color is disabled.
+func (r *Renderer) Panel(lines ...string) string {
+	box := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
+	if !r.noColor {
+		box = box.BorderForeground(NeutralGray)
+	}
+	return box.Render(strings.Join(lines, "\n"))
 }
 
 // style returns either the styled rendering of s, or s unmodified when colors


### PR DESCRIPTION
Bare `rc` printed the full ~29-command help — identical to `rc --help`, and overwhelming (especially for `npx` first-timers). Now it's a short getting-started screen:

```
rc — the RevenueCat CLI

New here? Two steps:
  rc auth login          log in (browser or API key)
  rc projects use        pick a project

Try it:
  rc paywalls            design a paywall with AI
  rc customer show <id>  look up a customer
  rc charts show mrr     see your MRR

More:
  rc --help              all commands
  rc <command> --help    details for any command
```

`rc --help` / `--all` are unchanged — they still list the full command surface for discovery. Test locks that bare `rc` shows the getting-started (not the full dump) while `--help` still lists everything.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX and presentation only; no API, auth, or data-path changes; behavior is covered by new integration tests.
> 
> **Overview**
> Bare **`rc`** no longer dumps the full command help; it prints a short **getting-started home** driven only by local config (auth + project). **`rc --help`** and **`rc --all`** still show the full Cobra help surface.
> 
> The home screen varies by state: logged-out users see login/project steps; authenticated users without a project get a project picker nudge; with a project they see a status panel (identity, project ID, dashboard link), a paywalls highlight, and grouped command hints (Build / Inspect / Automate & set up).
> 
> **`internal/output`** adds semantic **`Tone`**, **`Paint`**, and **`Panel`** so the home UI can compose styled text and a bordered header without duplicating lipgloss logic. **`root_gettingstarted_test`** locks the four behaviors above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6115593955fca6152c21f6ceb2d9137ea850ab30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->