### PR TITLE
fix(cli): install setup skills globally so agents find them on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ npx @revenuecat/cli capital setup        # connect App Store Connect for Revenue
 
 ## Quick start
 
+The fastest way in: from your app's directory, let an AI agent set up RevenueCat for you (you approve each step). It also emits a prompt for coding agents to run non-interactively.
+
+```bash
+rc setup
+```
+
+Prefer to do it by hand:
+
 ```bash
 # 1. Log in (browser OAuth or paste an API key)
 rc auth login

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -36,8 +36,8 @@ the code when adding/renaming a command.
      here: humans reach them through guided flows/pickers; agents discover
      them through the schema channel.
    - **punted** (`surface: "punted"` annotation) — hidden from `--help` *and*
-     schema, still runnable. For under-DX-tested commands (the one-shot
-     `setup` orchestrator). Promote to a real tier once tested.
+     schema, still runnable. For under-DX-tested commands. Promote to a real
+     tier once tested.
    `rc --all` / `RC_SURFACE=full` reveals everything to humans. Hidden never
    means disabled — skills naming an agent-only command keep working.
 
@@ -94,7 +94,7 @@ names; there's no list endpoint.
 
 ```
 # Onboarding entry points (the two scoped npx surfaces)
-rc setup                                                 # PUNTED: one-shot agent-driven bootstrap; hidden until DX-tested
+rc setup                                                 # one-shot agent-driven bootstrap; featured in --help/home/README, runs non-interactively for the prompt
 rc capital setup                                         # RevenueCat Capital = App Store Connect key flow (wraps apps apple setup)
 rc                                                       # bare rc -> getting-started help; --all reveals every command
 

--- a/internal/cli/home.go
+++ b/internal/cli/home.go
@@ -26,6 +26,7 @@ var homeMap = []homeGroup{
 		{"rc metrics", "project overview at a glance"},
 	}},
 	{"Automate & set up", [][2]string{
+		{"rc setup", "set up RevenueCat for a new app"},
 		{"rc apps", "connect App Store & Google Play"},
 		{"rc skills install", "AI workflows for coding agents"},
 		{"rc rico", "ask RevenueCat's AI ✨"},
@@ -43,7 +44,9 @@ func writeHomeScreen(w io.Writer, rt *Runtime) {
 	authed := rt.Config.BearerToken() != ""
 	switch {
 	case !authed:
-		b.WriteString(label("New here? Two steps to get going:") + "\n")
+		b.WriteString(label("New here? One command sets everything up:") + "\n")
+		b.WriteString("  " + paint(output.ToneCommand, "rc setup") + "   " + paint(output.ToneDim, "an AI agent sets up RevenueCat for this app (you approve each step)") + "\n\n")
+		b.WriteString(label("Prefer to wire it up yourself?") + "\n")
 		b.WriteString("  " + paint(output.ToneCommand, "1  rc auth login") + "     " + paint(output.ToneDim, "log in (browser or API key)") + "\n")
 		b.WriteString("  " + paint(output.ToneCommand, "2  rc projects use") + "   " + paint(output.ToneDim, "pick a project") + "\n")
 

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -503,7 +503,7 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 				checkpointed = true
 			}
 		case paywallai.EventRunFailed:
-			return WithHint(fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message), paywallRecoveryHint(opts, checkpointed))
+			return WithHint(fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message), paywallRunFailedHint(opts, checkpointed))
 		case paywallai.EventRunCompleted:
 			reportPaywallAIActivity(rt, event.Activity, reportedActivity)
 			return finishPaywallAI(ctx, rt, opts, session, event)
@@ -541,6 +541,13 @@ func paywallRecoveryHint(opts paywallAIOptions, checkpointed bool) string {
 		return "The draft was created. Continue editing it with: rc paywalls edit --session " + opts.sessionPath
 	}
 	return "Nothing was saved yet. Re-run the command to try again."
+}
+
+func paywallRunFailedHint(opts paywallAIOptions, checkpointed bool) string {
+	if checkpointed || opts.createdDraft {
+		return paywallRecoveryHint(opts, checkpointed)
+	}
+	return "This looks like a transient failure. Wait a moment and re-run the command to try again."
 }
 
 func streamDropError(opts paywallAIOptions, checkpointed bool, err error) error {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -535,7 +535,7 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 				checkpointed = true
 			}
 		case paywallai.EventRunFailed:
-			return WithHint(fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message), paywallRecoveryHint(opts, checkpointed))
+			return WithHint(fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message), paywallRunFailedHint(opts, checkpointed))
 		case paywallai.EventRunCompleted:
 			reportPaywallAIActivity(rt, event.Activity, reportedActivity)
 			return finishPaywallAI(ctx, rt, opts, session, event)
@@ -573,6 +573,13 @@ func paywallRecoveryHint(opts paywallAIOptions, checkpointed bool) string {
 		return "The draft was created. Continue editing it with: rc paywalls edit --session " + opts.sessionPath
 	}
 	return "Nothing was saved yet. Re-run the command to try again."
+}
+
+func paywallRunFailedHint(opts paywallAIOptions, checkpointed bool) string {
+	if checkpointed || opts.createdDraft {
+		return paywallRecoveryHint(opts, checkpointed)
+	}
+	return "This looks like a transient failure. Wait a moment and re-run the command to try again."
 }
 
 func streamDropError(opts paywallAIOptions, checkpointed bool, err error) error {

--- a/internal/cli/paywalls_stream_test.go
+++ b/internal/cli/paywalls_stream_test.go
@@ -54,3 +54,20 @@ func TestStreamDropError(t *testing.T) {
 		t.Fatalf("created-draft hint = %q", h)
 	}
 }
+
+func TestPaywallRunFailedHint(t *testing.T) {
+	checkpointed := paywallRunFailedHint(paywallAIOptions{sessionPath: "/tmp/s.paywall.json"}, true)
+	if !strings.Contains(checkpointed, "edit --session /tmp/s.paywall.json") {
+		t.Fatalf("checkpointed hint = %q", checkpointed)
+	}
+
+	created := paywallRunFailedHint(paywallAIOptions{sessionPath: "/tmp/s.paywall.json", createdDraft: true}, false)
+	if !strings.Contains(created, "edit --session /tmp/s.paywall.json") {
+		t.Fatalf("created-draft hint = %q", created)
+	}
+
+	none := paywallRunFailedHint(paywallAIOptions{}, false)
+	if !strings.Contains(none, "transient") || !strings.Contains(none, "re-run") {
+		t.Fatalf("no-progress hint = %q", none)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -120,7 +120,9 @@ Agent-friendly entrypoints:
 		if RuntimeFrom(cmd.Context()).Globals.ShowAll {
 			return cmd.Help()
 		}
-		writeHomeScreen(cmd.OutOrStdout(), RuntimeFrom(cmd.Context()))
+		rt := RuntimeFrom(cmd.Context())
+		writeHomeScreen(cmd.OutOrStdout(), rt)
+		maybeNudgeSkillsInstall(rt)
 		return nil
 	}
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ func NewRootCmd(version string) *cobra.Command {
 		Long: `rc is the RevenueCat command line interface.
 
 Getting started:
+  rc setup               set up RevenueCat for the app in this directory
   rc auth login          log in (browser or an API key)
   rc projects use        choose a default project
   rc <command> --help    explore any command group

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -216,22 +216,6 @@ func runSetup(cmd *cobra.Command) error {
 	}
 	rt.Out.Answer("Autonomy", autonomyLabels[autonomy])
 
-	rt.Out.Title("Step 3 · Skills")
-	skillsScope := "project"
-	if err := tui.Form(false).
-		Field(huh.NewSelect[string]().
-			Title("Install the RevenueCat skills here or globally?").
-			Description("Project keeps them with this repo; global shares them across every project on this machine.").
-			Options(
-				huh.NewOption("This project only", "project"),
-				huh.NewOption("Globally (all projects on this machine)", "global"),
-			).
-			Value(&skillsScope)).
-		Run(); err != nil {
-		return err
-	}
-	rt.Out.Answer("Skills", skillsScopeLabels[skillsScope])
-
 	// Apple needs a browser + 2FA; setup always defers it to the agent hand-back.
 	appleDeferred := applePending
 
@@ -262,20 +246,20 @@ func runSetup(cmd *cobra.Command) error {
 		toolkitSource = "https://github.com/RevenueCat/ai-toolkit/tree/" + branch
 		rt.Out.Info("Using toolkit branch " + branch + " (RC_SKILLS_BRANCH)")
 	}
-	installArgs := []string{"--yes", "skills", "add", toolkitSource, "--agent", choice.ToolkitKey}
-	if skillsScope == "global" {
-		installArgs = append(installArgs, "--global")
-	}
-	installArgs = append(installArgs, "--skill")
+	// Global so the agent finds the skills on first launch; project scope lands under
+	// the repo's .claude dir, which the agent won't load until it trusts the directory.
+	installArgs := []string{"--yes", "skills", "add", toolkitSource, "--global", "--agent", choice.ToolkitKey, "--skill"}
 	installArgs = append(installArgs, defaultToolkitSkills...)
-	// The skills CLI is a whole guided UI of its own; inside setup it runs
-	// silently — our flow owns the questions, its output appears only on
-	// failure.
 	npxPath, err := exec.LookPath("npx")
 	if err != nil {
 		return fmt.Errorf("npx is required to install the RevenueCat AI Toolkit: %w", err)
 	}
 	install := exec.CommandContext(cmd.Context(), npxPath, installArgs...)
+	// Run from a temp dir so the global install can't drop a lockfile in the app repo.
+	if tmp, err := os.MkdirTemp("", "rc-skills-"); err == nil {
+		install.Dir = tmp
+		defer os.RemoveAll(tmp)
+	}
 	if out, err := install.CombinedOutput(); err != nil {
 		tail := string(out)
 		if len(tail) > 1200 {
@@ -283,7 +267,7 @@ func runSetup(cmd *cobra.Command) error {
 		}
 		return fmt.Errorf("install skills: %w\n%s", err, strings.TrimSpace(tail))
 	}
-	rt.Out.Info("Skills installed")
+	rt.Out.Info("Skills installed globally")
 
 	configureAgentMCP(cmd, rt, choice)
 
@@ -299,11 +283,6 @@ var autonomyLabels = map[string]string{
 	autonomyTrusted: "pre-approve rc, edits, builds; ask for the rest",
 	autonomyManual:  "ask before each step",
 	autonomyFull:    "run freely (no approval prompts)",
-}
-
-var skillsScopeLabels = map[string]string{
-	"project": "this project only",
-	"global":  "global",
 }
 
 // confirmSetupAccount confirms the account and picks the project for this app,

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -51,18 +51,19 @@ var trustedClaudeTools = []string{
 
 var agentClients = []agentClient{
 	{"Claude Code", "claude", "claude-code", func(p, autonomy string) []string {
+		name := setupSessionName()
 		switch autonomy {
 		case autonomyTrusted:
 			// Prompt first — --allowedTools is variadic and would swallow a
 			// trailing positional. Patterns must be SEPARATE args: a
 			// comma-joined value registers as one bogus pattern that
 			// matches nothing (live-debugged: nothing was pre-approved).
-			args := []string{p, "--permission-mode", "acceptEdits", "--allowedTools"}
+			args := []string{"-n", name, p, "--permission-mode", "acceptEdits", "--allowedTools"}
 			return append(args, trustedClaudeTools...)
 		case autonomyFull:
-			return []string{"--dangerously-skip-permissions", p}
+			return []string{"-n", name, "--dangerously-skip-permissions", p}
 		default:
-			return []string{p}
+			return []string{"-n", name, p}
 		}
 	}},
 	{"Codex", "codex", "codex", func(p, autonomy string) []string {
@@ -656,6 +657,15 @@ func detectAppProject(dir string) (label string, ok bool) {
 		}
 	}
 	return "no app project detected", false
+}
+
+// setupSessionName names the launched agent's session after the app directory.
+func setupSessionName() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "RevenueCat setup"
+	}
+	return "RevenueCat setup (" + filepath.Base(dir) + ")"
 }
 
 func collapseHome(dir string) string {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -24,11 +24,13 @@ type agentClient struct {
 	LaunchArgs func(prompt, autonomy string) []string
 }
 
-// Autonomy levels for the launched agent. "trusted" pre-approves the tools
-// the setup journey actually uses (rc, file edits, builds) so the human
-// isn't asked to approve every step of a run they already consented to;
-// "full" removes approvals entirely; "manual" is the agent's default.
+// Autonomy levels for the launched agent. "auto" maps to each agent's own
+// auto-approval mode; "trusted" pre-approves the tools the setup journey
+// actually uses (rc, file edits, builds) so the human isn't asked to approve
+// every step of a run they already consented to; "full" removes approvals
+// entirely; "manual" is the agent's default.
 const (
+	autonomyAuto    = "auto"
 	autonomyTrusted = "trusted"
 	autonomyFull    = "full"
 	autonomyManual  = "manual"
@@ -51,24 +53,27 @@ var trustedClaudeTools = []string{
 
 var agentClients = []agentClient{
 	{"Claude Code", "claude", "claude-code", func(p, autonomy string) []string {
+		name := setupSessionName()
 		switch autonomy {
+		case autonomyAuto:
+			return []string{"-n", name, "--permission-mode", "auto", p}
 		case autonomyTrusted:
 			// Prompt first — --allowedTools is variadic and would swallow a
 			// trailing positional. Patterns must be SEPARATE args: a
 			// comma-joined value registers as one bogus pattern that
 			// matches nothing (live-debugged: nothing was pre-approved).
-			args := []string{p, "--permission-mode", "acceptEdits", "--allowedTools"}
+			args := []string{"-n", name, p, "--permission-mode", "acceptEdits", "--allowedTools"}
 			return append(args, trustedClaudeTools...)
 		case autonomyFull:
-			return []string{"--dangerously-skip-permissions", p}
+			return []string{"-n", name, "--dangerously-skip-permissions", p}
 		default:
-			return []string{p}
+			return []string{"-n", name, p}
 		}
 	}},
 	{"Codex", "codex", "codex", func(p, autonomy string) []string {
 		switch autonomy {
-		case autonomyTrusted:
-			return []string{"--full-auto", p}
+		case autonomyAuto, autonomyTrusted:
+			return []string{"-a", "on-request", "-s", "workspace-write", p}
 		case autonomyFull:
 			return []string{"--dangerously-bypass-approvals-and-sandbox", p}
 		default:
@@ -76,14 +81,14 @@ var agentClients = []agentClient{
 		}
 	}},
 	{"Cursor", "cursor-agent", "cursor", func(p, autonomy string) []string {
-		if autonomy == autonomyTrusted || autonomy == autonomyFull {
+		if autonomy == autonomyAuto || autonomy == autonomyTrusted || autonomy == autonomyFull {
 			return []string{"--force", p}
 		}
 		return []string{p}
 	}},
 	{"Gemini CLI", "gemini", "gemini-cli", func(p, autonomy string) []string {
 		switch autonomy {
-		case autonomyTrusted:
+		case autonomyAuto, autonomyTrusted:
 			return []string{"--approval-mode", "auto_edit", "-i", p}
 		case autonomyFull:
 			return []string{"--yolo", "-i", p}
@@ -195,12 +200,13 @@ func runSetup(cmd *cobra.Command) error {
 	rt.Out.Answer("Agent", choice.Name)
 
 	rt.Out.Title("Step 2 · Autonomy")
-	autonomy := autonomyFull
+	autonomy := autonomyAuto
 	if err := tui.Form(false).
 		Field(huh.NewSelect[string]().
 			Title("How much can "+choice.Name+" do without stopping to ask?").
 			Description("You can interrupt anytime.").
 			Options(
+				huh.NewOption("Auto — use "+choice.Name+"'s built-in auto-approve mode", autonomyAuto),
 				huh.NewOption("Run freely — no approval prompts", autonomyFull),
 				huh.NewOption("Pre-approve rc, edits, and builds; ask for anything unusual", autonomyTrusted),
 				huh.NewOption("Ask me before each step", autonomyManual),
@@ -290,6 +296,7 @@ func runSetup(cmd *cobra.Command) error {
 }
 
 var autonomyLabels = map[string]string{
+	autonomyAuto:    "the agent's built-in auto-approve mode",
 	autonomyTrusted: "pre-approve rc, edits, builds; ask for the rest",
 	autonomyManual:  "ask before each step",
 	autonomyFull:    "run freely (no approval prompts)",
@@ -656,6 +663,15 @@ func detectAppProject(dir string) (label string, ok bool) {
 		}
 	}
 	return "no app project detected", false
+}
+
+// setupSessionName names the launched agent's session after the app directory.
+func setupSessionName() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "RevenueCat setup"
+	}
+	return "RevenueCat setup (" + filepath.Base(dir) + ")"
 }
 
 func collapseHome(dir string) string {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -256,10 +256,12 @@ func runSetup(cmd *cobra.Command) error {
 	}
 	install := exec.CommandContext(cmd.Context(), npxPath, installArgs...)
 	// Run from a temp dir so the global install can't drop a lockfile in the app repo.
-	if tmp, err := os.MkdirTemp("", "rc-skills-"); err == nil {
-		install.Dir = tmp
-		defer os.RemoveAll(tmp)
+	tmp, err := os.MkdirTemp("", "rc-skills-")
+	if err != nil {
+		return fmt.Errorf("create isolated skills install directory: %w", err)
 	}
+	install.Dir = tmp
+	defer os.RemoveAll(tmp)
 	if out, err := install.CombinedOutput(); err != nil {
 		tail := string(out)
 		if len(tail) > 1200 {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -24,11 +24,13 @@ type agentClient struct {
 	LaunchArgs func(prompt, autonomy string) []string
 }
 
-// Autonomy levels for the launched agent. "trusted" pre-approves the tools
-// the setup journey actually uses (rc, file edits, builds) so the human
-// isn't asked to approve every step of a run they already consented to;
-// "full" removes approvals entirely; "manual" is the agent's default.
+// Autonomy levels for the launched agent. "auto" maps to each agent's own
+// auto-approval mode; "trusted" pre-approves the tools the setup journey
+// actually uses (rc, file edits, builds) so the human isn't asked to approve
+// every step of a run they already consented to; "full" removes approvals
+// entirely; "manual" is the agent's default.
 const (
+	autonomyAuto    = "auto"
 	autonomyTrusted = "trusted"
 	autonomyFull    = "full"
 	autonomyManual  = "manual"
@@ -53,6 +55,8 @@ var agentClients = []agentClient{
 	{"Claude Code", "claude", "claude-code", func(p, autonomy string) []string {
 		name := setupSessionName()
 		switch autonomy {
+		case autonomyAuto:
+			return []string{"-n", name, "--permission-mode", "auto", p}
 		case autonomyTrusted:
 			// Prompt first — --allowedTools is variadic and would swallow a
 			// trailing positional. Patterns must be SEPARATE args: a
@@ -68,7 +72,7 @@ var agentClients = []agentClient{
 	}},
 	{"Codex", "codex", "codex", func(p, autonomy string) []string {
 		switch autonomy {
-		case autonomyTrusted:
+		case autonomyAuto, autonomyTrusted:
 			return []string{"--full-auto", p}
 		case autonomyFull:
 			return []string{"--dangerously-bypass-approvals-and-sandbox", p}
@@ -77,14 +81,14 @@ var agentClients = []agentClient{
 		}
 	}},
 	{"Cursor", "cursor-agent", "cursor", func(p, autonomy string) []string {
-		if autonomy == autonomyTrusted || autonomy == autonomyFull {
+		if autonomy == autonomyAuto || autonomy == autonomyTrusted || autonomy == autonomyFull {
 			return []string{"--force", p}
 		}
 		return []string{p}
 	}},
 	{"Gemini CLI", "gemini", "gemini-cli", func(p, autonomy string) []string {
 		switch autonomy {
-		case autonomyTrusted:
+		case autonomyAuto, autonomyTrusted:
 			return []string{"--approval-mode", "auto_edit", "-i", p}
 		case autonomyFull:
 			return []string{"--yolo", "-i", p}
@@ -196,12 +200,13 @@ func runSetup(cmd *cobra.Command) error {
 	rt.Out.Answer("Agent", choice.Name)
 
 	rt.Out.Title("Step 2 · Autonomy")
-	autonomy := autonomyFull
+	autonomy := autonomyAuto
 	if err := tui.Form(false).
 		Field(huh.NewSelect[string]().
 			Title("How much can "+choice.Name+" do without stopping to ask?").
 			Description("You can interrupt anytime.").
 			Options(
+				huh.NewOption("Auto — use "+choice.Name+"'s built-in auto-approve mode", autonomyAuto),
 				huh.NewOption("Run freely — no approval prompts", autonomyFull),
 				huh.NewOption("Pre-approve rc, edits, and builds; ask for anything unusual", autonomyTrusted),
 				huh.NewOption("Ask me before each step", autonomyManual),
@@ -291,6 +296,7 @@ func runSetup(cmd *cobra.Command) error {
 }
 
 var autonomyLabels = map[string]string{
+	autonomyAuto:    "the agent's built-in auto-approve mode",
 	autonomyTrusted: "pre-approve rc, edits, builds; ask for the rest",
 	autonomyManual:  "ask before each step",
 	autonomyFull:    "run freely (no approval prompts)",

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -114,7 +114,6 @@ the step-by-step commands in the docs.`,
   npx @revenuecat/cli setup`,
 		Args: cobra.NoArgs,
 		Annotations: map[string]string{
-			"surface":               "punted",
 			"requires_human":        "true",
 			"requires_human_reason": "interactively it launches a local AI agent; run non-interactively (rc setup --json) to get the setup prompt to follow directly",
 		},

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/revenuecat/cli/internal/config"
+	"github.com/revenuecat/cli/internal/tui"
 )
 
 const (
@@ -69,6 +73,76 @@ func revenueCatStarterPrompts() []starterPrompt {
 			Prompt: "Use the revenuecat-status skill to audit my RevenueCat project, identify missing or inconsistent configuration, and give me exact recovery steps without changing anything first.",
 		},
 	}
+}
+
+// skillsNudgeState persists whether the one-time install nudge has been shown.
+type skillsNudgeState struct {
+	Shown bool `json:"skills_nudge_shown"`
+}
+
+// revenueCatSkillDirs returns the skill dirs rc can inspect for an agent; nil when the layout is unknown (e.g. Gemini).
+func revenueCatSkillDirs(toolkitKey string) []string {
+	var rel string
+	switch toolkitKey {
+	case "claude-code":
+		rel = filepath.Join(".claude", "skills")
+	case "codex":
+		rel = filepath.Join(".codex", "skills")
+	case "cursor":
+		rel = filepath.Join(".cursor", "skills-cursor")
+	default:
+		return nil
+	}
+	var dirs []string
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, rel))
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		dirs = append(dirs, filepath.Join(cwd, rel))
+	}
+	return dirs
+}
+
+// revenueCatSkillsInstalledFor reports whether the skills are installed; checkable is false when rc can't inspect the agent.
+func revenueCatSkillsInstalledFor(a agentClient) (checkable, installed bool) {
+	dirs := revenueCatSkillDirs(a.ToolkitKey)
+	if len(dirs) == 0 {
+		return false, false
+	}
+	for _, d := range dirs {
+		if _, err := os.Stat(filepath.Join(d, "create-revenuecat-project")); err == nil {
+			return true, true
+		}
+	}
+	return true, false
+}
+
+// maybeNudgeSkillsInstall shows the install-skills hint once, for humans only, when a supported agent has no skills.
+func maybeNudgeSkillsInstall(rt *Runtime) {
+	if rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
+		return
+	}
+	missing := false
+	for _, a := range detectAgents() {
+		checkable, installed := revenueCatSkillsInstalledFor(a)
+		if !checkable {
+			continue
+		}
+		if installed {
+			return
+		}
+		missing = true
+	}
+	if !missing {
+		return
+	}
+	var st skillsNudgeState
+	if err := config.LoadState(rt.Globals.Profile, "hints", &st); err != nil || st.Shown {
+		return
+	}
+	rt.Out.Hint("Coding with an AI agent? Install the RevenueCat skills:  rc skills install")
+	st.Shown = true
+	_ = config.SaveState(rt.Globals.Profile, "hints", &st)
 }
 
 func showStarterPrompts(rt *Runtime) {

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/revenuecat/cli/internal/config"
+	"github.com/revenuecat/cli/internal/tui"
 )
 
 const (
@@ -69,6 +73,76 @@ func revenueCatStarterPrompts() []starterPrompt {
 			Prompt: "Use the revenuecat-status skill to audit my RevenueCat project, identify missing or inconsistent configuration, and give me exact recovery steps without changing anything first.",
 		},
 	}
+}
+
+// skillsNudgeState persists whether the one-time install nudge has been shown.
+type skillsNudgeState struct {
+	Shown bool `json:"skills_nudge_shown"`
+}
+
+// revenueCatSkillDirs returns the skill dirs rc can inspect for an agent; nil when the layout is unknown (e.g. Gemini).
+func revenueCatSkillDirs(toolkitKey string) []string {
+	var rel string
+	switch toolkitKey {
+	case "claude-code":
+		rel = filepath.Join(".claude", "skills")
+	case "codex":
+		rel = filepath.Join(".codex", "skills")
+	case "cursor":
+		rel = filepath.Join(".cursor", "skills")
+	default:
+		return nil
+	}
+	var dirs []string
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, rel))
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		dirs = append(dirs, filepath.Join(cwd, rel))
+	}
+	return dirs
+}
+
+// revenueCatSkillsInstalledFor reports whether the skills are installed; checkable is false when rc can't inspect the agent.
+func revenueCatSkillsInstalledFor(a agentClient) (checkable, installed bool) {
+	dirs := revenueCatSkillDirs(a.ToolkitKey)
+	if len(dirs) == 0 {
+		return false, false
+	}
+	for _, d := range dirs {
+		if _, err := os.Stat(filepath.Join(d, "create-revenuecat-project")); err == nil {
+			return true, true
+		}
+	}
+	return true, false
+}
+
+// maybeNudgeSkillsInstall shows the install-skills hint once, for humans only, when a supported agent has no skills.
+func maybeNudgeSkillsInstall(rt *Runtime) {
+	if rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
+		return
+	}
+	missing := false
+	for _, a := range detectAgents() {
+		checkable, installed := revenueCatSkillsInstalledFor(a)
+		if !checkable {
+			continue
+		}
+		if installed {
+			return
+		}
+		missing = true
+	}
+	if !missing {
+		return
+	}
+	var st skillsNudgeState
+	if err := config.LoadState(rt.Globals.Profile, "hints", &st); err != nil || st.Shown {
+		return
+	}
+	rt.Out.Hint("Coding with an AI agent? Install the RevenueCat skills:  rc skills install")
+	st.Shown = true
+	_ = config.SaveState(rt.Globals.Profile, "hints", &st)
 }
 
 func showStarterPrompts(rt *Runtime) {

--- a/internal/cli/surface_test.go
+++ b/internal/cli/surface_test.go
@@ -1,36 +1,37 @@
 package cli
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
 
 // The command surface splits by output channel: humans see the curated set in
 // --help, agents/JSON see everything. These guard the two invariants that
 // keep that honest.
 
-// Agent discovery (rc commands --schemas) must include agent-only commands —
-// hidden from --help but present here — while excluding the punted tier.
-// Hiding from humans must not hide from agents.
-func TestCommandSurface_SchemaIncludesAgentOnlyExcludesPunted(t *testing.T) {
+// Agent discovery (rc commands --schemas) must include every non-punted
+// command, including setup (agents run it non-interactively for the prompt).
+func TestCommandSurface_SchemaIncludesAgentCommands(t *testing.T) {
 	root := NewRootCmd("test")
 	tree := commandTreeWithSchemas(root)
 	names := map[string]bool{}
 	for _, c := range tree["commands"].([]map[string]any) {
 		names[c["name"].(string)] = true
 	}
-	for _, agentOnly := range []string{"customer", "offerings", "entitlements", "packages"} {
-		if !names[agentOnly] {
-			t.Errorf("agent-only command %q missing from schema surface", agentOnly)
+	for _, want := range []string{"customer", "offerings", "entitlements", "packages", "setup"} {
+		if !names[want] {
+			t.Errorf("command %q missing from schema surface", want)
 		}
-	}
-	if names["setup"] {
-		t.Error("punted command 'setup' should not appear in the schema surface")
 	}
 }
 
 // The human-help curation runs behind a testing.Testing() short-circuit, so
-// this drives curateSurface directly: the full surface shows by default, only
-// punted is held back, aliases stay hidden, and --all reveals punted too.
+// this drives curateSurface directly: the full surface shows by default, a
+// punted command is held back until --all, and aliases stay hidden.
 func TestCurateSurface(t *testing.T) {
 	root := NewRootCmd("test")
+	root.AddCommand(&cobra.Command{Use: "x-punted", Annotations: map[string]string{annotationSurface: surfacePunted}})
 	hidden := func(name string) bool {
 		for _, c := range root.Commands() {
 			if c.Name() == name {
@@ -48,15 +49,18 @@ func TestCurateSurface(t *testing.T) {
 	if hidden("customer") {
 		t.Error("'customer' should be visible in --help (full surface)")
 	}
+	if hidden("setup") {
+		t.Error("'setup' should be visible in --help")
+	}
 	if !hidden("login") {
 		t.Error("the back-compat 'login' alias should stay hidden")
 	}
-	if !hidden("setup") {
-		t.Error("punted 'setup' should be hidden by default")
+	if !hidden("x-punted") {
+		t.Error("a punted command should be hidden by default")
 	}
 
 	curateSurface(root, true) // rc --all
-	if hidden("setup") {
-		t.Error("--all should reveal punted 'setup'")
+	if hidden("x-punted") {
+		t.Error("--all should reveal a punted command")
 	}
 }

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -80,6 +80,12 @@ func (e *ChatEmitter) Approve(prompt string, destructive bool) bool {
 // RunChat opens the window and blocks until the user exits.
 func (c Chat) RunChat() error {
 	model := newChatModel(c)
+	// Probe the background before Bubble Tea owns stdin; a later auto-probe leaks
+	// the terminal's OSC 11 / cursor-report replies into the textarea.
+	model.markdownStyle = "light"
+	if lipgloss.HasDarkBackground() {
+		model.markdownStyle = "dark"
+	}
 	program := tea.NewProgram(model, tea.WithAltScreen())
 	model.program = program
 	_, err := program.Run()
@@ -100,10 +106,11 @@ type chatModel struct {
 	cfg     Chat
 	program *tea.Program
 
-	viewport viewport.Model
-	input    textarea.Model
-	spin     spinner.Model
-	markdown *glamour.TermRenderer
+	viewport      viewport.Model
+	input         textarea.Model
+	spin          spinner.Model
+	markdown      *glamour.TermRenderer
+	markdownStyle string
 
 	entries   []ChatEntry
 	streaming bool
@@ -341,7 +348,7 @@ func (m *chatModel) layout() {
 	}
 	m.input.SetWidth(max(m.width-6, 10)) // border + padding
 	renderer, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
+		glamour.WithStandardStyle(m.markdownStyle),
 		glamour.WithWordWrap(max(m.width-4, 20)),
 		glamour.WithEmoji(),
 	)


### PR DESCRIPTION
`rc setup` installed the RevenueCat skills project-scoped, into the app repo's `.claude` dir. The agent it launches won't load skills from a project directory until it trusts that directory, so on the very first `rc setup` the agent couldn't find `create-revenuecat-project` and re-installed it itself.

Install globally instead (matching `rc skills install`), from a temp dir so nothing leaks into the app repo. Global skills load immediately, no per-directory trust step. Drops the here-or-globally question too.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default onboarding UX and how setup launches external agents with elevated autonomy; setup and skills install behavior affects first-run paths but does not alter RevenueCat API or auth logic.
> 
> **Overview**
> **`rc setup` is now the primary onboarding path** — featured in README, home screen, root help, and default `--help` (no longer `surface: punted`), and included in `rc commands --schemas` for agents running `rc setup --json`.
> 
> The interactive setup flow **installs RevenueCat skills globally** (not project-scoped) from an isolated temp directory so agents load skills on first launch without trusting the repo, and **drops the project-vs-global skills picker**. Default agent autonomy is **Auto**, with updated launch flags (named sessions, Codex/Cursor/Gemini mappings).
> 
> Bare **`rc`** may show a **one-time hint** to run `rc skills install` when a detected agent lacks skills.
> 
> **Paywall AI** uses a separate hint on `EventRunFailed` when nothing was saved (suggest transient re-run vs session recovery).
> 
> **Rico chat TUI** probes dark/light background before Bubble Tea owns stdin to avoid terminal probe noise in the input area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb55d14f7952e6ec325833055fce6ffbb52a8b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->