### PR TITLE
fix(cli): derive command capabilities from the tree, not a fixed allowlist (DX-918)

### DIFF
--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -150,38 +150,62 @@ func addHumanRequirement(schema map[string]any, c *cobra.Command) {
 	}
 }
 
-// inferCapabilities returns CRUD-style capability labels by inspecting subcommand names.
-// This lets agents know what operations are available without reading every subcommand.
+// inferCapabilities lists runnable descendants as `group:verb` labels relative to c.
 func inferCapabilities(c *cobra.Command) []string {
-	known := map[string]string{
-		"list":      "list",
-		"show":      "show",
-		"get":       "show",
-		"create":    "create",
-		"update":    "update",
-		"delete":    "delete",
-		"archive":   "archive",
-		"restore":   "restore",
-		"push":      "push",
-		"attach":    "attach",
-		"detach":    "detach",
-		"publish":   "publish",
-		"unpublish": "unpublish",
-		"verify":    "verify",
-		"preview":   "preview",
+	acc := &capAccumulator{seen: map[string]bool{}}
+	if c.Runnable() {
+		acc.add(canonicalVerb(c.Name()))
 	}
-	seen := map[string]bool{}
-	var caps []string
 	for _, sc := range c.Commands() {
 		if puntedFromSchema(sc) {
 			continue
 		}
-		if cap, ok := known[sc.Name()]; ok && !seen[cap] {
-			seen[cap] = true
-			caps = append(caps, cap)
-		}
+		collectCapabilities(sc, []string{sc.Name()}, acc)
 	}
-	return caps
+	return acc.caps
+}
+
+func collectCapabilities(c *cobra.Command, path []string, acc *capAccumulator) {
+	if c.Runnable() {
+		acc.add(capLabel(path))
+	}
+	for _, sc := range c.Commands() {
+		if puntedFromSchema(sc) {
+			continue
+		}
+		collectCapabilities(sc, append(append([]string{}, path...), sc.Name()), acc)
+	}
+}
+
+func capLabel(path []string) string {
+	if len(path) == 0 {
+		return ""
+	}
+	out := append([]string{}, path[:len(path)-1]...)
+	out = append(out, canonicalVerb(path[len(path)-1]))
+	return strings.Join(out, ":")
+}
+
+func canonicalVerb(name string) string {
+	switch name {
+	case "get":
+		return "show"
+	default:
+		return name
+	}
+}
+
+type capAccumulator struct {
+	seen map[string]bool
+	caps []string
+}
+
+func (a *capAccumulator) add(label string) {
+	if label == "" || a.seen[label] {
+		return
+	}
+	a.seen[label] = true
+	a.caps = append(a.caps, label)
 }
 
 // parseArgsFromUse extracts <required> and [optional] tokens from a cobra Use

--- a/internal/cli/schema_test.go
+++ b/internal/cli/schema_test.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func findCommand(t *testing.T, root *cobra.Command, path string) *cobra.Command {
+	t.Helper()
+	cur := root
+	if path == "" {
+		return cur
+	}
+	for _, name := range strings.Fields(path) {
+		var next *cobra.Command
+		for _, sc := range cur.Commands() {
+			if sc.Name() == name {
+				next = sc
+				break
+			}
+		}
+		if next == nil {
+			t.Fatalf("command %q not found (stuck at %q)", path, cur.Name())
+		}
+		cur = next
+	}
+	return cur
+}
+
+func capsOf(t *testing.T, root *cobra.Command, path string) []string {
+	t.Helper()
+	return inferCapabilities(findCommand(t, root, path))
+}
+
+func contains(caps []string, want string) bool {
+	for _, c := range caps {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestInferCapabilities_NestedPriceWriteSurfaces(t *testing.T) {
+	root := NewRootCmd("test")
+
+	priceCaps := capsOf(t, root, "products prices")
+	if !contains(priceCaps, "set") {
+		t.Errorf("products prices should expose a `set` capability, got %v", priceCaps)
+	}
+
+	productCaps := capsOf(t, root, "products")
+	if !contains(productCaps, "prices:set") {
+		t.Errorf("products should aggregate the nested `prices:set` capability, got %v", productCaps)
+	}
+}
+
+func TestInferCapabilities_NoActionableGroupIsBlank(t *testing.T) {
+	root := NewRootCmd("test")
+
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"auth", "login"},
+		{"apps apple", "setup"},
+		{"apps apple", "check"},
+		{"rico", "rico"},
+	}
+	for _, tc := range cases {
+		caps := capsOf(t, root, tc.path)
+		if len(caps) == 0 {
+			t.Errorf("%q reported no capabilities; a command with actions must not be blank", tc.path)
+			continue
+		}
+		if !contains(caps, tc.want) {
+			t.Errorf("%q capabilities %v missing expected %q", tc.path, caps, tc.want)
+		}
+	}
+}
+
+func TestCanonicalVerb_FoldsGetToShow(t *testing.T) {
+	if got := canonicalVerb("get"); got != "show" {
+		t.Errorf("canonicalVerb(get) = %q, want show", got)
+	}
+	if got := canonicalVerb("sync"); got != "sync" {
+		t.Errorf("canonicalVerb(sync) = %q, want sync", got)
+	}
+}
+
+func TestInferCapabilities_DriftGuard(t *testing.T) {
+	root := NewRootCmd("test")
+
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		if puntedFromSchema(c) {
+			return
+		}
+
+		if hasRunnableDescendant(c) && len(inferCapabilities(c)) == 0 {
+			t.Errorf("%q has actionable subcommands but reports no capabilities", commandPath(c))
+		}
+
+		if len(c.Commands()) > 0 {
+			caps := inferCapabilities(c)
+			for _, sc := range c.Commands() {
+				if puntedFromSchema(sc) || !sc.Runnable() {
+					continue
+				}
+				want := canonicalVerb(sc.Name())
+				if !contains(caps, want) {
+					t.Errorf("runnable command %q not represented in %q capabilities %v (want %q)",
+						commandPath(sc), commandPath(c), caps, want)
+				}
+			}
+		}
+
+		for _, sc := range c.Commands() {
+			walk(sc)
+		}
+	}
+	walk(root)
+}
+
+func hasRunnableDescendant(c *cobra.Command) bool {
+	for _, sc := range c.Commands() {
+		if puntedFromSchema(sc) {
+			continue
+		}
+		if sc.Runnable() || hasRunnableDescendant(sc) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
`inferCapabilities` used a hardcoded verb allowlist and only looked one level down, so `products prices set` (and other nested/novel verbs) showed no capability — which is why agents thought the CLI couldn't write prices. Now derives capabilities from runnable descendants (`group:verb`), with a drift-guard test so a new verb can't silently go missing.

DX-918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect CLI schema/introspection output for agents; no runtime command behavior or security-sensitive paths.
> 
> **Overview**
> **`inferCapabilities`** no longer uses a hardcoded verb map and a single level of subcommands. It walks the full command tree, records every **runnable** descendant as **`group:verb`** labels (e.g. **`prices:set`** on **`products`**), and includes the current command’s own verb when it is runnable. **`get`** is still normalized to **`show`** via **`canonicalVerb`**.
> 
> New tests cover nested price **`set`**, non-empty capabilities on actionable groups, **`get`→show`**, and a **drift guard** that walks the real root so new runnable verbs cannot disappear from parent **`capabilities`** in **`rc schema`** / **`rc commands`** JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64720cdd440b3cedc764d4d968c2397a3424bff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->