### PR TITLE
fix(cli): stop rico chat from garbling input on launch

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -80,6 +80,12 @@ func (e *ChatEmitter) Approve(prompt string, destructive bool) bool {
 // RunChat opens the window and blocks until the user exits.
 func (c Chat) RunChat() error {
 	model := newChatModel(c)
+	// Probe the background before Bubble Tea owns stdin; a later auto-probe leaks
+	// the terminal's OSC 11 / cursor-report replies into the textarea.
+	model.markdownStyle = "light"
+	if lipgloss.HasDarkBackground() {
+		model.markdownStyle = "dark"
+	}
 	program := tea.NewProgram(model, tea.WithAltScreen())
 	model.program = program
 	_, err := program.Run()
@@ -100,10 +106,11 @@ type chatModel struct {
 	cfg     Chat
 	program *tea.Program
 
-	viewport viewport.Model
-	input    textarea.Model
-	spin     spinner.Model
-	markdown *glamour.TermRenderer
+	viewport      viewport.Model
+	input         textarea.Model
+	spin          spinner.Model
+	markdown      *glamour.TermRenderer
+	markdownStyle string
 
 	entries   []ChatEntry
 	streaming bool
@@ -341,7 +348,7 @@ func (m *chatModel) layout() {
 	}
 	m.input.SetWidth(max(m.width-6, 10)) // border + padding
 	renderer, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
+		glamour.WithStandardStyle(m.markdownStyle),
 		glamour.WithWordWrap(max(m.width-4, 20)),
 		glamour.WithEmoji(),
 	)


### PR DESCRIPTION
Bare `rc rico` opened the chat with junk already in the input box (the terminal's background-color query replies leaking in as keystrokes). The renderer was auto-detecting the terminal background after Bubble Tea had taken over stdin; this detects it once beforehand and builds the markdown renderer with an explicit light/dark style so nothing probes the terminal at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI startup and markdown styling change with no auth, data, or API impact.
> 
> **Overview**
> Fixes **junk text appearing in the chat input** when opening bare `rc rico`—terminal OSC 11 / cursor-report replies were read as keystrokes after Bubble Tea took over stdin.
> 
> **Light/dark markdown styling** is chosen once in `RunChat` via `lipgloss.HasDarkBackground()` before `tea.NewProgram` runs. The glamour renderer in `layout()` now uses `WithStandardStyle(m.markdownStyle)` instead of `WithAutoStyle()`, so nothing probes the terminal during resize/layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29db1b9ec1f1b8953516c81828c8d727062c2a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->