### PR TITLE
feat(cli): human-readable durations in TTY output (DX-916)

### DIFF
--- a/internal/cli/duration.go
+++ b/internal/cli/duration.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var isoDurationRe = regexp.MustCompile(`^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$`)
+
+// formatISODuration renders an ISO 8601 duration as human text, returning the input unchanged if it can't parse.
+func formatISODuration(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return s
+	}
+	m := isoDurationRe.FindStringSubmatch(trimmed)
+	if m == nil {
+		return s
+	}
+
+	years := atoiOrZero(m[1])
+	months := atoiOrZero(m[2])
+	weeks := atoiOrZero(m[3])
+	days := atoiOrZero(m[4])
+	hours := atoiOrZero(m[5])
+	minutes := atoiOrZero(m[6])
+	seconds := atoiOrZero(m[7])
+
+	total := years + months + weeks + days + hours + minutes + seconds
+	if total == 0 {
+		if !strings.ContainsAny(trimmed, "0123456789") {
+			return s
+		}
+		return "none"
+	}
+
+	if weeks == 0 && days > 0 && days%7 == 0 && years+months+hours+minutes+seconds == 0 {
+		weeks = days / 7
+		days = 0
+	}
+
+	var parts []string
+	add := func(n int, unit string) {
+		if n > 0 {
+			parts = append(parts, pluralize(n, unit))
+		}
+	}
+	add(years, "year")
+	add(months, "month")
+	add(weeks, "week")
+	add(days, "day")
+	add(hours, "hour")
+	add(minutes, "minute")
+	add(seconds, "second")
+
+	return strings.Join(parts, " ")
+}
+
+func atoiOrZero(s string) int {
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func pluralize(n int, unit string) string {
+	s := strconv.Itoa(n) + " " + unit
+	if n != 1 {
+		s += "s"
+	}
+	return s
+}

--- a/internal/cli/duration_test.go
+++ b/internal/cli/duration_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import "testing"
+
+func TestFormatISODuration(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"P0D", "none"},
+		{"PT0S", "none"},
+		{"P1D", "1 day"},
+		{"P3D", "3 days"},
+		{"P7D", "1 week"},
+		{"P1W", "1 week"},
+		{"P1M", "1 month"},
+		{"P2M", "2 months"},
+		{"P1Y", "1 year"},
+		{"P1Y1M", "1 year 1 month"},
+		{"P14D", "2 weeks"},
+		{"PT1H30M", "1 hour 30 minutes"},
+		{"", ""},
+		{"banana", "banana"},
+		{"P", "P"},
+		{"P1X", "P1X"},
+	}
+	for _, c := range cases {
+		if got := formatISODuration(c.in); got != c.want {
+			t.Errorf("formatISODuration(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -202,7 +202,7 @@ func newProductsListCmd() *cobra.Command {
 			for _, p := range page.Items {
 				dur := ""
 				if p.Subscription != nil && p.Subscription.Duration != nil {
-					dur = *p.Subscription.Duration
+					dur = formatISODuration(*p.Subscription.Duration)
 				}
 				rows = append(rows, []string{p.ID, derefStr(p.DisplayName), string(p.Type), p.StoreIdentifier, dur, string(p.State)})
 			}
@@ -622,9 +622,9 @@ func productPickerItems(ctx context.Context, client *api.Client, projectID strin
 func productToItem(p api.Product) tui.BrowserItem {
 	dur, grace, trial := "", "", ""
 	if p.Subscription != nil {
-		dur = derefStr(p.Subscription.Duration)
-		grace = derefStr(p.Subscription.GracePeriodDuration)
-		trial = derefStr(p.Subscription.TrialDuration)
+		dur = formatISODuration(derefStr(p.Subscription.Duration))
+		grace = formatISODuration(derefStr(p.Subscription.GracePeriodDuration))
+		trial = formatISODuration(derefStr(p.Subscription.TrialDuration))
 	}
 	displayName := derefStr(p.DisplayName)
 	return tui.BrowserItem{

--- a/internal/cli/products_duration_render_test.go
+++ b/internal/cli/products_duration_render_test.go
@@ -1,0 +1,49 @@
+package cli_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestProductsListDurationRendering(t *testing.T) {
+	const body = `{"object":"list","items":[{"object":"product","id":"prod_sub","display_name":"Premium Monthly","type":"subscription","store_identifier":"rc_monthly","state":"active","app_id":"app_x","created_at":1658399423658,"subscription":{"duration":"P1M","grace_period_duration":"P3D","trial_duration":"P1W"}}],"next_page":null,"url":"/products"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/products") {
+			io.WriteString(w, body)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		io.WriteString(w, `{"object":"error","type":"resource_missing","message":"not found"}`)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("RC_BASE_URL", server.URL)
+
+	base := []string{"products", "list", "--no-input", "--project-id", "proj_x", "--api-key", "sk_x"}
+
+	humanOut, _, err := runAgentCmd(t, base...)
+	if err != nil {
+		t.Fatalf("human run failed: %v", err)
+	}
+	if !strings.Contains(humanOut, "1 month") {
+		t.Errorf("human output missing friendly duration %q; got:\n%s", "1 month", humanOut)
+	}
+	if strings.Contains(humanOut, "P1M") {
+		t.Errorf("human output leaked raw ISO duration P1M; got:\n%s", humanOut)
+	}
+
+	jsonOut, _, err := runAgentCmd(t, append(base, "--json")...)
+	if err != nil {
+		t.Fatalf("json run failed: %v", err)
+	}
+	if !strings.Contains(jsonOut, `"duration": "P1M"`) {
+		t.Errorf("json output lost raw duration P1M; got:\n%s", jsonOut)
+	}
+	if strings.Contains(jsonOut, "1 month") {
+		t.Errorf("json output contained humanized duration; got:\n%s", jsonOut)
+	}
+}


### PR DESCRIPTION
Renders ISO-8601 durations (`P0D`, `P1M`, `P1Y`, …) as human text in TTY/human output while keeping raw ISO values in `--json`. Left `metrics.go`'s PERIOD column alone (different semantics there).

DX-916

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting in CLI tables and TUI fields; no API or persistence changes, with JSON output explicitly unchanged.
> 
> **Overview**
> Human-readable subscription durations in **products** human/TTY output instead of raw ISO-8601 strings like `P1M`.
> 
> Adds **`formatISODuration`** in `duration.go` to parse common ISO durations and render phrases such as `1 month`, `2 weeks`, or `none` for zero lengths; unparsable values stay unchanged. **`products list`** uses it for the DURATION column, and **`productToItem`** applies it to duration, grace period, and trial in the interactive browser detail fields.
> 
> **`--json`** output still exposes raw ISO values from the API (verified by integration test). Unit tests cover the formatter and list rendering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d76c9d25e8c178393898822ccbada309967372b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->