### PR TITLE
Make rc setup discoverable in help, home, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ npx @revenuecat/cli capital setup        # connect App Store Connect for Revenue
 
 ## Quick start
 
+The fastest way in: from your app's directory, let an AI agent set up RevenueCat for you (you approve each step). It also emits a prompt for coding agents to run non-interactively.
+
+```bash
+rc setup
+```
+
+Prefer to do it by hand:
+
 ```bash
 # 1. Log in (browser OAuth or paste an API key)
 rc auth login

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -36,8 +36,8 @@ the code when adding/renaming a command.
      here: humans reach them through guided flows/pickers; agents discover
      them through the schema channel.
    - **punted** (`surface: "punted"` annotation) — hidden from `--help` *and*
-     schema, still runnable. For under-DX-tested commands (the one-shot
-     `setup` orchestrator). Promote to a real tier once tested.
+     schema, still runnable. For under-DX-tested commands. Promote to a real
+     tier once tested.
    `rc --all` / `RC_SURFACE=full` reveals everything to humans. Hidden never
    means disabled — skills naming an agent-only command keep working.
 
@@ -94,7 +94,7 @@ names; there's no list endpoint.
 
 ```
 # Onboarding entry points (the two scoped npx surfaces)
-rc setup                                                 # PUNTED: one-shot agent-driven bootstrap; hidden until DX-tested
+rc setup                                                 # one-shot agent-driven bootstrap; featured in --help/home/README, runs non-interactively for the prompt
 rc capital setup                                         # RevenueCat Capital = App Store Connect key flow (wraps apps apple setup)
 rc                                                       # bare rc -> getting-started help; --all reveals every command
 

--- a/internal/cli/home.go
+++ b/internal/cli/home.go
@@ -26,6 +26,7 @@ var homeMap = []homeGroup{
 		{"rc metrics", "project overview at a glance"},
 	}},
 	{"Automate & set up", [][2]string{
+		{"rc setup", "set up RevenueCat for a new app"},
 		{"rc apps", "connect App Store & Google Play"},
 		{"rc skills install", "AI workflows for coding agents"},
 		{"rc rico", "ask RevenueCat's AI ✨"},
@@ -43,7 +44,9 @@ func writeHomeScreen(w io.Writer, rt *Runtime) {
 	authed := rt.Config.BearerToken() != ""
 	switch {
 	case !authed:
-		b.WriteString(label("New here? Two steps to get going:") + "\n")
+		b.WriteString(label("New here? One command sets everything up:") + "\n")
+		b.WriteString("  " + paint(output.ToneCommand, "rc setup") + "   " + paint(output.ToneDim, "an AI agent sets up RevenueCat for this app (you approve each step)") + "\n\n")
+		b.WriteString(label("Prefer to wire it up yourself?") + "\n")
 		b.WriteString("  " + paint(output.ToneCommand, "1  rc auth login") + "     " + paint(output.ToneDim, "log in (browser or API key)") + "\n")
 		b.WriteString("  " + paint(output.ToneCommand, "2  rc projects use") + "   " + paint(output.ToneDim, "pick a project") + "\n")
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ func NewRootCmd(version string) *cobra.Command {
 		Long: `rc is the RevenueCat command line interface.
 
 Getting started:
+  rc setup               set up RevenueCat for the app in this directory
   rc auth login          log in (browser or an API key)
   rc projects use        choose a default project
   rc <command> --help    explore any command group

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -114,7 +114,6 @@ the step-by-step commands in the docs.`,
   npx @revenuecat/cli setup`,
 		Args: cobra.NoArgs,
 		Annotations: map[string]string{
-			"surface":               "punted",
 			"requires_human":        "true",
 			"requires_human_reason": "interactively it launches a local AI agent; run non-interactively (rc setup --json) to get the setup prompt to follow directly",
 		},

--- a/internal/cli/surface_test.go
+++ b/internal/cli/surface_test.go
@@ -1,36 +1,37 @@
 package cli
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
 
 // The command surface splits by output channel: humans see the curated set in
 // --help, agents/JSON see everything. These guard the two invariants that
 // keep that honest.
 
-// Agent discovery (rc commands --schemas) must include agent-only commands —
-// hidden from --help but present here — while excluding the punted tier.
-// Hiding from humans must not hide from agents.
-func TestCommandSurface_SchemaIncludesAgentOnlyExcludesPunted(t *testing.T) {
+// Agent discovery (rc commands --schemas) must include every non-punted
+// command, including setup (agents run it non-interactively for the prompt).
+func TestCommandSurface_SchemaIncludesAgentCommands(t *testing.T) {
 	root := NewRootCmd("test")
 	tree := commandTreeWithSchemas(root)
 	names := map[string]bool{}
 	for _, c := range tree["commands"].([]map[string]any) {
 		names[c["name"].(string)] = true
 	}
-	for _, agentOnly := range []string{"customer", "offerings", "entitlements", "packages"} {
-		if !names[agentOnly] {
-			t.Errorf("agent-only command %q missing from schema surface", agentOnly)
+	for _, want := range []string{"customer", "offerings", "entitlements", "packages", "setup"} {
+		if !names[want] {
+			t.Errorf("command %q missing from schema surface", want)
 		}
-	}
-	if names["setup"] {
-		t.Error("punted command 'setup' should not appear in the schema surface")
 	}
 }
 
 // The human-help curation runs behind a testing.Testing() short-circuit, so
-// this drives curateSurface directly: the full surface shows by default, only
-// punted is held back, aliases stay hidden, and --all reveals punted too.
+// this drives curateSurface directly: the full surface shows by default, a
+// punted command is held back until --all, and aliases stay hidden.
 func TestCurateSurface(t *testing.T) {
 	root := NewRootCmd("test")
+	root.AddCommand(&cobra.Command{Use: "x-punted", Annotations: map[string]string{annotationSurface: surfacePunted}})
 	hidden := func(name string) bool {
 		for _, c := range root.Commands() {
 			if c.Name() == name {
@@ -48,15 +49,18 @@ func TestCurateSurface(t *testing.T) {
 	if hidden("customer") {
 		t.Error("'customer' should be visible in --help (full surface)")
 	}
+	if hidden("setup") {
+		t.Error("'setup' should be visible in --help")
+	}
 	if !hidden("login") {
 		t.Error("the back-compat 'login' alias should stay hidden")
 	}
-	if !hidden("setup") {
-		t.Error("punted 'setup' should be hidden by default")
+	if !hidden("x-punted") {
+		t.Error("a punted command should be hidden by default")
 	}
 
 	curateSurface(root, true) // rc --all
-	if hidden("setup") {
-		t.Error("--all should reveal punted 'setup'")
+	if hidden("x-punted") {
+		t.Error("--all should reveal a punted command")
 	}
 }


### PR DESCRIPTION
rc setup is the front door but it was hidden from both `rc --help` and the agent schema (it was punted). This un-puts it and features it in the bare-`rc` home screen, the `--help` getting-started list, and the README quick start. It has a non-interactive agent mode (`rc setup --json` emits the setup prompt), so it belongs in the schema too.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CLI surface visibility only; `rc setup` behavior is unchanged aside from discoverability.
> 
> **Overview**
> **`rc setup`** was hidden as a **punted** command (not in `rc --help` or `rc commands --schemas`). This PR **promotes** it so it appears in default help, the bare-`rc` home screen, README quick start, and agent schema discovery.
> 
> The **`surface: punted`** annotation is removed from `setup`; only truly punted commands stay hidden until `rc --all`. Tests now expect **`setup`** visible in help and included in the schema surface (alongside agent-oriented commands like `customer`), with a synthetic **`x-punted`** command used to verify punted behavior.
> 
> Onboarding copy shifts from a two-step login/project flow to **`rc setup`** as the primary path for new users, with manual **`auth login`** / **`projects use`** as the alternative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b8ee480148a65a4ff066b68b2b022073c180db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->