### PR TITLE
Make `rc rico` the agent command (drop `rc rico chat`)

### DIFF
--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -217,9 +217,11 @@ rc paywalls unpublish [id]                               # remove the published 
 rc paywalls delete <id>
 
 # Rico (AI assistant)
-rc rico chat [message]                                   # streaming chat window in a TTY (--plain for a line loop)
-rc rico chat -r                                          # pick a past conversation to resume (last one on top)
-rc rico chat "..." --approve-tools --yes --no-input      # agent mode: auto-approve tool calls (destructive need --yes)
+rc rico [message]                                        # streaming chat window in a TTY (--plain for a line loop)
+rc rico --continue                                       # continue the most recent conversation
+rc rico -r                                               # pick a past conversation to resume (last one on top)
+rc rico --print "..." --json                             # headless: one answer and exit (for scripts/agents)
+rc rico "..." --approve-tools --yes --no-input           # agent mode: auto-approve tool calls (destructive need --yes)
 rc rico conversations list|show <id>|delete <id>
 rc rico feedback <run-id> <good|bad>
 

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -170,8 +170,7 @@ func TestRicoChat_RequiresPromptNonInteractive(t *testing.T) {
 	}
 }
 
-// --json is a non-interactive signal: `rc rico --json` with no message must
-// require one rather than opening the chat UI.
+// --json is non-interactive: no message must error, not open the chat UI.
 func TestRico_JSONWithoutMessageRequiresMessage(t *testing.T) {
 	_, _, err := runCmd(t, "rico", "--json", "--api-key", "sk_test")
 	if err == nil || !strings.Contains(err.Error(), "message is required") {

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -170,6 +170,15 @@ func TestRicoChat_RequiresPromptNonInteractive(t *testing.T) {
 	}
 }
 
+// --json is a non-interactive signal: `rc rico --json` with no message must
+// require one rather than opening the chat UI.
+func TestRico_JSONWithoutMessageRequiresMessage(t *testing.T) {
+	_, _, err := runCmd(t, "rico", "--json", "--api-key", "sk_test")
+	if err == nil || !strings.Contains(err.Error(), "message is required") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
 func TestRicoConversations_ListJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/conversations" {

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -53,7 +53,7 @@ func TestRicoChat_JSONApprovesDestructiveToolWithYes(t *testing.T) {
 	t.Setenv("RC_RICO_BASE_URL", server.URL)
 
 	stdout, stderr, err := runCmd(t,
-		"rico", "chat", "delete the test offering",
+		"rico", "delete the test offering",
 		"--conversation", "conv1",
 		"--approve-tools", "--yes", "--no-input", "--json",
 		"--api-key", "sk_test",
@@ -101,7 +101,7 @@ func TestRicoChat_JSONRejectsDestructiveToolWithoutYes(t *testing.T) {
 	t.Setenv("RC_RICO_BASE_URL", server.URL)
 
 	stdout, _, err := runCmd(t,
-		"rico", "chat", "delete the test offering",
+		"rico", "delete the test offering",
 		"--conversation", "conv1",
 		"--approve-tools", "--no-input", "--json",
 		"--api-key", "sk_test",
@@ -134,7 +134,7 @@ func TestRicoChat_RemembersLastConversationForResume(t *testing.T) {
 
 	configDir := t.TempDir()
 	_, _, err := runCmdInConfigDir(t, configDir,
-		"rico", "chat", "delete the test offering",
+		"rico", "delete the test offering",
 		"--conversation", "conv1",
 		"--approve-tools", "--yes", "--no-input", "--json", "--api-key", "sk_test",
 	)
@@ -157,14 +157,14 @@ func TestRicoChat_RemembersLastConversationForResume(t *testing.T) {
 }
 
 func TestRicoChat_ResumeRequiresInteractivePicker(t *testing.T) {
-	_, _, err := runCmd(t, "rico", "chat", "hi", "--resume", "--no-input", "--api-key", "sk_test")
+	_, _, err := runCmd(t, "rico", "hi", "--resume", "--no-input", "--api-key", "sk_test")
 	if err == nil || !strings.Contains(err.Error(), "conversation ID is required") {
 		t.Fatalf("err = %v", err)
 	}
 }
 
 func TestRicoChat_RequiresPromptNonInteractive(t *testing.T) {
-	_, _, err := runCmd(t, "rico", "chat", "--no-input", "--api-key", "sk_test")
+	_, _, err := runCmd(t, "rico", "--no-input", "--api-key", "sk_test")
 	if err == nil || !strings.Contains(err.Error(), "message is required") {
 		t.Fatalf("err = %v", err)
 	}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -11,7 +11,7 @@ func TestSubcommandHelp_CollapsesGlobalFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, want := range []string{
-		"Available Commands:", "chat",
+		"Available Commands:", "conversations",
 		"Global flags: ", "--api-key", "--json",
 		"Run `rc --help` for what each global flag does.",
 	} {

--- a/internal/cli/home.go
+++ b/internal/cli/home.go
@@ -28,7 +28,7 @@ var homeMap = []homeGroup{
 	{"Automate & set up", [][2]string{
 		{"rc apps", "connect App Store & Google Play"},
 		{"rc skills install", "AI workflows for coding agents"},
-		{"rc rico chat", "ask RevenueCat's AI ✨"},
+		{"rc rico", "ask RevenueCat's AI ✨"},
 	}},
 }
 

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -25,40 +25,6 @@ import (
 const ricoResumeRounds = 10
 
 func newRicoCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "rico",
-		Short: "Chat with Rico, RevenueCat's AI assistant",
-		Long: `Rico answers questions about your projects, metrics, and configuration, and
-can run RevenueCat tools on your behalf. Tool calls that change data pause for
-approval before executing.
-
-Conversations are stored server-side; continue one with --conversation.`,
-	}
-	cmd.AddCommand(
-		newRicoChatCmd(),
-		newRicoConversationsCmd(),
-		newRicoFeedbackCmd(),
-	)
-	return cmd
-}
-
-type ricoChatOptions struct {
-	prompt         string
-	conversationID string
-	resume         bool
-	approveTools   bool
-	plain          bool
-	timeout        time.Duration
-	baseURL        string
-}
-
-// ricoState is the per-profile memory of the last CLI conversation; the
-// --resume picker floats it to the top.
-type ricoState struct {
-	LastConversationID string `json:"last_conversation_id"`
-}
-
-func newRicoChatCmd() *cobra.Command {
 	opts := ricoChatOptions{
 		prompt:         os.Getenv("RC_RICO_PROMPT"),
 		conversationID: os.Getenv("RC_RICO_CONVERSATION_ID"),
@@ -66,21 +32,26 @@ func newRicoChatCmd() *cobra.Command {
 		timeout:        10 * time.Minute,
 	}
 	cmd := &cobra.Command{
-		Use:   "chat [message]",
-		Short: "Send a message to Rico",
-		Long: `Sends a message and streams Rico's reply. In a terminal with no message
-given, opens a full-screen chat window; with a message (or --prompt) it
-answers once and exits. Pass --plain for a line-based prompt loop instead of
-the chat window.
+		Use:   "rico [message]",
+		Short: "Chat with Rico, RevenueCat's AI assistant",
+		Long: `Rico answers questions about your projects, metrics, and configuration, and
+can run RevenueCat tools on your behalf. Tool calls that change data pause for
+approval before executing.
 
-Tool calls that modify data pause the run for approval. Interactive terminals
-prompt; non-interactive runs reject them unless --approve-tools is passed
-(destructive tools additionally require --yes).`,
-		Example: `  rc rico chat
-  rc rico chat "why did trial conversions drop this week?"
-  rc rico chat "delete the test offering" --approve-tools --yes --json --no-input
-  rc rico chat --resume
-  rc rico chat --conversation NQ7bGmww8rLcPT9d`,
+With no message in a terminal, opens a full-screen chat window; with a message
+(or --prompt) it answers once and exits. Pass --print to force a single answer
+for scripts and agents, or --plain for a line-based loop.
+
+Conversations are stored server-side: --continue resumes the most recent one,
+--resume picks from a list, and --conversation <id> continues a specific one.
+Tool calls that modify data pause for approval; non-interactive runs reject
+them unless --approve-tools is passed (destructive tools also require --yes).`,
+		Example: `  rc rico
+  rc rico "why did trial conversions drop this week?"
+  rc rico --continue
+  rc rico --resume
+  rc rico --print "how many active subscriptions do we have?" --json
+  rc rico "delete the test offering" --approve-tools --yes --no-input`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -93,6 +64,14 @@ prompt; non-interactive runs reject them unless --approve-tools is passed
 			client, err := ricoClient(rt, opts.baseURL)
 			if err != nil {
 				return err
+			}
+			if opts.continueLast && opts.conversationID == "" {
+				var state ricoState
+				_ = config.LoadState(rt.Globals.Profile, "rico", &state)
+				if state.LastConversationID == "" {
+					return fmt.Errorf("no recent conversation to continue — start one with `rc rico`, or pick one with --resume")
+				}
+				opts.conversationID = state.LastConversationID
 			}
 			if opts.resume && opts.conversationID == "" {
 				opts.conversationID, err = pickRicoConversation(cmd.Context(), rt, client)
@@ -113,7 +92,7 @@ prompt; non-interactive runs reject them unless --approve-tools is passed
 			if session.conversationID == "" {
 				session.conversationID = rico.NewConversationID()
 			}
-			if opts.prompt != "" || rt.Globals.NoInput || !tui.IsInteractive() {
+			if opts.prompt != "" || opts.print || rt.Globals.NoInput || !tui.IsInteractive() {
 				if opts.prompt == "" {
 					return fmt.Errorf("message is required; pass it as an argument or set RC_RICO_PROMPT")
 				}
@@ -126,13 +105,37 @@ prompt; non-interactive runs reject them unless --approve-tools is passed
 		},
 	}
 	cmd.Flags().StringVar(&opts.prompt, "prompt", opts.prompt, "message to send (or RC_RICO_PROMPT)")
-	cmd.Flags().StringVarP(&opts.conversationID, "conversation", "c", opts.conversationID, "conversation to continue (or RC_RICO_CONVERSATION_ID)")
+	cmd.Flags().StringVar(&opts.conversationID, "conversation", opts.conversationID, "continue a specific conversation by ID (or RC_RICO_CONVERSATION_ID)")
+	cmd.Flags().BoolVarP(&opts.continueLast, "continue", "c", false, "continue the most recent conversation")
 	cmd.Flags().BoolVarP(&opts.resume, "resume", "r", false, "pick a past conversation to resume (most recent first)")
+	cmd.Flags().BoolVarP(&opts.print, "print", "p", false, "print a single answer and exit (for scripts and agents)")
 	cmd.Flags().BoolVar(&opts.approveTools, "approve-tools", false, "approve tool calls without prompting (destructive ones still need --yes)")
 	cmd.Flags().BoolVar(&opts.plain, "plain", false, "line-based prompt loop instead of the chat window")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", opts.timeout, "maximum time to wait for a reply")
 	cmd.Flags().StringVar(&opts.baseURL, "base-url", opts.baseURL, "Rico endpoint (or RC_RICO_BASE_URL)")
+	cmd.AddCommand(
+		newRicoConversationsCmd(),
+		newRicoFeedbackCmd(),
+	)
 	return cmd
+}
+
+type ricoChatOptions struct {
+	prompt         string
+	conversationID string
+	continueLast   bool
+	resume         bool
+	print          bool
+	approveTools   bool
+	plain          bool
+	timeout        time.Duration
+	baseURL        string
+}
+
+// ricoState is the per-profile memory of the last CLI conversation; the
+// --resume picker floats it to the top.
+type ricoState struct {
+	LastConversationID string `json:"last_conversation_id"`
 }
 
 // ricoSession drives chat turns: streaming, interrupt approval, and resumes.
@@ -191,7 +194,7 @@ func (s *ricoSession) chatWindow(ctx context.Context) error {
 	if err := chat.RunChat(); err != nil {
 		return err
 	}
-	s.rt.Out.Hint("Resume this conversation:  rc rico chat -r")
+	s.rt.Out.Hint("Continue this conversation:  rc rico --continue")
 	return nil
 }
 
@@ -206,7 +209,7 @@ func pickRicoConversation(ctx context.Context, rt *Runtime, client *rico.Client)
 		return "", err
 	}
 	if len(items) == 0 {
-		return "", fmt.Errorf("no conversations found — start one with rc rico chat")
+		return "", fmt.Errorf("no conversations found — start one with rc rico")
 	}
 	options := make([]huh.Option[string], len(items))
 	for i, item := range items {

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -197,7 +197,7 @@ func (s *ricoSession) chatWindow(ctx context.Context) error {
 	if err := chat.RunChat(); err != nil {
 		return err
 	}
-	s.rt.Out.Hint("Continue this conversation:  rc rico --continue")
+	s.rt.Out.Hint("Continue this conversation:  rc rico --conversation " + s.conversationID)
 	return nil
 }
 

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -92,7 +92,7 @@ them unless --approve-tools is passed (destructive tools also require --yes).`,
 			if session.conversationID == "" {
 				session.conversationID = rico.NewConversationID()
 			}
-			if opts.prompt != "" || opts.print || rt.Globals.NoInput || !tui.IsInteractive() {
+			if opts.prompt != "" || opts.print || rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
 				if opts.prompt == "" {
 					return fmt.Errorf("message is required; pass it as an argument or set RC_RICO_PROMPT")
 				}

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -243,9 +243,7 @@ func ricoConversationPickerItems(ctx context.Context, rt *Runtime, client *rico.
 	var state ricoState
 	_ = config.LoadState(rt.Globals.Profile, "rico", &state)
 
-	// Align the age into a fixed-width gutter so summaries line up in a clean
-	// column (the way Claude Code / Codex render their session pickers) rather
-	// than running age and summary together on a ragged line.
+	// age in a fixed-width gutter so summaries align in a column
 	type row struct {
 		id, age, summary string
 		recent           bool

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -251,7 +251,7 @@ func ricoConversationPickerItems(ctx context.Context, rt *Runtime, client *rico.
 		}
 		item := PickerItem{
 			ID:    conversation.ID,
-			Label: fmt.Sprintf("%s — %s (%s)", summary, lastActivity(conversation.UpdatedAt), conversation.ID),
+			Label: fmt.Sprintf("%s  ·  %s", summary, lastActivity(conversation.UpdatedAt)),
 		}
 		if conversation.ID == state.LastConversationID {
 			item.Label = "↩ " + item.Label

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -243,18 +243,43 @@ func ricoConversationPickerItems(ctx context.Context, rt *Runtime, client *rico.
 	var state ricoState
 	_ = config.LoadState(rt.Globals.Profile, "rico", &state)
 
-	items := make([]PickerItem, 0, len(conversations))
+	// Align the age into a fixed-width gutter so summaries line up in a clean
+	// column (the way Claude Code / Codex render their session pickers) rather
+	// than running age and summary together on a ragged line.
+	type row struct {
+		id, age, summary string
+		recent           bool
+	}
+	rows := make([]row, 0, len(conversations))
+	ageWidth := 0
 	for _, conversation := range conversations {
 		summary := conversation.Summary
 		if summary == "" {
 			summary = "(no summary)"
 		}
-		item := PickerItem{
-			ID:    conversation.ID,
-			Label: fmt.Sprintf("%s  ·  %s", summary, lastActivity(conversation.UpdatedAt)),
+		age := lastActivity(conversation.UpdatedAt)
+		if len(age) > ageWidth {
+			ageWidth = len(age)
 		}
-		if conversation.ID == state.LastConversationID {
-			item.Label = "↩ " + item.Label
+		rows = append(rows, row{
+			id:      conversation.ID,
+			age:     age,
+			summary: summary,
+			recent:  conversation.ID == state.LastConversationID,
+		})
+	}
+
+	items := make([]PickerItem, 0, len(rows))
+	for _, r := range rows {
+		marker := "  "
+		if r.recent {
+			marker = "↩ "
+		}
+		item := PickerItem{
+			ID:    r.id,
+			Label: fmt.Sprintf("%s%-*s   %s", marker, ageWidth, r.age, r.summary),
+		}
+		if r.recent {
 			items = append([]PickerItem{item}, items...)
 			continue
 		}

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -92,7 +92,8 @@ them unless --approve-tools is passed (destructive tools also require --yes).`,
 			if session.conversationID == "" {
 				session.conversationID = rico.NewConversationID()
 			}
-			if opts.prompt != "" || opts.print || rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
+			oneShot := opts.print || rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive()
+			if oneShot || (opts.plain && opts.prompt != "") {
 				if opts.prompt == "" {
 					return fmt.Errorf("message is required; pass it as an argument or set RC_RICO_PROMPT")
 				}
@@ -101,6 +102,7 @@ them unless --approve-tools is passed (destructive tools also require --yes).`,
 			if opts.plain {
 				return session.repl(cmd.Context())
 			}
+			// interactive: a message seeds the chat window, no message opens it empty
 			return session.chatWindow(cmd.Context())
 		},
 	}
@@ -180,6 +182,7 @@ func (s *ricoSession) chatWindow(ctx context.Context) error {
 		Subtitle:         "conversation " + s.conversationID,
 		Placeholder:      "Ask Rico anything about your RevenueCat projects…",
 		Transcript:       transcript,
+		Initial:          s.opts.prompt,
 		RelativeLinkBase: envOrDefault("RC_DASHBOARD_URL", "https://app.revenuecat.com"),
 		Send: func(turnCtx context.Context, message string, emit *tui.ChatEmitter) {
 			turnCtx, cancel := context.WithTimeout(turnCtx, s.opts.timeout)
@@ -201,7 +204,7 @@ func (s *ricoSession) chatWindow(ctx context.Context) error {
 // pickRicoConversation shows the --resume picker in the alternate screen (so
 // nothing lingers on the primary screen once the chat window exits).
 func pickRicoConversation(ctx context.Context, rt *Runtime, client *rico.Client) (string, error) {
-	if rt.Globals.NoInput || !tui.IsInteractive() {
+	if rt.Globals.NoInput || rt.Globals.JSON || !tui.IsInteractive() {
 		return "", fmt.Errorf("conversation ID is required; --resume needs a terminal (use --conversation <id>)")
 	}
 	items, err := ricoConversationPickerItems(ctx, rt, client)

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -25,7 +25,7 @@ func newSchemaCmd(root *cobra.Command) *cobra.Command {
 Always emits JSON regardless of --json (the command is purely informational).
 Use this from an agent rather than scraping the human --help output.`,
 		Example: `  rc schema apps create
-  rc schema rico chat`,
+  rc schema rico`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -29,6 +29,8 @@ type Chat struct {
 	Send func(ctx context.Context, message string, emit *ChatEmitter)
 	// Transcript preloads history (e.g. when resuming a conversation).
 	Transcript []ChatEntry
+	// Initial, when set, is sent as the first turn as soon as the window opens.
+	Initial string
 	// RelativeLinkBase, when set, prefixes relative markdown link targets
 	// ("[x](/path)") in assistant messages so they are clickable in a
 	// terminal (e.g. "https://app.revenuecat.com").
@@ -159,7 +161,12 @@ func (m *chatModel) cancelTurn() {
 	}
 }
 
-func (m *chatModel) Init() tea.Cmd { return textarea.Blink }
+func (m *chatModel) Init() tea.Cmd {
+	if m.cfg.Initial != "" {
+		return tea.Batch(textarea.Blink, m.startTurn(m.cfg.Initial))
+	}
+	return textarea.Blink
+}
 
 func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {


### PR DESCRIPTION
`rc rico chat` was redundant — the point of `rc rico` is to chat. Reshaped it to work like Codex / Claude Code: the bare command launches the session.

- `rc rico` — interactive session; `rc rico "…"` seeds it
- `-c/--continue` — most recent conversation · `-r/--resume` — pick one · `--conversation <id>` — a specific one
- `-p/--print` — headless one-shot for scripts/agents
- `conversations` and `feedback` stay as subcommands

Stacked on the home-screen PR (#81 → base) and help PR (#82). `chat` is gone (nothing depends on it yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CLI surface change breaks anyone still using `rc rico chat`, and Rico’s mode routing (interactive vs one-shot vs tool approval) is touched across the main command path.
> 
> **Overview**
> **Rico chat is now invoked directly on `rc rico`** instead of the nested `rc rico chat` subcommand. `conversations` and `feedback` remain subcommands; help, docs, home screen, and schema examples are updated to match.
> 
> **New flags and behavior:** `-c/--continue` resumes the last conversation from profile state; `-p/--print` forces a one-shot answer for scripts. `--json` and `--no-input` without a message now error with “message is required” instead of opening the UI. The resume picker is blocked when `--json` is set. Conversation list labels in the resume picker use aligned age + summary columns with a ↩ marker for the recent thread.
> 
> **Chat TUI:** An optional `Initial` message on the chat window auto-sends the first turn on open (so `rc rico "…"` can seed an interactive session).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5a8689b56f1ac6a0e7282032cf3f45acbeeef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->