### PR TITLE
fix(cli): dashboardProjectID drops a leading hex char from project IDs (DX-933)

### DIFF
--- a/internal/cli/projects.go
+++ b/internal/cli/projects.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/huh"
@@ -294,22 +295,11 @@ func derefStr(s *string) string {
 	return *s
 }
 
-// dashboardProjectID strips the alphabetic type prefix (and optional underscore
-// separator) from an API resource ID so it can be used in dashboard URLs.
-//
-//	"proj5adb8697"  → "5adb8697"   (no underscore)
-//	"app_abc123"    → "abc123"     (underscore separator)
-//	"ofrng_xyz"     → "xyz"
+// dashboardProjectID strips the "proj" prefix (and an optional "_" separator) from a project ID for use in dashboard URLs.
 func dashboardProjectID(id string) string {
-	i := 0
-	for i < len(id) && ((id[i] >= 'a' && id[i] <= 'z') || (id[i] >= 'A' && id[i] <= 'Z')) {
-		i++
+	s := strings.TrimPrefix(id, "proj")
+	if s == id {
+		return id
 	}
-	if i < len(id) && id[i] == '_' {
-		i++
-	}
-	if i < len(id) {
-		return id[i:]
-	}
-	return id
+	return strings.TrimPrefix(s, "_")
 }

--- a/internal/cli/projects_test.go
+++ b/internal/cli/projects_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import "testing"
+
+func TestDashboardProjectID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"hash starting with hex letter is preserved", "projf61a7d28", "f61a7d28"},
+		{"hash starting with digit", "proj0abc", "0abc"},
+		{"hash starting with non-hex letter", "projzed123", "zed123"},
+		{"existing example", "proj5adb8697", "5adb8697"},
+		{"underscore separator form", "proj_abc", "abc"},
+		{"id without proj prefix returned unchanged", "5adb8697", "5adb8697"},
+		{"empty string", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dashboardProjectID(tt.in); got != tt.want {
+				t.Errorf("dashboardProjectID(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`dashboardProjectID` stripped a run of letters instead of the literal `proj` prefix, so a project id like `projf61a7d28` came out as `61a7d28` — mangling every dashboard link whose hash starts with a–f. Now strips just the prefix. Adds a regression table test.

DX-933

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI URL helper fix with regression tests; no auth, API, or data-path changes.
> 
> **Overview**
> Fixes **broken RevenueCat dashboard links** in the CLI when a project ID’s hash starts with a hex letter (`a`–`f`).
> 
> `dashboardProjectID` no longer strips every leading run of letters; it removes only the literal **`proj`** prefix (and an optional **`_`** after it), so IDs like `projf61a7d28` map to `f61a7d28` instead of `61a7d28`. IDs without a `proj` prefix are left unchanged.
> 
> Adds **`TestDashboardProjectID`** with table cases for hex-leading hashes, `proj_` form, and edge inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 589c527dcf740853d03ae29084b78f4f32185dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->