### PR TITLE
Setup quick wins: session name, Auto autonomy, skills nudge

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -120,7 +120,9 @@ Agent-friendly entrypoints:
 		if RuntimeFrom(cmd.Context()).Globals.ShowAll {
 			return cmd.Help()
 		}
-		writeHomeScreen(cmd.OutOrStdout(), RuntimeFrom(cmd.Context()))
+		rt := RuntimeFrom(cmd.Context())
+		writeHomeScreen(cmd.OutOrStdout(), rt)
+		maybeNudgeSkillsInstall(rt)
 		return nil
 	}
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -51,18 +51,19 @@ var trustedClaudeTools = []string{
 
 var agentClients = []agentClient{
 	{"Claude Code", "claude", "claude-code", func(p, autonomy string) []string {
+		name := setupSessionName()
 		switch autonomy {
 		case autonomyTrusted:
 			// Prompt first — --allowedTools is variadic and would swallow a
 			// trailing positional. Patterns must be SEPARATE args: a
 			// comma-joined value registers as one bogus pattern that
 			// matches nothing (live-debugged: nothing was pre-approved).
-			args := []string{p, "--permission-mode", "acceptEdits", "--allowedTools"}
+			args := []string{"-n", name, p, "--permission-mode", "acceptEdits", "--allowedTools"}
 			return append(args, trustedClaudeTools...)
 		case autonomyFull:
-			return []string{"--dangerously-skip-permissions", p}
+			return []string{"-n", name, "--dangerously-skip-permissions", p}
 		default:
-			return []string{p}
+			return []string{"-n", name, p}
 		}
 	}},
 	{"Codex", "codex", "codex", func(p, autonomy string) []string {
@@ -656,6 +657,15 @@ func detectAppProject(dir string) (label string, ok bool) {
 		}
 	}
 	return "no app project detected", false
+}
+
+// setupSessionName names the launched agent's session after the app directory.
+func setupSessionName() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "RevenueCat setup"
+	}
+	return "RevenueCat setup (" + filepath.Base(dir) + ")"
 }
 
 func collapseHome(dir string) string {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -73,7 +73,7 @@ var agentClients = []agentClient{
 	{"Codex", "codex", "codex", func(p, autonomy string) []string {
 		switch autonomy {
 		case autonomyAuto, autonomyTrusted:
-			return []string{"--full-auto", p}
+			return []string{"-a", "never", "-s", "workspace-write", p}
 		case autonomyFull:
 			return []string{"--dangerously-bypass-approvals-and-sandbox", p}
 		default:

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -73,7 +73,7 @@ var agentClients = []agentClient{
 	{"Codex", "codex", "codex", func(p, autonomy string) []string {
 		switch autonomy {
 		case autonomyAuto, autonomyTrusted:
-			return []string{"-a", "never", "-s", "workspace-write", p}
+			return []string{"-a", "on-request", "-s", "workspace-write", p}
 		case autonomyFull:
 			return []string{"--dangerously-bypass-approvals-and-sandbox", p}
 		default:

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -24,11 +24,13 @@ type agentClient struct {
 	LaunchArgs func(prompt, autonomy string) []string
 }
 
-// Autonomy levels for the launched agent. "trusted" pre-approves the tools
-// the setup journey actually uses (rc, file edits, builds) so the human
-// isn't asked to approve every step of a run they already consented to;
-// "full" removes approvals entirely; "manual" is the agent's default.
+// Autonomy levels for the launched agent. "auto" maps to each agent's own
+// auto-approval mode; "trusted" pre-approves the tools the setup journey
+// actually uses (rc, file edits, builds) so the human isn't asked to approve
+// every step of a run they already consented to; "full" removes approvals
+// entirely; "manual" is the agent's default.
 const (
+	autonomyAuto    = "auto"
 	autonomyTrusted = "trusted"
 	autonomyFull    = "full"
 	autonomyManual  = "manual"
@@ -53,6 +55,8 @@ var agentClients = []agentClient{
 	{"Claude Code", "claude", "claude-code", func(p, autonomy string) []string {
 		name := setupSessionName()
 		switch autonomy {
+		case autonomyAuto:
+			return []string{"-n", name, "--permission-mode", "auto", p}
 		case autonomyTrusted:
 			// Prompt first — --allowedTools is variadic and would swallow a
 			// trailing positional. Patterns must be SEPARATE args: a
@@ -68,7 +72,7 @@ var agentClients = []agentClient{
 	}},
 	{"Codex", "codex", "codex", func(p, autonomy string) []string {
 		switch autonomy {
-		case autonomyTrusted:
+		case autonomyAuto, autonomyTrusted:
 			return []string{"--full-auto", p}
 		case autonomyFull:
 			return []string{"--dangerously-bypass-approvals-and-sandbox", p}
@@ -77,14 +81,14 @@ var agentClients = []agentClient{
 		}
 	}},
 	{"Cursor", "cursor-agent", "cursor", func(p, autonomy string) []string {
-		if autonomy == autonomyTrusted || autonomy == autonomyFull {
+		if autonomy == autonomyAuto || autonomy == autonomyTrusted || autonomy == autonomyFull {
 			return []string{"--force", p}
 		}
 		return []string{p}
 	}},
 	{"Gemini CLI", "gemini", "gemini-cli", func(p, autonomy string) []string {
 		switch autonomy {
-		case autonomyTrusted:
+		case autonomyAuto, autonomyTrusted:
 			return []string{"--approval-mode", "auto_edit", "-i", p}
 		case autonomyFull:
 			return []string{"--yolo", "-i", p}
@@ -196,12 +200,13 @@ func runSetup(cmd *cobra.Command) error {
 	rt.Out.Answer("Agent", choice.Name)
 
 	rt.Out.Title("Step 2 · Autonomy")
-	autonomy := autonomyFull
+	autonomy := autonomyAuto
 	if err := tui.Form(false).
 		Field(huh.NewSelect[string]().
 			Title("How much can "+choice.Name+" do without stopping to ask?").
 			Description("You can interrupt anytime.").
 			Options(
+				huh.NewOption("Auto — use "+choice.Name+"'s built-in auto-approve mode", autonomyAuto),
 				huh.NewOption("Run freely — no approval prompts", autonomyFull),
 				huh.NewOption("Pre-approve rc, edits, and builds; ask for anything unusual", autonomyTrusted),
 				huh.NewOption("Ask me before each step", autonomyManual),
@@ -291,6 +296,7 @@ func runSetup(cmd *cobra.Command) error {
 }
 
 var autonomyLabels = map[string]string{
+	autonomyAuto:    "the agent's built-in auto-approve mode",
 	autonomyTrusted: "pre-approve rc, edits, builds; ask for the rest",
 	autonomyManual:  "ask before each step",
 	autonomyFull:    "run freely (no approval prompts)",

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/revenuecat/cli/internal/config"
+	"github.com/revenuecat/cli/internal/tui"
 )
 
 const (
@@ -69,6 +73,76 @@ func revenueCatStarterPrompts() []starterPrompt {
 			Prompt: "Use the revenuecat-status skill to audit my RevenueCat project, identify missing or inconsistent configuration, and give me exact recovery steps without changing anything first.",
 		},
 	}
+}
+
+// skillsNudgeState persists whether the one-time install nudge has been shown.
+type skillsNudgeState struct {
+	Shown bool `json:"skills_nudge_shown"`
+}
+
+// revenueCatSkillDirs returns the skill dirs rc can inspect for an agent; nil when the layout is unknown (e.g. Gemini).
+func revenueCatSkillDirs(toolkitKey string) []string {
+	var rel string
+	switch toolkitKey {
+	case "claude-code":
+		rel = filepath.Join(".claude", "skills")
+	case "codex":
+		rel = filepath.Join(".codex", "skills")
+	case "cursor":
+		rel = filepath.Join(".cursor", "skills-cursor")
+	default:
+		return nil
+	}
+	var dirs []string
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, rel))
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		dirs = append(dirs, filepath.Join(cwd, rel))
+	}
+	return dirs
+}
+
+// revenueCatSkillsInstalledFor reports whether the skills are installed; checkable is false when rc can't inspect the agent.
+func revenueCatSkillsInstalledFor(a agentClient) (checkable, installed bool) {
+	dirs := revenueCatSkillDirs(a.ToolkitKey)
+	if len(dirs) == 0 {
+		return false, false
+	}
+	for _, d := range dirs {
+		if _, err := os.Stat(filepath.Join(d, "create-revenuecat-project")); err == nil {
+			return true, true
+		}
+	}
+	return true, false
+}
+
+// maybeNudgeSkillsInstall shows the install-skills hint once, for humans only, when a supported agent has no skills.
+func maybeNudgeSkillsInstall(rt *Runtime) {
+	if rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
+		return
+	}
+	missing := false
+	for _, a := range detectAgents() {
+		checkable, installed := revenueCatSkillsInstalledFor(a)
+		if !checkable {
+			continue
+		}
+		if installed {
+			return
+		}
+		missing = true
+	}
+	if !missing {
+		return
+	}
+	var st skillsNudgeState
+	if err := config.LoadState(rt.Globals.Profile, "hints", &st); err != nil || st.Shown {
+		return
+	}
+	rt.Out.Hint("Coding with an AI agent? Install the RevenueCat skills:  rc skills install")
+	st.Shown = true
+	_ = config.SaveState(rt.Globals.Profile, "hints", &st)
 }
 
 func showStarterPrompts(rt *Runtime) {

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -89,7 +89,7 @@ func revenueCatSkillDirs(toolkitKey string) []string {
 	case "codex":
 		rel = filepath.Join(".codex", "skills")
 	case "cursor":
-		rel = filepath.Join(".cursor", "skills-cursor")
+		rel = filepath.Join(".cursor", "skills")
 	default:
 		return nil
 	}


### PR DESCRIPTION
Three small improvements to the setup flow:

- rc setup now names the launched Claude session after the app directory instead of letting it default to the first line of the prompt. Codex, Cursor, and Gemini have no equivalent flag, so they're unchanged.
- Adds an "Auto" autonomy tier that maps to each agent's own auto-approve mode (Claude `--permission-mode auto`, Codex `--full-auto`, Gemini `--approval-mode auto_edit`, Cursor `--force`), and makes it the default choice.
- When a supported agent CLI is installed but the RevenueCat skills aren't, bare `rc` prints a one-time hint pointing at `rc skills install`. Shown at most once, silent under `--json`/`--no-input`/non-TTY, and never nags if any agent already has the skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX and local filesystem checks only; no auth, API, or payment logic changes.
> 
> **Overview**
> **`rc setup`** now passes a **`-n`** session name to Claude Code (`RevenueCat setup (<app dir>)`) and makes **Auto** the default autonomy tier, mapping each agent to its native auto-approve flags (e.g. Claude `--permission-mode auto`, Codex `-a on-request` / `-s workspace-write`, Cursor `--force`, Gemini `--approval-mode auto_edit`). Codex **trusted** no longer uses `--full-auto`; it shares the Auto path.
> 
> Bare **`rc`** (home screen) calls **`maybeNudgeSkillsInstall`**: if a supported agent is on PATH but **`create-revenuecat-project`** is missing from inspectable skill dirs (home + cwd for Claude/Codex/Cursor), it prints a one-time hint to run **`rc skills install`**, persisted in profile **`hints`** state; skipped under **`--json`**, **`--no-input`**, non-TTY, or when skills are already present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd53f069fa7fb023799c58084ebce5c54242d773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->