### PR TITLE
Redesign rc setup: defer Apple, cleaner stepped flow

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -132,6 +132,13 @@ You must accept the RevenueCat Terms of Service and Privacy Policy:
 					}
 					generatePassword = passwordMode == passwordGenerate
 					rt.Out.Answer("Password", map[bool]string{true: "generate", false: "create my own"}[generatePassword])
+					if generatePassword {
+						note := `You can set your own anytime with "Forgot password?" at revenuecat.com.`
+						if runtime.GOOS == "darwin" {
+							note = "We'll offer to save it to your macOS Keychain. " + note
+						}
+						rt.Out.Info(note)
+					}
 				}
 				if password == "" && !generatePassword {
 					var confirmation string

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/charmbracelet/huh"
+
 	"github.com/revenuecat/cli/internal/api"
 	"github.com/revenuecat/cli/internal/output"
 )
@@ -29,6 +31,13 @@ func Run(version string) int {
 	var silent *SilentExitError
 	if errors.As(err, &silent) {
 		return silent.Code
+	}
+	// Cancelling a prompt (Esc / Ctrl-C) is a choice, not a failure.
+	if errors.Is(err, huh.ErrUserAborted) {
+		if mode, _ := root.PersistentFlags().GetBool("json"); !mode {
+			fmt.Fprintln(os.Stderr, output.StyleDim.Render("Cancelled."))
+		}
+		return 130
 	}
 	jsonMode, _ := root.PersistentFlags().GetBool("json")
 	if jsonMode {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -32,7 +32,7 @@ func Run(version string) int {
 	if errors.As(err, &silent) {
 		return silent.Code
 	}
-	// Cancelling a prompt (Esc / Ctrl-C) is a choice, not a failure.
+	// user-cancelled prompt: exit cleanly, not as an error
 	if errors.Is(err, huh.ErrUserAborted) {
 		if mode, _ := root.PersistentFlags().GetBool("json"); !mode {
 			fmt.Fprintln(os.Stderr, output.StyleDim.Render("Cancelled."))

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -111,7 +110,7 @@ the step-by-step commands in the docs.`,
 		Annotations: map[string]string{
 			"surface":               "punted",
 			"requires_human":        "true",
-			"requires_human_reason": "launches the user's local AI agent in an interactive terminal; agents should follow the RevenueCat skills directly instead",
+			"requires_human_reason": "interactively it launches a local AI agent; run non-interactively (rc setup --json) to get the setup prompt to follow directly",
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runSetup(cmd)
@@ -123,7 +122,7 @@ the step-by-step commands in the docs.`,
 func runSetup(cmd *cobra.Command) error {
 	rt := RuntimeFrom(cmd.Context())
 	if rt.Globals.NoInput || !tui.IsInteractive() {
-		return errors.New("rc setup is interactive: it verifies the directory and launches your AI agent. Agents should use the RevenueCat skills directly (rc skills prompts --json)")
+		return runSetupAgentPrompt(cmd, rt)
 	}
 
 	dir, err := os.Getwd()
@@ -359,6 +358,46 @@ func setupAgentPrompt(rt *Runtime, stage setupStage, appleDeferred bool) string 
 		prompt += "\n\nApple: I have deliberately deferred connecting my Apple account. Do NOT pause, wait, or poll for Apple credentials at any point — complete every stage that does not require Apple (Test Store catalog, paywall, SDK integration, build verification) and finish your run by listing the Apple steps as remaining work with the exact commands I should run later."
 	}
 	return prompt
+}
+
+// runSetupAgentPrompt handles `rc setup` run non-interactively (by an agent):
+// instead of launching a nested agent, it emits the stage-aware setup prompt
+// for the caller to follow, with the human-only steps called out.
+func runSetupAgentPrompt(cmd *cobra.Command, rt *Runtime) error {
+	dir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	projectLabel, _ := detectAppProject(dir)
+	platform := platformFromLabel(projectLabel)
+	stage := detectSetupStage(cmd, rt, platform)
+	authed := rt.Config != nil && rt.Config.BearerToken() != ""
+	applePending := (platform == "ios" || platform == "cross") &&
+		(stage.PromptID == "test-store-ready" || stage.PromptID == "connect-apple")
+
+	prompt := setupAgentPrompt(rt, stage, applePending) + setupAuthHandbackNote(authed)
+
+	if rt.Globals.JSON {
+		return rt.Out.Render(map[string]any{
+			"prompt":         prompt,
+			"stage":          stage.PromptID,
+			"authenticated":  authed,
+			"apple_deferred": applePending,
+			"platform":       platform,
+		})
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), prompt)
+	return nil
+}
+
+// setupAuthHandbackNote tells an agent how to handle auth: it can create a new
+// account without a browser, but logging in to an existing one is a human step
+// it must hand back.
+func setupAuthHandbackNote(authed bool) string {
+	if authed {
+		return ""
+	}
+	return "\n\nAuth: you are not logged in. If the user has no RevenueCat account, create one without a browser: `rc auth signup --email <user's email> --name \"<user's name>\" --generate-password --save-password --accept-terms --no-input --json` — but only after the user explicitly agrees to the RevenueCat Terms of Service and Privacy Policy. If the user already has an account, STOP and ask them to run `rc auth login` (a browser sign-in you cannot perform), then continue."
 }
 
 // setupStage is where this project stands in the onboarding journey; it

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -133,24 +133,16 @@ func runSetup(cmd *cobra.Command) error {
 	platform := platformFromLabel(projectLabel)
 	agents := detectAgents()
 
-	account := "not logged in"
-	if rt.Config != nil && rt.Config.BearerToken() != "" {
-		account = "logged in"
-		if rt.Config.AccountEmail != "" {
-			account = rt.Config.AccountEmail
-		}
-	}
-
 	rt.Out.Title("RevenueCat setup — " + filepath.Base(dir))
-	rt.Out.Lead("Hands your app's RevenueCat onboarding to an AI agent with RevenueCat's skills installed — nothing runs without your OK.")
+	rt.Out.Lead("Installs RevenueCat's skills into an AI agent and lets it build your Test Store catalog, paywall, and SDK integration — you approve each step. Connecting Apple for the real App Store comes later, when you're ready to ship.")
 	rt.Out.Field("Directory", collapseHome(dir), projectLabel)
-	rt.Out.Field("Account", account)
-	agentNames := make([]string, 0, len(agents))
-	for _, a := range agents {
-		agentNames = append(agentNames, a.Name)
-	}
-	if len(agentNames) > 0 {
-		rt.Out.Field("Agents found", strings.Join(agentNames, ", "))
+	rt.Out.Field("Account", setupAccountLabel(rt))
+	if len(agents) > 0 {
+		names := make([]string, 0, len(agents))
+		for _, a := range agents {
+			names = append(names, a.Name)
+		}
+		rt.Out.Field("Agents found", strings.Join(names, ", "))
 	} else {
 		rt.Out.Field("Agents found", "none", "install Claude Code, Codex, Cursor, or Gemini CLI for agent-driven setup")
 	}
@@ -165,18 +157,6 @@ func runSetup(cmd *cobra.Command) error {
 	stage := detectSetupStage(cmd, rt, platform)
 	rt.Out.Field("Stage", stage.Label)
 
-	// Everything that would interrupt the agent mid-run (Apple sign-in, 2FA)
-	// happens before the handoff.
-	appleDeferred := false
-	if stage.PromptID == "connect-apple" || (stage.PromptID == "test-store-ready" && rt.Config != nil && rt.Config.BearerToken() != "") {
-		if offerOneShotApple(cmd, rt, dir, platform) {
-			stage = detectSetupStage(cmd, rt, platform)
-			rt.Out.Field("Stage", stage.Label)
-		} else if platform == "ios" || platform == "cross" {
-			appleDeferred = true
-		}
-	}
-
 	if !projectDetected {
 		cont, err := tui.ConfirmDefault(false, "No app project detected in this directory. Set up here anyway?", false)
 		if err != nil {
@@ -189,48 +169,50 @@ func runSetup(cmd *cobra.Command) error {
 		}
 	}
 
-	prompt := starterPromptByID(stage.PromptID) + setupToolingNote(rt)
-	if appleDeferred {
-		prompt += "\n\nApple: I have deliberately deferred connecting my Apple account. Do NOT pause, wait, or poll for Apple credentials at any point — complete every stage that does not require Apple (Test Store catalog, paywall, SDK integration, build verification) and finish your run by listing the Apple steps as remaining work with the exact commands I should run later."
-	}
+	// Apple is the last mile — the agent builds everything on the Test Store
+	// first; it's connected only at the production stage, and until then the
+	// agent is told not to wait for it.
+	applePending := (platform == "ios" || platform == "cross") &&
+		(stage.PromptID == "test-store-ready" || stage.PromptID == "connect-apple")
+
+	rt.Out.Title("Step 1 · Choose your agent")
 	choice, err := pickSetupAgent(agents)
 	if err != nil {
 		return err
 	}
 	if choice == nil {
-		rt.Out.Answer("Agent", "none — manual prompt")
+		rt.Out.Answer("Agent", "none — copy the prompt")
 		rt.Out.Blank()
-		rt.Out.Info("Paste this into any agent after running rc skills install:")
-		rt.Out.Info(prompt)
+		rt.Out.Info("Run rc skills install, then paste this into any agent:")
+		rt.Out.Info(setupAgentPrompt(rt, stage, applePending))
 		rt.Out.Hint("more starter prompts:  rc skills prompts")
 		return nil
 	}
 	rt.Out.Answer("Agent", choice.Name)
 
+	rt.Out.Title("Step 2 · Autonomy")
 	autonomy := autonomyTrusted
 	if err := tui.Form(false).
 		Field(huh.NewSelect[string]().
-			Title("How much should "+choice.Name+" do without asking?").
+			Title("How much can "+choice.Name+" do without stopping to ask?").
+			Description("You can interrupt anytime. \"Run freely\" pre-approves rc commands, file edits, and builds.").
 			Options(
-				huh.NewOption("Run the setup freely (pre-approves rc, file edits, and builds)", autonomyTrusted),
+				huh.NewOption("Run freely — pre-approve rc, file edits, and builds", autonomyTrusted),
 				huh.NewOption("Ask me before each step", autonomyManual),
-				huh.NewOption("Everything, no approvals at all", autonomyFull),
+				huh.NewOption("No approvals at all", autonomyFull),
 			).
 			Value(&autonomy)).
 		Run(); err != nil {
 		return err
 	}
-	autonomyLabels := map[string]string{
-		autonomyTrusted: "run freely (rc, edits, builds pre-approved)",
-		autonomyManual:  "ask before each step",
-		autonomyFull:    "no approvals",
-	}
 	rt.Out.Answer("Autonomy", autonomyLabels[autonomy])
 
+	rt.Out.Title("Step 3 · Skills")
 	skillsScope := "project"
 	if err := tui.Form(false).
 		Field(huh.NewSelect[string]().
-			Title("Install the RevenueCat skills for this project or globally?").
+			Title("Install the RevenueCat skills here or globally?").
+			Description("Project keeps them with this repo; global shares them across every project on this machine.").
 			Options(
 				huh.NewOption("This project only", "project"),
 				huh.NewOption("Globally (all projects on this machine)", "global"),
@@ -239,13 +221,29 @@ func runSetup(cmd *cobra.Command) error {
 		Run(); err != nil {
 		return err
 	}
-	rt.Out.Answer("Skills", map[string]string{"project": "this project only", "global": "global"}[skillsScope])
+	rt.Out.Answer("Skills", skillsScopeLabels[skillsScope])
+
+	// Only at the production stage, opt-in, defaulting to No.
+	appleDeferred := applePending
+	if stage.PromptID == "connect-apple" {
+		rt.Out.Title("Step 4 · Apple (optional)")
+		if offerProductionApple(cmd, rt, dir, platform) {
+			appleDeferred = false
+			stage = detectSetupStage(cmd, rt, platform)
+			rt.Out.Field("Stage", stage.Label)
+		}
+	}
+
+	prompt := setupAgentPrompt(rt, stage, appleDeferred)
 
 	rt.Out.Plan([]string{
-		"Install/update the RevenueCat AI Toolkit skills for " + choice.Name,
+		"Install the RevenueCat AI Toolkit skills for " + choice.Name,
 		"Configure the RevenueCat MCP for " + choice.Name,
-		"Launch " + choice.Name + " with the \"" + stage.PromptID + "\" prompt (takes over this terminal)",
+		"Launch " + choice.Name + " to build your Test Store catalog, paywall, and SDK integration",
 	})
+	if appleDeferred {
+		rt.Out.Info("Apple is deferred — the agent finishes everything that doesn't need it, then hands you the exact commands to connect App Store Connect when you're ready to ship.")
+	}
 	if err := confirmOrAbort(rt, "Launch "+choice.Name+" now?"); err != nil {
 		return err
 	}
@@ -286,6 +284,38 @@ func runSetup(cmd *cobra.Command) error {
 	agent := exec.CommandContext(cmd.Context(), choice.Binary, choice.LaunchArgs(prompt, autonomy)...)
 	agent.Stdin, agent.Stdout, agent.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return agent.Run()
+}
+
+var autonomyLabels = map[string]string{
+	autonomyTrusted: "run freely (rc, edits, builds pre-approved)",
+	autonomyManual:  "ask before each step",
+	autonomyFull:    "no approvals",
+}
+
+var skillsScopeLabels = map[string]string{
+	"project": "this project only",
+	"global":  "global",
+}
+
+func setupAccountLabel(rt *Runtime) string {
+	if rt.Config == nil || rt.Config.BearerToken() == "" {
+		return "not logged in"
+	}
+	if rt.Config.AccountEmail != "" {
+		return rt.Config.AccountEmail
+	}
+	return "logged in"
+}
+
+// setupAgentPrompt is the starter prompt handed to the agent. When Apple is
+// deferred it tells the agent to finish everything else and list the Apple
+// steps as remaining work rather than waiting on sign-in.
+func setupAgentPrompt(rt *Runtime, stage setupStage, appleDeferred bool) string {
+	prompt := starterPromptByID(stage.PromptID) + setupToolingNote(rt)
+	if appleDeferred {
+		prompt += "\n\nApple: I have deliberately deferred connecting my Apple account. Do NOT pause, wait, or poll for Apple credentials at any point — complete every stage that does not require Apple (Test Store catalog, paywall, SDK integration, build verification) and finish your run by listing the Apple steps as remaining work with the exact commands I should run later."
+	}
+	return prompt
 }
 
 // setupStage is where this project stands in the onboarding journey; it

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -302,23 +302,37 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
 		optNewProject = iota
 		optExistingProject
 		optSwitchAccount
+		optContinue
 	)
 	for {
+		active := rt.Config != nil && rt.Config.ProjectID != ""
+		title := "Create a new RevenueCat project for " + filepath.Base(dir) + "?"
+		opts := []huh.Option[int]{
+			huh.NewOption("Yes — new project", optNewProject),
+			huh.NewOption("Use an existing project", optExistingProject),
+			huh.NewOption("Switch account", optSwitchAccount),
+		}
 		choice := optNewProject
+		if active {
+			// resuming a project: continuing keeps it (a new project here would orphan the old one)
+			title = "Continue setting up under your active project, or start fresh?"
+			opts = []huh.Option[int]{
+				huh.NewOption("Continue with "+activeProjectLabel(cmd, rt), optContinue),
+				huh.NewOption("New project for "+filepath.Base(dir), optNewProject),
+				huh.NewOption("Use a different project", optExistingProject),
+				huh.NewOption("Switch account", optSwitchAccount),
+			}
+			choice = optContinue
+		}
 		if err := tui.Form(false).
-			Field(huh.NewSelect[int]().
-				Title("Create a new RevenueCat project for "+filepath.Base(dir)+"?").
-				Options(
-					huh.NewOption("Yes — new project", optNewProject),
-					huh.NewOption("Use an existing project", optExistingProject),
-					huh.NewOption("Switch account", optSwitchAccount),
-				).
-				Value(&choice)).
+			Field(huh.NewSelect[int]().Title(title).Options(opts...).Value(&choice)).
 			Run(); err != nil {
 			return err
 		}
 
 		switch choice {
+		case optContinue:
+			return nil
 		case optNewProject:
 			// persist the clear so the agent's fresh rc process doesn't reload the old active project
 			rt.Config.ProjectID = ""
@@ -343,6 +357,20 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
 			}
 		}
 	}
+}
+
+// activeProjectLabel resolves the active project's name via the API, falling
+// back to the ID.
+func activeProjectLabel(cmd *cobra.Command, rt *Runtime) string {
+	id := rt.Config.ProjectID
+	client, err := rt.API()
+	if err != nil {
+		return id
+	}
+	if p, err := client.Projects.Get(cmd.Context(), id); err == nil && p.Name != "" {
+		return p.Name + " (" + id + ")"
+	}
+	return id
 }
 
 // setupAgentPrompt is the starter prompt handed to the agent, with the

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/revenuecat/cli/internal/api"
+	"github.com/revenuecat/cli/internal/config"
 	"github.com/revenuecat/cli/internal/output"
 	"github.com/revenuecat/cli/internal/tui"
 )
@@ -121,7 +122,7 @@ the step-by-step commands in the docs.`,
 
 func runSetup(cmd *cobra.Command) error {
 	rt := RuntimeFrom(cmd.Context())
-	if rt.Globals.NoInput || !tui.IsInteractive() {
+	if rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
 		return runSetupAgentPrompt(cmd, rt)
 	}
 
@@ -319,13 +320,14 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
 
 		switch choice {
 		case optNewProject:
-			rt.Config.ProjectID = "" // agent (or Apple prep) creates a fresh project
+			// persist the clear so the agent's fresh rc process doesn't reload the old active project
+			rt.Config.ProjectID = ""
+			_ = config.Save(rt.Globals.Profile, rt.Config)
 			return nil
 		case optExistingProject:
 			use, _, err := cmd.Root().Find([]string{"projects", "use"})
 			if err != nil || use == nil {
-				rt.Out.Warn("Couldn't open the project picker — run `rc projects use` and start again.")
-				return nil
+				return fmt.Errorf("couldn't open the project picker — run `rc projects use`, then rerun setup")
 			}
 			use.SetContext(cmd.Context())
 			if err := use.RunE(use, nil); err != nil {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -149,8 +149,11 @@ func runSetup(cmd *cobra.Command) error {
 		justAuthed = true
 	}
 
+	newProjectPending := false
 	if rt.Config != nil && rt.Config.BearerToken() != "" {
-		if err := confirmSetupAccount(cmd, rt, dir, justAuthed); err != nil {
+		var err error
+		newProjectPending, err = confirmSetupAccount(cmd, rt, dir, justAuthed)
+		if err != nil {
 			return err
 		}
 	}
@@ -240,6 +243,13 @@ func runSetup(cmd *cobra.Command) error {
 		return err
 	}
 
+	// deferred to here so canceling setup above doesn't wipe the active project
+	if newProjectPending {
+		if err := config.Save(rt.Globals.Profile, rt.Config); err != nil {
+			rt.Out.Warn("Couldn't save the cleared project to your profile: " + err.Error())
+		}
+	}
+
 	rt.Out.Info("Installing the RevenueCat AI Toolkit skills…")
 	toolkitSource := officialToolkitSource
 	if branch := os.Getenv("RC_SKILLS_BRANCH"); branch != "" {
@@ -291,7 +301,7 @@ var skillsScopeLabels = map[string]string{
 
 // confirmSetupAccount confirms the account and picks the project for this app,
 // defaulting a new app to a fresh project rather than the active one.
-func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string, justAuthed bool) error {
+func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string, justAuthed bool) (newProjectPending bool, err error) {
 	const (
 		optNewProject = iota
 		optExistingProject
@@ -322,33 +332,32 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string, justAuthed
 		if err := tui.Form(false).
 			Field(huh.NewSelect[int]().Title(title).Options(opts...).Value(&choice)).
 			Run(); err != nil {
-			return err
+			return false, err
 		}
 
 		switch choice {
 		case optContinue:
-			return nil
+			return false, nil
 		case optNewProject:
-			// persist the clear so the agent's fresh rc process doesn't reload the old active project
+			// persisted after launch is confirmed, not here
 			rt.Config.ProjectID = ""
-			_ = config.Save(rt.Globals.Profile, rt.Config)
-			return nil
+			return true, nil
 		case optExistingProject:
 			use, _, err := cmd.Root().Find([]string{"projects", "use"})
 			if err != nil || use == nil {
-				return fmt.Errorf("couldn't open the project picker — run `rc projects use`, then rerun setup")
+				return false, fmt.Errorf("couldn't open the project picker — run `rc projects use`, then rerun setup")
 			}
 			use.SetContext(cmd.Context())
 			if err := use.RunE(use, nil); err != nil {
 				rt.Out.Warn("Project not changed: " + err.Error())
 				continue
 			}
-			return nil
+			return false, nil
 		case optSwitchAccount:
 			rt.Config.AccountEmail = ""
 			rt.Config.AccountName = ""
 			if err := loginWithOAuth(cmd.Context(), rt); err != nil {
-				return err
+				return false, err
 			}
 		}
 	}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -134,12 +134,8 @@ func runSetup(cmd *cobra.Command) error {
 	platform := platformFromLabel(projectLabel)
 	agents := detectAgents()
 
-	paint := rt.Out.Paint
-	rt.Out.Blank()
-	fmt.Fprintln(cmd.ErrOrStderr(), rt.Out.Panel(
-		paint(output.ToneAccent, "RevenueCat setup")+paint(output.ToneDim, "  ·  "+filepath.Base(dir)),
-		paint(output.ToneDim, projectLabel+"  ·  "+collapseHome(dir)),
-	))
+	rt.Out.Title("RevenueCat setup  ·  " + filepath.Base(dir))
+	fmt.Fprintln(cmd.ErrOrStderr(), "  "+rt.Out.Paint(output.ToneDim, projectLabel+"  ·  "+collapseHome(dir)))
 	rt.Out.Lead("An AI agent with RevenueCat's skills sets up your paywall and in-app purchases here — you approve each step. Apple is optional and comes later.")
 	if len(agents) == 0 {
 		rt.Out.Field("Agents", "none found", "install Claude Code, Codex, Cursor, or Gemini CLI, or copy the prompt below")
@@ -314,19 +310,14 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
 		optSwitchAccount
 	)
 	for {
-		existing := "Use an existing project"
-		if rt.Config != nil && rt.Config.ProjectID != "" {
-			existing += " (currently " + setupProjectLabel(cmd, rt) + ")"
-		}
-
 		choice := optNewProject
 		if err := tui.Form(false).
 			Field(huh.NewSelect[int]().
-				Title("Set up as "+setupAccountLabel(rt)+"?").
+				Title("Create a new RevenueCat project for "+filepath.Base(dir)+"?").
 				Options(
-					huh.NewOption("New project for "+filepath.Base(dir), optNewProject),
-					huh.NewOption(existing, optExistingProject),
-					huh.NewOption("No — switch account", optSwitchAccount),
+					huh.NewOption("Yes — new project", optNewProject),
+					huh.NewOption("Use an existing project", optExistingProject),
+					huh.NewOption("Switch account", optSwitchAccount),
 				).
 				Value(&choice)).
 			Run(); err != nil {
@@ -357,33 +348,6 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
 			}
 		}
 	}
-}
-
-// setupProjectLabel resolves the active project's name via the API, which also
-// verifies the token can reach it. Falls back to the ID when it can't.
-func setupProjectLabel(cmd *cobra.Command, rt *Runtime) string {
-	if rt.Config == nil || rt.Config.ProjectID == "" {
-		return "none selected"
-	}
-	client, err := rt.API()
-	if err != nil {
-		return rt.Config.ProjectID
-	}
-	p, err := client.Projects.Get(cmd.Context(), rt.Config.ProjectID)
-	if err != nil {
-		return rt.Config.ProjectID + " (can't verify — check the account)"
-	}
-	return p.Name + " (" + rt.Config.ProjectID + ")"
-}
-
-func setupAccountLabel(rt *Runtime) string {
-	if rt.Config == nil || rt.Config.BearerToken() == "" {
-		return "not logged in"
-	}
-	if rt.Config.AccountEmail != "" {
-		return rt.Config.AccountEmail
-	}
-	return "logged in"
 }
 
 // setupAgentPrompt is the starter prompt handed to the agent. When Apple is

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/revenuecat/cli/internal/api"
+	"github.com/revenuecat/cli/internal/output"
 	"github.com/revenuecat/cli/internal/tui"
 )
 
@@ -133,9 +134,13 @@ func runSetup(cmd *cobra.Command) error {
 	platform := platformFromLabel(projectLabel)
 	agents := detectAgents()
 
-	rt.Out.Title("RevenueCat setup — " + filepath.Base(dir))
+	paint := rt.Out.Paint
+	rt.Out.Blank()
+	fmt.Fprintln(cmd.ErrOrStderr(), rt.Out.Panel(
+		paint(output.ToneAccent, "RevenueCat setup")+paint(output.ToneDim, "  ·  "+filepath.Base(dir)),
+		paint(output.ToneDim, projectLabel+"  ·  "+collapseHome(dir)),
+	))
 	rt.Out.Lead("An AI agent with RevenueCat's skills sets up your paywall and in-app purchases here — you approve each step. Apple is optional and comes later.")
-	rt.Out.Field("Directory", collapseHome(dir), projectLabel)
 	if len(agents) == 0 {
 		rt.Out.Field("Agents", "none found", "install Claude Code, Codex, Cursor, or Gemini CLI, or copy the prompt below")
 	}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -134,17 +134,10 @@ func runSetup(cmd *cobra.Command) error {
 	agents := detectAgents()
 
 	rt.Out.Title("RevenueCat setup — " + filepath.Base(dir))
-	rt.Out.Lead("Installs RevenueCat's skills into an AI agent and lets it build your Test Store catalog, paywall, and SDK integration — you approve each step. Connecting Apple for the real App Store is optional; skip it to build on the Test Store first.")
+	rt.Out.Lead("An AI agent with RevenueCat's skills sets up your paywall and in-app purchases here — you approve each step. Apple is optional and comes later.")
 	rt.Out.Field("Directory", collapseHome(dir), projectLabel)
-	rt.Out.Field("Account", setupAccountLabel(rt))
-	if len(agents) > 0 {
-		names := make([]string, 0, len(agents))
-		for _, a := range agents {
-			names = append(names, a.Name)
-		}
-		rt.Out.Field("Agents found", strings.Join(names, ", "))
-	} else {
-		rt.Out.Field("Agents found", "none", "install Claude Code, Codex, Cursor, or Gemini CLI for agent-driven setup")
+	if len(agents) == 0 {
+		rt.Out.Field("Agents", "none found", "install Claude Code, Codex, Cursor, or Gemini CLI, or copy the prompt below")
 	}
 
 	if rt.Config == nil || rt.Config.BearerToken() == "" {
@@ -316,15 +309,16 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime) error {
 		optSwitchProject
 	)
 	for {
-		rt.Out.Title("Confirm your account")
-		rt.Out.Field("Account", setupAccountLabel(rt))
-		rt.Out.Field("Project", setupProjectLabel(cmd, rt))
+		title := "Set up as " + setupAccountLabel(rt)
+		if rt.Config != nil && rt.Config.ProjectID != "" {
+			title += " in " + setupProjectLabel(cmd, rt)
+		}
+		title += "?"
 
 		choice := optContinue
 		if err := tui.Form(false).
 			Field(huh.NewSelect[int]().
-				Title("Set up under this account?").
-				Description("Everything the agent creates — project, apps, catalog — lands here.").
+				Title(title).
 				Options(
 					huh.NewOption("Yes, continue", optContinue),
 					huh.NewOption("Switch account (log out and back in)", optSwitchAccount),

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -314,15 +314,14 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
 		}
 		choice := optNewProject
 		if active {
-			// resuming a project: continuing keeps it (a new project here would orphan the old one)
-			title = "Continue setting up under your active project, or start fresh?"
+			// New stays the default: the active project is profile-global, not this dir's
+			title = "Set up " + filepath.Base(dir) + " — new project, or continue an existing one?"
 			opts = []huh.Option[int]{
-				huh.NewOption("Continue with "+activeProjectLabel(cmd, rt), optContinue),
 				huh.NewOption("New project for "+filepath.Base(dir), optNewProject),
+				huh.NewOption("Continue with "+activeProjectLabel(cmd, rt), optContinue),
 				huh.NewOption("Use a different project", optExistingProject),
 				huh.NewOption("Switch account", optSwitchAccount),
 			}
-			choice = optContinue
 		}
 		if err := tui.Form(false).
 			Field(huh.NewSelect[int]().Title(title).Options(opts...).Value(&choice)).

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -152,7 +152,7 @@ func runSetup(cmd *cobra.Command) error {
 	}
 
 	if rt.Config != nil && rt.Config.BearerToken() != "" {
-		if err := confirmSetupAccount(cmd, rt); err != nil {
+		if err := confirmSetupAccount(cmd, rt, dir); err != nil {
 			return err
 		}
 	}
@@ -303,31 +303,30 @@ var skillsScopeLabels = map[string]string{
 	"global":  "global",
 }
 
-// confirmSetupAccount gates the flow on the right account/project before the
-// agent creates anything under them. Loops until the user continues; switching
-// account clears the cached label (it can be stale) so a wrong email is never
-// shown as confirmed.
-func confirmSetupAccount(cmd *cobra.Command, rt *Runtime) error {
+// confirmSetupAccount confirms the account and picks the project for this app
+// before handing off. A new app defaults to a fresh project rather than the
+// CLI's globally-active one, which would otherwise set this app up under an
+// unrelated project.
+func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
 	const (
-		optContinue = iota
+		optNewProject = iota
+		optExistingProject
 		optSwitchAccount
-		optSwitchProject
 	)
 	for {
-		title := "Set up as " + setupAccountLabel(rt)
+		existing := "Use an existing project"
 		if rt.Config != nil && rt.Config.ProjectID != "" {
-			title += " in " + setupProjectLabel(cmd, rt)
+			existing += " (currently " + setupProjectLabel(cmd, rt) + ")"
 		}
-		title += "?"
 
-		choice := optContinue
+		choice := optNewProject
 		if err := tui.Form(false).
 			Field(huh.NewSelect[int]().
-				Title(title).
+				Title("Set up as "+setupAccountLabel(rt)+"?").
 				Options(
-					huh.NewOption("Yes, continue", optContinue),
-					huh.NewOption("Switch account (log out and back in)", optSwitchAccount),
-					huh.NewOption("Switch project", optSwitchProject),
+					huh.NewOption("New project for "+filepath.Base(dir), optNewProject),
+					huh.NewOption(existing, optExistingProject),
+					huh.NewOption("No — switch account", optSwitchAccount),
 				).
 				Value(&choice)).
 			Run(); err != nil {
@@ -335,15 +334,10 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime) error {
 		}
 
 		switch choice {
-		case optContinue:
+		case optNewProject:
+			rt.Config.ProjectID = "" // agent (or Apple prep) creates a fresh project
 			return nil
-		case optSwitchAccount:
-			rt.Config.AccountEmail = ""
-			rt.Config.AccountName = ""
-			if err := loginWithOAuth(cmd.Context(), rt); err != nil {
-				return err
-			}
-		case optSwitchProject:
+		case optExistingProject:
 			use, _, err := cmd.Root().Find([]string{"projects", "use"})
 			if err != nil || use == nil {
 				rt.Out.Warn("Couldn't open the project picker — run `rc projects use` and start again.")
@@ -352,6 +346,14 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime) error {
 			use.SetContext(cmd.Context())
 			if err := use.RunE(use, nil); err != nil {
 				rt.Out.Warn("Project not changed: " + err.Error())
+				continue
+			}
+			return nil
+		case optSwitchAccount:
+			rt.Config.AccountEmail = ""
+			rt.Config.AccountName = ""
+			if err := loginWithOAuth(cmd.Context(), rt); err != nil {
+				return err
 			}
 		}
 	}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -168,9 +168,7 @@ func runSetup(cmd *cobra.Command) error {
 		}
 	}
 
-	// Apple is the last mile — the agent builds everything on the Test Store
-	// first; it's connected only at the production stage, and until then the
-	// agent is told not to wait for it.
+	// Apple runs before the handoff (the agent can't do 2FA); deferred until then.
 	applePending := (platform == "ios" || platform == "cross") &&
 		(stage.PromptID == "test-store-ready" || stage.PromptID == "connect-apple")
 
@@ -222,9 +220,7 @@ func runSetup(cmd *cobra.Command) error {
 	}
 	rt.Out.Answer("Skills", skillsScopeLabels[skillsScope])
 
-	// Apple is a human 2FA action the agent can't do, so it happens here,
-	// before the handoff — optional and defaulting to No. Skipping defers it:
-	// the agent builds on the Test Store and lists the Apple steps for later.
+	// human-only (2FA), optional, offered pre-handoff and defaulting to No
 	appleDeferred := applePending
 	if applePending {
 		rt.Out.Title("Step 4 · Apple (optional)")
@@ -298,10 +294,8 @@ var skillsScopeLabels = map[string]string{
 	"global":  "global",
 }
 
-// confirmSetupAccount confirms the account and picks the project for this app
-// before handing off. A new app defaults to a fresh project rather than the
-// CLI's globally-active one, which would otherwise set this app up under an
-// unrelated project.
+// confirmSetupAccount confirms the account and picks the project for this app,
+// defaulting a new app to a fresh project rather than the active one.
 func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
 	const (
 		optNewProject = iota
@@ -349,9 +343,8 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
 	}
 }
 
-// setupAgentPrompt is the starter prompt handed to the agent. When Apple is
-// deferred it tells the agent to finish everything else and list the Apple
-// steps as remaining work rather than waiting on sign-in.
+// setupAgentPrompt is the starter prompt handed to the agent, with the
+// Apple-deferred instruction appended when relevant.
 func setupAgentPrompt(rt *Runtime, stage setupStage, appleDeferred bool) string {
 	prompt := starterPromptByID(stage.PromptID) + setupToolingNote(rt)
 	if appleDeferred {
@@ -360,9 +353,8 @@ func setupAgentPrompt(rt *Runtime, stage setupStage, appleDeferred bool) string 
 	return prompt
 }
 
-// runSetupAgentPrompt handles `rc setup` run non-interactively (by an agent):
-// instead of launching a nested agent, it emits the stage-aware setup prompt
-// for the caller to follow, with the human-only steps called out.
+// runSetupAgentPrompt emits the stage-aware setup prompt for a non-interactive
+// (agent) run instead of launching a nested agent.
 func runSetupAgentPrompt(cmd *cobra.Command, rt *Runtime) error {
 	dir, err := os.Getwd()
 	if err != nil {
@@ -390,9 +382,8 @@ func runSetupAgentPrompt(cmd *cobra.Command, rt *Runtime) error {
 	return nil
 }
 
-// setupAuthHandbackNote tells an agent how to handle auth: it can create a new
-// account without a browser, but logging in to an existing one is a human step
-// it must hand back.
+// setupAuthHandbackNote appends auth guidance when logged out: headless signup
+// is fine, but existing-account login is a human step to hand back.
 func setupAuthHandbackNote(authed bool) string {
 	if authed {
 		return ""

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/revenuecat/cli/internal/api"
 	"github.com/revenuecat/cli/internal/config"
-	"github.com/revenuecat/cli/internal/output"
 	"github.com/revenuecat/cli/internal/tui"
 )
 
@@ -135,20 +134,23 @@ func runSetup(cmd *cobra.Command) error {
 	agents := detectAgents()
 
 	rt.Out.Title("RevenueCat setup  ·  " + filepath.Base(dir))
-	fmt.Fprintln(cmd.ErrOrStderr(), "  "+rt.Out.Paint(output.ToneDim, projectLabel+"  ·  "+collapseHome(dir)))
-	rt.Out.Lead("An AI agent with RevenueCat's skills sets up your paywall and in-app purchases here — you approve each step. Apple is optional and comes later.")
+	rt.Out.Lead("An AI agent sets up RevenueCat for this app — you approve each step.")
+	rt.Out.Field("Project", projectLabel)
+	rt.Out.Field("Location", collapseHome(dir))
 	if len(agents) == 0 {
 		rt.Out.Field("Agents", "none found", "install Claude Code, Codex, Cursor, or Gemini CLI, or copy the prompt below")
 	}
 
+	justAuthed := false
 	if rt.Config == nil || rt.Config.BearerToken() == "" {
 		if err := setupAuthenticate(cmd, rt); err != nil {
 			return err
 		}
+		justAuthed = true
 	}
 
 	if rt.Config != nil && rt.Config.BearerToken() != "" {
-		if err := confirmSetupAccount(cmd, rt, dir); err != nil {
+		if err := confirmSetupAccount(cmd, rt, dir, justAuthed); err != nil {
 			return err
 		}
 	}
@@ -297,7 +299,7 @@ var skillsScopeLabels = map[string]string{
 
 // confirmSetupAccount confirms the account and picks the project for this app,
 // defaulting a new app to a fresh project rather than the active one.
-func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
+func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string, justAuthed bool) error {
 	const (
 		optNewProject = iota
 		optExistingProject
@@ -310,7 +312,6 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
 		opts := []huh.Option[int]{
 			huh.NewOption("Yes — new project", optNewProject),
 			huh.NewOption("Use an existing project", optExistingProject),
-			huh.NewOption("Switch account", optSwitchAccount),
 		}
 		choice := optNewProject
 		if active {
@@ -320,8 +321,11 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string) error {
 				huh.NewOption("New project for "+filepath.Base(dir), optNewProject),
 				huh.NewOption("Continue with "+activeProjectLabel(cmd, rt), optContinue),
 				huh.NewOption("Use a different project", optExistingProject),
-				huh.NewOption("Switch account", optSwitchAccount),
 			}
+		}
+		// Switching accounts only makes sense if we didn't just log them in.
+		if !justAuthed {
+			opts = append(opts, huh.NewOption("Switch account", optSwitchAccount))
 		}
 		if err := tui.Form(false).
 			Field(huh.NewSelect[int]().Title(title).Options(opts...).Value(&choice)).
@@ -549,8 +553,7 @@ func setupAuthenticate(cmd *cobra.Command, rt *Runtime) error {
 	choice := optLogin
 	if err := tui.Form(false).
 		Field(huh.NewSelect[int]().
-			Title("You're not logged in. Setup logs you in, then launches the agent.").
-			Description("Browser sign-in is a human step — the agent can't do it. To get the prompt without logging in, run rc skills prompts instead.").
+			Title("You're not logged in — how would you like to sign in?").
 			Options(
 				huh.NewOption("Log in (opens your browser)", optLogin),
 				huh.NewOption("Create a RevenueCat account", optSignup),

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -191,15 +191,15 @@ func runSetup(cmd *cobra.Command) error {
 	rt.Out.Answer("Agent", choice.Name)
 
 	rt.Out.Title("Step 2 · Autonomy")
-	autonomy := autonomyTrusted
+	autonomy := autonomyFull
 	if err := tui.Form(false).
 		Field(huh.NewSelect[string]().
 			Title("How much can "+choice.Name+" do without stopping to ask?").
-			Description("You can interrupt anytime. \"Run freely\" pre-approves rc commands, file edits, and builds.").
+			Description("You can interrupt anytime.").
 			Options(
-				huh.NewOption("Run freely — pre-approve rc, file edits, and builds", autonomyTrusted),
+				huh.NewOption("Run freely — no approval prompts", autonomyFull),
+				huh.NewOption("Pre-approve rc, edits, and builds; ask for anything unusual", autonomyTrusted),
 				huh.NewOption("Ask me before each step", autonomyManual),
-				huh.NewOption("No approvals at all", autonomyFull),
 			).
 			Value(&autonomy)).
 		Run(); err != nil {
@@ -223,16 +223,8 @@ func runSetup(cmd *cobra.Command) error {
 	}
 	rt.Out.Answer("Skills", skillsScopeLabels[skillsScope])
 
-	// human-only (2FA), optional, offered pre-handoff and defaulting to No
+	// Apple needs a browser + 2FA; setup always defers it to the agent hand-back.
 	appleDeferred := applePending
-	if applePending {
-		rt.Out.Title("Step 4 · Apple (optional)")
-		if offerApple(cmd, rt, dir, platform) {
-			appleDeferred = false
-			stage = detectSetupStage(cmd, rt, platform)
-			rt.Out.Field("Stage", stage.Label)
-		}
-	}
 
 	prompt := setupAgentPrompt(rt, stage, appleDeferred)
 
@@ -287,9 +279,9 @@ func runSetup(cmd *cobra.Command) error {
 }
 
 var autonomyLabels = map[string]string{
-	autonomyTrusted: "run freely (rc, edits, builds pre-approved)",
+	autonomyTrusted: "pre-approve rc, edits, builds; ask for the rest",
 	autonomyManual:  "ask before each step",
-	autonomyFull:    "no approvals",
+	autonomyFull:    "run freely (no approval prompts)",
 }
 
 var skillsScopeLabels = map[string]string{

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -486,42 +486,26 @@ func setupAuthenticate(cmd *cobra.Command, rt *Runtime) error {
 	const (
 		optLogin = iota
 		optSignup
-		optSkip
 	)
 	choice := optLogin
 	if err := tui.Form(false).
 		Field(huh.NewSelect[int]().
-			Title("You're not logged in. What would you like to do?").
+			Title("You're not logged in. Setup logs you in, then launches the agent.").
+			Description("Browser sign-in is a human step — the agent can't do it. To get the prompt without logging in, run rc skills prompts instead.").
 			Options(
 				huh.NewOption("Log in (opens your browser)", optLogin),
 				huh.NewOption("Create a RevenueCat account", optSignup),
-				huh.NewOption("Skip — the agent can handle it later", optSkip),
 			).
 			Value(&choice)).
 		Run(); err != nil {
 		return err
 	}
-	switch choice {
-	case optLogin:
-		if err := loginWithOAuth(cmd.Context(), rt); err != nil {
-			return err
-		}
-	case optSignup:
+	if choice == optSignup {
 		signup := newAuthSignupCmd()
 		signup.SetContext(cmd.Context())
-		if err := signup.RunE(signup, nil); err != nil {
-			return err
-		}
-	default:
-		rt.Out.Answer("Account", "skipped — the agent will sign you in or up")
-		return nil
+		return signup.RunE(signup, nil)
 	}
-	account := "logged in"
-	if rt.Config != nil && rt.Config.AccountEmail != "" {
-		account = rt.Config.AccountEmail
-	}
-	rt.Out.Answer("Account", account)
-	return nil
+	return loginWithOAuth(cmd.Context(), rt)
 }
 
 func starterPromptByID(id string) string {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -134,7 +134,7 @@ func runSetup(cmd *cobra.Command) error {
 	agents := detectAgents()
 
 	rt.Out.Title("RevenueCat setup — " + filepath.Base(dir))
-	rt.Out.Lead("Installs RevenueCat's skills into an AI agent and lets it build your Test Store catalog, paywall, and SDK integration — you approve each step. Connecting Apple for the real App Store comes later, when you're ready to ship.")
+	rt.Out.Lead("Installs RevenueCat's skills into an AI agent and lets it build your Test Store catalog, paywall, and SDK integration — you approve each step. Connecting Apple for the real App Store is optional; skip it to build on the Test Store first.")
 	rt.Out.Field("Directory", collapseHome(dir), projectLabel)
 	rt.Out.Field("Account", setupAccountLabel(rt))
 	if len(agents) > 0 {
@@ -223,11 +223,13 @@ func runSetup(cmd *cobra.Command) error {
 	}
 	rt.Out.Answer("Skills", skillsScopeLabels[skillsScope])
 
-	// Only at the production stage, opt-in, defaulting to No.
+	// Apple is a human 2FA action the agent can't do, so it happens here,
+	// before the handoff — optional and defaulting to No. Skipping defers it:
+	// the agent builds on the Test Store and lists the Apple steps for later.
 	appleDeferred := applePending
-	if stage.PromptID == "connect-apple" {
+	if applePending {
 		rt.Out.Title("Step 4 · Apple (optional)")
-		if offerProductionApple(cmd, rt, dir, platform) {
+		if offerApple(cmd, rt, dir, platform) {
 			appleDeferred = false
 			stage = detectSetupStage(cmd, rt, platform)
 			rt.Out.Field("Stage", stage.Label)

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -422,7 +423,11 @@ func setupAuthHandbackNote(authed bool) string {
 	if authed {
 		return ""
 	}
-	return "\n\nAuth: you are not logged in. If the user has no RevenueCat account, create one without a browser: `rc auth signup --email <user's email> --name \"<user's name>\" --generate-password --save-password --accept-terms --no-input --json` — but only after the user explicitly agrees to the RevenueCat Terms of Service and Privacy Policy. If the user already has an account, STOP and ask them to run `rc auth login` (a browser sign-in you cannot perform), then continue."
+	savePassword := ""
+	if runtime.GOOS == "darwin" {
+		savePassword = " --save-password"
+	}
+	return "\n\nAuth: you are not logged in. If the user has no RevenueCat account, create one without a browser: `rc auth signup --email <user's email> --name \"<user's name>\" --generate-password" + savePassword + " --accept-terms --no-input --json` — but only after the user explicitly agrees to the RevenueCat Terms of Service and Privacy Policy. If the user already has an account, STOP and ask them to run `rc auth login` (a browser sign-in you cannot perform), then continue."
 }
 
 // setupStage is where this project stands in the onboarding journey; it

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -153,6 +153,12 @@ func runSetup(cmd *cobra.Command) error {
 		}
 	}
 
+	if rt.Config != nil && rt.Config.BearerToken() != "" {
+		if err := confirmSetupAccount(cmd, rt); err != nil {
+			return err
+		}
+	}
+
 	rt.Out.Info("Checking where this project stands…")
 	stage := detectSetupStage(cmd, rt, platform)
 	rt.Out.Field("Stage", stage.Label)
@@ -297,6 +303,76 @@ var autonomyLabels = map[string]string{
 var skillsScopeLabels = map[string]string{
 	"project": "this project only",
 	"global":  "global",
+}
+
+// confirmSetupAccount gates the flow on the right account/project before the
+// agent creates anything under them. Loops until the user continues; switching
+// account clears the cached label (it can be stale) so a wrong email is never
+// shown as confirmed.
+func confirmSetupAccount(cmd *cobra.Command, rt *Runtime) error {
+	const (
+		optContinue = iota
+		optSwitchAccount
+		optSwitchProject
+	)
+	for {
+		rt.Out.Title("Confirm your account")
+		rt.Out.Field("Account", setupAccountLabel(rt))
+		rt.Out.Field("Project", setupProjectLabel(cmd, rt))
+
+		choice := optContinue
+		if err := tui.Form(false).
+			Field(huh.NewSelect[int]().
+				Title("Set up under this account?").
+				Description("Everything the agent creates — project, apps, catalog — lands here.").
+				Options(
+					huh.NewOption("Yes, continue", optContinue),
+					huh.NewOption("Switch account (log out and back in)", optSwitchAccount),
+					huh.NewOption("Switch project", optSwitchProject),
+				).
+				Value(&choice)).
+			Run(); err != nil {
+			return err
+		}
+
+		switch choice {
+		case optContinue:
+			return nil
+		case optSwitchAccount:
+			rt.Config.AccountEmail = ""
+			rt.Config.AccountName = ""
+			if err := loginWithOAuth(cmd.Context(), rt); err != nil {
+				return err
+			}
+		case optSwitchProject:
+			use, _, err := cmd.Root().Find([]string{"projects", "use"})
+			if err != nil || use == nil {
+				rt.Out.Warn("Couldn't open the project picker — run `rc projects use` and start again.")
+				return nil
+			}
+			use.SetContext(cmd.Context())
+			if err := use.RunE(use, nil); err != nil {
+				rt.Out.Warn("Project not changed: " + err.Error())
+			}
+		}
+	}
+}
+
+// setupProjectLabel resolves the active project's name via the API, which also
+// verifies the token can reach it. Falls back to the ID when it can't.
+func setupProjectLabel(cmd *cobra.Command, rt *Runtime) string {
+	if rt.Config == nil || rt.Config.ProjectID == "" {
+		return "none selected"
+	}
+	client, err := rt.API()
+	if err != nil {
+		return rt.Config.ProjectID
+	}
+	p, err := client.Projects.Get(cmd.Context(), rt.Config.ProjectID)
+	if err != nil {
+		return rt.Config.ProjectID + " (can't verify — check the account)"
+	}
+	return p.Name + " (" + rt.Config.ProjectID + ")"
 }
 
 func setupAccountLabel(rt *Runtime) string {

--- a/internal/cli/setup_oneshot.go
+++ b/internal/cli/setup_oneshot.go
@@ -1,25 +1,14 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 
-	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
-
-	"github.com/revenuecat/cli/internal/api"
-	"github.com/revenuecat/cli/internal/config"
-	"github.com/revenuecat/cli/internal/tui"
 )
-
-// One-shot preparation: everything that would interrupt the agent mid-run is
-// a human/auth action, and those happen BEFORE the terminal is handed over —
-// RevenueCat login (already handled), Apple sign-in with 2FA, and MCP
-// authentication for the chosen agent.
 
 const revenueCatMCPURL = "https://mcp.revenuecat.ai/mcp"
 
@@ -56,92 +45,6 @@ func firstBundleID(path string, pattern *regexp.Regexp) string {
 		return id
 	}
 	return ""
-}
-
-// offerApple optionally connects the Apple account (human 2FA) before the
-// handoff, creating the project and App Store app records if missing.
-func offerApple(cmd *cobra.Command, rt *Runtime, dir, platform string) bool {
-	if platform != "ios" && platform != "cross" {
-		return false
-	}
-	if rt.Config == nil || rt.Config.BearerToken() == "" {
-		return false
-	}
-	rt.Out.Info("Connecting Apple lets the agent set up the real App Store too — it signs in to your Apple account (2FA) and creates App Store Connect keys. Skip it and the agent builds everything on the Test Store; connect Apple later with rc apps apple setup.")
-	ok, err := tui.ConfirmDefault(false, "Connect your Apple account now?", false)
-	if err != nil || !ok {
-		return false
-	}
-
-	client, err := rt.API()
-	if err != nil {
-		rt.Out.Warn("Couldn't reach RevenueCat (" + err.Error() + ") — the agent will handle Apple later.")
-		return false
-	}
-	ctx := cmd.Context()
-
-	projectID := rt.Config.ProjectID
-	if projectID == "" {
-		name := filepath.Base(dir)
-		if err := tui.Form(false).
-			Field(huh.NewInput().Title("Project name").Value(&name).Validate(tui.Required("name"))).
-			Run(); err != nil {
-			return false
-		}
-		project, err := client.Projects.Create(ctx, api.ProjectCreate{Name: name})
-		if err != nil {
-			rt.Out.Warn("Couldn't create the project (" + err.Error() + ") — the agent will handle it.")
-			return false
-		}
-		projectID = project.ID
-		rt.Config.ProjectID = projectID
-		if err := config.Save(rt.Globals.Profile, rt.Config); err != nil {
-			rt.Out.Info(fmt.Sprintf("note: couldn't save profile: %v", err))
-		}
-		rt.Out.Answer("Project", name+"  ("+projectID+")")
-	}
-
-	appID, appName := "", ""
-	if apps, err := client.Apps.List(ctx, projectID); err == nil {
-		for _, app := range apps.Items {
-			if app.Type == "app_store" {
-				appID = app.ID
-				break
-			}
-		}
-	}
-	if appID == "" {
-		bundleID := detectBundleID(dir)
-		if err := tui.Form(false).
-			Field(huh.NewInput().Title("Bundle ID").Description("detected from the Xcode project").Value(&bundleID).Validate(tui.Required("bundle ID"))).
-			Run(); err != nil {
-			return false
-		}
-		app, err := client.Apps.Create(ctx, projectID, api.AppCreate{
-			Name:     filepath.Base(dir) + " (App Store)",
-			Type:     "app_store",
-			AppStore: &api.AppStoreAppConfig{BundleID: bundleID},
-		})
-		if err != nil {
-			rt.Out.Warn("Couldn't create the App Store app (" + err.Error() + ") — the agent will handle it.")
-			return false
-		}
-		appID, appName = app.ID, app.Name
-		rt.Out.Answer("App Store app", appName+"  ("+bundleID+")")
-	}
-
-	rt.Out.Blank()
-	apple := newAppsAppleCmd()
-	setupSub, _, err := apple.Find([]string{"setup"})
-	if err != nil {
-		return false
-	}
-	setupSub.SetContext(cmd.Context())
-	if err := setupSub.RunE(setupSub, []string{appID}); err != nil {
-		rt.Out.Warn("Apple setup didn't finish (" + err.Error() + ") — rerun with: rc apps apple setup " + appID)
-		return false
-	}
-	return true
 }
 
 // configureAgentMCP registers the RevenueCat MCP server for the chosen agent

--- a/internal/cli/setup_oneshot.go
+++ b/internal/cli/setup_oneshot.go
@@ -58,19 +58,18 @@ func firstBundleID(path string, pattern *regexp.Regexp) string {
 	return ""
 }
 
-// offerProductionApple connects the Apple account for the real App Store. It's
-// the last mile — offered only at the production stage — and runs before the
-// agent launches so the run never stops for sign-in or 2FA. Creates the
-// project and App Store app records if missing, then runs the guided Apple
-// setup inline.
-func offerProductionApple(cmd *cobra.Command, rt *Runtime, dir, platform string) bool {
+// offerApple optionally connects the Apple account for the real App Store.
+// Apple sign-in is a human 2FA action the launched agent can't perform, so it
+// runs here, before the handoff. Creates the project and App Store app records
+// if missing, then runs the guided Apple setup inline.
+func offerApple(cmd *cobra.Command, rt *Runtime, dir, platform string) bool {
 	if platform != "ios" && platform != "cross" {
 		return false
 	}
 	if rt.Config == nil || rt.Config.BearerToken() == "" {
 		return false
 	}
-	rt.Out.Info("You've done everything the Test Store covers. Connecting Apple lets you sync products to the real App Store — it signs in to your Apple account (2FA) and creates App Store Connect keys.")
+	rt.Out.Info("Connecting Apple lets the agent set up the real App Store too — it signs in to your Apple account (2FA) and creates App Store Connect keys. Skip it and the agent builds everything on the Test Store; connect Apple later with rc apps apple setup.")
 	ok, err := tui.ConfirmDefault(false, "Connect your Apple account now?", false)
 	if err != nil || !ok {
 		return false

--- a/internal/cli/setup_oneshot.go
+++ b/internal/cli/setup_oneshot.go
@@ -58,10 +58,8 @@ func firstBundleID(path string, pattern *regexp.Regexp) string {
 	return ""
 }
 
-// offerApple optionally connects the Apple account for the real App Store.
-// Apple sign-in is a human 2FA action the launched agent can't perform, so it
-// runs here, before the handoff. Creates the project and App Store app records
-// if missing, then runs the guided Apple setup inline.
+// offerApple optionally connects the Apple account (human 2FA) before the
+// handoff, creating the project and App Store app records if missing.
 func offerApple(cmd *cobra.Command, rt *Runtime, dir, platform string) bool {
 	if platform != "ios" && platform != "cross" {
 		return false

--- a/internal/cli/setup_oneshot.go
+++ b/internal/cli/setup_oneshot.go
@@ -58,18 +58,20 @@ func firstBundleID(path string, pattern *regexp.Regexp) string {
 	return ""
 }
 
-// offerOneShotApple connects the Apple account before the agent launches so
-// the run never stops for sign-in or 2FA. Creates the project and App Store
-// app records if they don't exist yet (deterministic work the agent would
-// otherwise redo), then runs the full guided Apple setup inline.
-func offerOneShotApple(cmd *cobra.Command, rt *Runtime, dir, platform string) bool {
+// offerProductionApple connects the Apple account for the real App Store. It's
+// the last mile — offered only at the production stage — and runs before the
+// agent launches so the run never stops for sign-in or 2FA. Creates the
+// project and App Store app records if missing, then runs the guided Apple
+// setup inline.
+func offerProductionApple(cmd *cobra.Command, rt *Runtime, dir, platform string) bool {
 	if platform != "ios" && platform != "cross" {
 		return false
 	}
 	if rt.Config == nil || rt.Config.BearerToken() == "" {
 		return false
 	}
-	ok, err := tui.ConfirmDefault(false, "Connect your Apple account now so the agent can run end to end without stopping?", true)
+	rt.Out.Info("You've done everything the Test Store covers. Connecting Apple lets you sync products to the real App Store — it signs in to your Apple account (2FA) and creates App Store Connect keys.")
+	ok, err := tui.ConfirmDefault(false, "Connect your Apple account now?", false)
 	if err != nil || !ok {
 		return false
 	}


### PR DESCRIPTION
`rc setup` forced the full Apple / App Store Connect connection (sign-in + 2FA + key creation) as ~step 2, default yes, before you'd created a project or picked an agent.

Apple sign-in is a **human 2FA action the launched agent can't perform**, so it has to happen *before* the agent takes over the terminal — it can't be deferred to a later "agent milestone." The fix keeps it pre-handoff but makes it **optional and default No**, with the tradeoff spelled out:

- **Connect now** → the agent goes end-to-end, including the real App Store.
- **Skip** (default) → the agent builds everything on the Test Store, and lists the exact `rc apps apple setup` commands to connect Apple later.

Offered on any iOS/cross run, after the agent/autonomy/skills choices. Also reworks the flow into clear numbered steps with what/why descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Onboarding and auth flows change materially (project defaults, no Apple pre-connect, new non-interactive contract), but changes stay in CLI UX and prompts rather than API or credential handling.
> 
> **Overview**
> **`rc setup`** is reworked into a clearer stepped interactive flow (agent → autonomy → skills) and **stops forcing an early Apple / App Store Connect connection** before the agent runs.
> 
> The pre-handoff **one-shot Apple setup** (`offerOneShotApple`) is removed. For iOS/cross projects at the right stage, Apple is **always deferred**: the agent prompt tells the model to finish Test Store catalog, paywall, and SDK work and list the exact `rc apps apple setup` commands for later. Users see an explicit message that Apple is deferred until they’re ready to ship.
> 
> **Account and project handling** is added before stage detection: logged-out users must log in or sign up (no “skip — agent handles it”). After auth, **`confirmSetupAccount`** defaults new apps to a **fresh project** (clears active `ProjectID` only after launch is confirmed). Users can continue the active project, pick another via `projects use`, or switch accounts.
> 
> **Non-interactive / agent runs** (`--json`, `--no-input`, or non-TTY) now emit the stage-aware setup prompt via **`runSetupAgentPrompt`** (JSON includes `prompt`, `stage`, `authenticated`, `apple_deferred`, `platform`) instead of failing as “use skills directly.” Logged-out agent runs get an **`setupAuthHandbackNote`** with headless signup vs human `rc auth login` guidance.
> 
> Smaller UX fixes: signup shows Keychain / forgot-password info when choosing generated passwords; **`huh.ErrUserAborted`** exits cleanly with code **130** and “Cancelled.” on stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8023536c8f4e884693513d325fe3f0ce49ba646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->