### PR TITLE
Stop listing Rico state files as phantom profiles

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,9 +14,8 @@ import (
 // from --profile, RC_PROFILE, or the .active file, so an unchecked name like
 // "../../x" would read/write outside ~/.config/revenuecat.
 func validateProfileName(name string) error {
-	if name == "" || name == "." || name == ".." ||
-		strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
-		return fmt.Errorf("invalid profile name %q: must not be empty or contain path separators", name)
+	if name == "" || strings.ContainsAny(name, `/\`) || strings.Contains(name, ".") {
+		return fmt.Errorf("invalid profile name %q: must be non-empty and contain no '.' or path separators", name)
 	}
 	return nil
 }
@@ -169,7 +168,12 @@ func ListProfiles() ([]string, error) {
 		if !filepathIsJSON(n) {
 			continue
 		}
-		names = append(names, n[:len(n)-5])
+		base := n[:len(n)-5]
+		// dotted base = state file (<profile>.<name>.json), not a profile
+		if strings.Contains(base, ".") {
+			continue
+		}
+		names = append(names, base)
 	}
 	return names, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,7 +90,7 @@ func ProfileName(p string) string {
 	if p != "" {
 		return p
 	}
-	// ignore an invalid RC_PROFILE / .active (e.g. a residual dotted name) instead of failing every command
+	// tolerate a residual/invalid RC_PROFILE or .active pointer
 	if env := os.Getenv("RC_PROFILE"); env != "" && validateProfileName(env) == nil {
 		return env
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,10 +90,11 @@ func ProfileName(p string) string {
 	if p != "" {
 		return p
 	}
-	if env := os.Getenv("RC_PROFILE"); env != "" {
+	// ignore an invalid RC_PROFILE / .active (e.g. a residual dotted name) instead of failing every command
+	if env := os.Getenv("RC_PROFILE"); env != "" && validateProfileName(env) == nil {
 		return env
 	}
-	if name := readActivePointer(); name != "" {
+	if name := readActivePointer(); name != "" && validateProfileName(name) == nil {
 		return name
 	}
 	return defaultProfile

--- a/internal/config/profiles_test.go
+++ b/internal/config/profiles_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListProfiles_SkipsStateFiles(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", dir)
+	for _, name := range []string{"default.json", "work.json", "default.rico.json", "work.paywalls.json"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := ListProfiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{"default": true, "work": true}
+	if len(got) != len(want) {
+		t.Fatalf("profiles = %v, want default+work only (state files must be skipped)", got)
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Fatalf("state file leaked into profiles as %q: %v", name, got)
+		}
+	}
+}
+
+func TestValidateProfileName_RejectsDotted(t *testing.T) {
+	if err := validateProfileName("default"); err != nil {
+		t.Fatalf("plain name rejected: %v", err)
+	}
+	for _, bad := range []string{"default.rico", "a.b", ".", "..", "", "a/b"} {
+		if err := validateProfileName(bad); err == nil {
+			t.Fatalf("expected %q to be rejected", bad)
+		}
+	}
+}

--- a/internal/config/profiles_test.go
+++ b/internal/config/profiles_test.go
@@ -29,6 +29,27 @@ func TestListProfiles_SkipsStateFiles(t *testing.T) {
 	}
 }
 
+func TestProfileName_IgnoresInvalidActiveAndEnv(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", dir)
+	t.Setenv("RC_PROFILE", "")
+	// residual dotted name from the old phantom-profile bug
+	if err := os.WriteFile(filepath.Join(dir, ".active"), []byte("default.rico\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ProfileName(""); got != "default" {
+		t.Fatalf("ProfileName = %q, want default (invalid .active must be ignored)", got)
+	}
+	if _, err := Load(""); err != nil {
+		t.Fatalf("Load errored on invalid .active instead of self-healing: %v", err)
+	}
+
+	t.Setenv("RC_PROFILE", "bad.name")
+	if got := ProfileName(""); got != "default" {
+		t.Fatalf("ProfileName = %q, want default (invalid RC_PROFILE must be ignored)", got)
+	}
+}
+
 func TestValidateProfileName_RejectsDotted(t *testing.T) {
 	if err := validateProfileName("default"); err != nil {
 		t.Fatalf("plain name rejected: %v", err)


### PR DESCRIPTION
After any Rico chat, a `<profile>.rico.json` state file is written next to the profile files. `rc profiles list` listed every `*.json`, so it showed a phantom `default.rico` "profile" — and `rc profiles use default.rico` would load the broken state file as one.

Fix: a profile name is a dot-free segment. `ListProfiles` skips dotted bases (state files), and `validateProfileName` rejects `.`. No migration — existing installs clean up immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local CLI config/profile listing only; no auth or network changes. Users with dotted profile names in env or `.active` will silently fall back to `default`.
> 
> **Overview**
> Fixes phantom profiles like `default.rico` appearing in `rc profiles list` because Rico writes `<profile>.rico.json` state files next to real profile JSON files.
> 
> **Profile naming** now treats names as dot-free segments: `validateProfileName` rejects any `.` (not only `..`), and `ListProfiles` skips `*.json` files whose basename contains a dot so state files such as `default.rico.json` are not listed.
> 
> **Self-healing resolution**: `ProfileName` ignores invalid `RC_PROFILE` or `.active` values (e.g. leftover `default.rico`) and falls back to `default`, so `Load` does not fail on a bad pointer.
> 
> Tests cover list filtering, invalid env/active handling, and dotted-name validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f482f42c876e728febc878800f69eee4eb790a1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->