### PR TITLE
fix(cli): give paywall AI run-failed errors an actionable hint

### DIFF
--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -535,7 +535,7 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 				checkpointed = true
 			}
 		case paywallai.EventRunFailed:
-			return WithHint(fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message), paywallRecoveryHint(opts, checkpointed))
+			return WithHint(fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message), paywallRunFailedHint(opts, checkpointed))
 		case paywallai.EventRunCompleted:
 			reportPaywallAIActivity(rt, event.Activity, reportedActivity)
 			return finishPaywallAI(ctx, rt, opts, session, event)
@@ -573,6 +573,13 @@ func paywallRecoveryHint(opts paywallAIOptions, checkpointed bool) string {
 		return "The draft was created. Continue editing it with: rc paywalls edit --session " + opts.sessionPath
 	}
 	return "Nothing was saved yet. Re-run the command to try again."
+}
+
+func paywallRunFailedHint(opts paywallAIOptions, checkpointed bool) string {
+	if checkpointed || opts.createdDraft {
+		return paywallRecoveryHint(opts, checkpointed)
+	}
+	return "This looks like a transient failure. Wait a moment and re-run the command to try again."
 }
 
 func streamDropError(opts paywallAIOptions, checkpointed bool, err error) error {

--- a/internal/cli/paywalls_stream_test.go
+++ b/internal/cli/paywalls_stream_test.go
@@ -54,3 +54,20 @@ func TestStreamDropError(t *testing.T) {
 		t.Fatalf("created-draft hint = %q", h)
 	}
 }
+
+func TestPaywallRunFailedHint(t *testing.T) {
+	checkpointed := paywallRunFailedHint(paywallAIOptions{sessionPath: "/tmp/s.paywall.json"}, true)
+	if !strings.Contains(checkpointed, "edit --session /tmp/s.paywall.json") {
+		t.Fatalf("checkpointed hint = %q", checkpointed)
+	}
+
+	created := paywallRunFailedHint(paywallAIOptions{sessionPath: "/tmp/s.paywall.json", createdDraft: true}, false)
+	if !strings.Contains(created, "edit --session /tmp/s.paywall.json") {
+		t.Fatalf("created-draft hint = %q", created)
+	}
+
+	none := paywallRunFailedHint(paywallAIOptions{}, false)
+	if !strings.Contains(none, "transient") || !strings.Contains(none, "re-run") {
+		t.Fatalf("no-progress hint = %q", none)
+	}
+}


### PR DESCRIPTION
When the Paywalls AI backend reports a run-failed event, testers were left with a generic transient error and no next step. This routes that error through a hint that points to `rc paywalls edit --session` when a checkpoint or draft already exists, and otherwise notes the failure is likely transient and worth retrying in a moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only error messaging for Paywalls AI runs; no API, auth, or persistence logic changes.
> 
> **Overview**
> **Paywalls AI `EventRunFailed` errors** now attach hints via `paywallRunFailedHint` instead of the generic `paywallRecoveryHint` used for stream drops.
> 
> When a checkpoint or draft already exists, behavior is unchanged: users still see **continue with** `rc paywalls edit --session <path>`. When nothing was saved yet, the hint no longer says only “nothing was saved — re-run”; it frames the failure as **likely transient** and suggests waiting briefly before re-running the same command.
> 
> Tests cover checkpointed, created-draft, and no-progress cases for the new hint helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f30bbad9869270d0be7f0294d5b06936c3193080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->