### PR TITLE
fix(paywalls): keep one Astra session across edit turns (DX-939)

### DIFF
--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -560,7 +560,10 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 				checkpointed = true
 			}
 		case paywallai.EventRunFailed:
-			applySessionEvent(session, event)
+			// not applySessionEvent: a failed event omits trace_id and would clear the last good turn's TraceID, breaking rewind.
+			if event.SessionID != "" {
+				session.SessionID = event.SessionID
+			}
 			_ = savePaywallAISession(opts.sessionPath, session)
 			return WithHint(fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message), paywallRunFailedHint(opts, checkpointed))
 		case paywallai.EventRunCompleted:

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -323,9 +323,9 @@ Using it well:
 				if perr != nil {
 					return perr
 				}
-				session, err = seedSessionFromServer(cmd.Context(), rt, projectID, paywallID)
+				opts.sessionPath, err = defaultPaywallSessionPath(projectID, paywallID)
 				if err == nil {
-					opts.sessionPath, err = defaultPaywallSessionPath(projectID, paywallID)
+					session, err = resumeOrSeedSession(cmd.Context(), rt, projectID, paywallID, opts.sessionPath)
 				}
 			default:
 				return fmt.Errorf("pass a paywall ID or --session <file>")
@@ -367,6 +367,27 @@ func preflightSessionRevision(ctx context.Context, rt *Runtime, session *paywall
 		return nil, err
 	}
 	return seedSessionFromServer(ctx, rt, session.ProjectID, session.PaywallID)
+}
+
+// resumeOrSeedSession reuses the default-path session for an `edit` turn without
+// an explicit --session when it still matches the server's draft, else seeds fresh.
+func resumeOrSeedSession(ctx context.Context, rt *Runtime, projectID, paywallID, sessionPath string) (*paywallAISession, error) {
+	stored, err := loadPaywallAISession(rt, sessionPath)
+	if err != nil {
+		return seedSessionFromServer(ctx, rt, projectID, paywallID)
+	}
+	client, err := rt.API()
+	if err != nil {
+		return nil, err
+	}
+	revision, err := currentDraftRevision(ctx, client, projectID, paywallID)
+	if err != nil {
+		return nil, err
+	}
+	if stored.Revision != nil && revision == *stored.Revision {
+		return stored, nil
+	}
+	return seedSessionFromServer(ctx, rt, projectID, paywallID)
 }
 
 // seedSessionFromServer starts an editor session from the paywall's current
@@ -527,7 +548,11 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 		}
 		switch event.Type {
 		case paywallai.EventRunStarted:
-			session.SessionID = event.SessionID
+			// An empty id must not wipe a stored one, or the next turn forks a new session.
+			if event.SessionID != "" {
+				session.SessionID = event.SessionID
+			}
+			_ = savePaywallAISession(opts.sessionPath, session)
 		case paywallai.EventTurnSnapshot:
 			reportedActivity = reportPaywallAIActivity(rt, event.Activity, reportedActivity)
 			applySessionEvent(session, event)
@@ -535,6 +560,8 @@ func runPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, sessi
 				checkpointed = true
 			}
 		case paywallai.EventRunFailed:
+			applySessionEvent(session, event)
+			_ = savePaywallAISession(opts.sessionPath, session)
 			return WithHint(fmt.Errorf("paywall AI editor run failed (%s): %s", event.Error.Code, event.Error.Message), paywallRunFailedHint(opts, checkpointed))
 		case paywallai.EventRunCompleted:
 			reportPaywallAIActivity(rt, event.Activity, reportedActivity)

--- a/internal/cli/paywalls_ai_session_test.go
+++ b/internal/cli/paywalls_ai_session_test.go
@@ -44,7 +44,7 @@ func newTestSession() *paywallAISession {
 	}
 }
 
-func astraFailingServer(t *testing.T, startedSessionID string) *httptest.Server {
+func failingEditorServer(t *testing.T, startedSessionID string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -54,8 +54,8 @@ func astraFailingServer(t *testing.T, startedSessionID string) *httptest.Server 
 }
 
 func TestRunPaywallAI_FailedRunPersistsSessionID(t *testing.T) {
-	astra := astraFailingServer(t, "sess_minted")
-	defer astra.Close()
+	editor := failingEditorServer(t, "sess_minted")
+	defer editor.Close()
 
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session"+paywallSessionSuffix)
@@ -65,7 +65,7 @@ func TestRunPaywallAI_FailedRunPersistsSessionID(t *testing.T) {
 	}
 
 	rt := newSessionTestRuntime("https://rc.invalid")
-	opts := paywallAIOptions{baseURL: astra.URL, sessionPath: sessionPath, prompt: "make it blue", timeout: 30 * time.Second}
+	opts := paywallAIOptions{baseURL: editor.URL, sessionPath: sessionPath, prompt: "make it blue", timeout: 30 * time.Second}
 	if err := runPaywallAI(context.Background(), rt, opts, session); err == nil {
 		t.Fatal("expected the failed run to return an error")
 	}
@@ -80,8 +80,8 @@ func TestRunPaywallAI_FailedRunPersistsSessionID(t *testing.T) {
 }
 
 func TestRunPaywallAI_EmptyRunStartedKeepsStoredSessionID(t *testing.T) {
-	astra := astraFailingServer(t, "")
-	defer astra.Close()
+	editor := failingEditorServer(t, "")
+	defer editor.Close()
 
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session"+paywallSessionSuffix)
@@ -92,7 +92,7 @@ func TestRunPaywallAI_EmptyRunStartedKeepsStoredSessionID(t *testing.T) {
 	}
 
 	rt := newSessionTestRuntime("https://rc.invalid")
-	opts := paywallAIOptions{baseURL: astra.URL, sessionPath: sessionPath, prompt: "keep going", timeout: 30 * time.Second}
+	opts := paywallAIOptions{baseURL: editor.URL, sessionPath: sessionPath, prompt: "keep going", timeout: 30 * time.Second}
 	if err := runPaywallAI(context.Background(), rt, opts, session); err == nil {
 		t.Fatal("expected the failed run to return an error")
 	}
@@ -137,13 +137,13 @@ func (m *rcPaywallMock) server(t *testing.T) *httptest.Server {
 	}))
 }
 
-type astraEchoServer struct {
+type echoEditorServer struct {
 	mu       sync.Mutex
 	received []string
 	minted   int
 }
 
-func (s *astraEchoServer) server(t *testing.T) *httptest.Server {
+func (s *echoEditorServer) server(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
@@ -167,10 +167,10 @@ func (s *astraEchoServer) server(t *testing.T) *httptest.Server {
 	}))
 }
 
-func runEditTurn(t *testing.T, configDir, astraURL, rcURL, paywallID string) {
+func runEditTurn(t *testing.T, configDir, editorURL, rcURL, paywallID string) {
 	t.Helper()
 	t.Setenv("RC_CONFIG_DIR", configDir)
-	t.Setenv("RC_PAYWALL_AI_BASE_URL", astraURL)
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", editorURL)
 	cmd := newPaywallsEditCmd()
 	rt := newSessionTestRuntime(rcURL)
 	cmd.SetContext(WithRuntime(context.Background(), rt))
@@ -186,17 +186,17 @@ func TestPaywallsEdit_AutoContinuesSessionAcrossTurns(t *testing.T) {
 	rc := &rcPaywallMock{}
 	rcServer := rc.server(t)
 	defer rcServer.Close()
-	astra := &astraEchoServer{}
-	astraServer := astra.server(t)
-	defer astraServer.Close()
+	editor := &echoEditorServer{}
+	editorServer := editor.server(t)
+	defer editorServer.Close()
 
 	configDir := t.TempDir()
-	runEditTurn(t, configDir, astraServer.URL, rcServer.URL, "pw_test")
-	runEditTurn(t, configDir, astraServer.URL, rcServer.URL, "pw_test")
+	runEditTurn(t, configDir, editorServer.URL, rcServer.URL, "pw_test")
+	runEditTurn(t, configDir, editorServer.URL, rcServer.URL, "pw_test")
 
-	astra.mu.Lock()
-	received := append([]string(nil), astra.received...)
-	astra.mu.Unlock()
+	editor.mu.Lock()
+	received := append([]string(nil), editor.received...)
+	editor.mu.Unlock()
 
 	if len(received) != 2 {
 		t.Fatalf("expected 2 editor turns, got %d: %v", len(received), received)
@@ -216,9 +216,9 @@ func TestPaywallsEdit_ExplicitSessionOverridesDefault(t *testing.T) {
 	rc := &rcPaywallMock{}
 	rcServer := rc.server(t)
 	defer rcServer.Close()
-	astra := &astraEchoServer{}
-	astraServer := astra.server(t)
-	defer astraServer.Close()
+	editor := &echoEditorServer{}
+	editorServer := editor.server(t)
+	defer editorServer.Close()
 
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "custom"+paywallSessionSuffix)
@@ -229,7 +229,7 @@ func TestPaywallsEdit_ExplicitSessionOverridesDefault(t *testing.T) {
 	}
 
 	t.Setenv("RC_CONFIG_DIR", t.TempDir())
-	t.Setenv("RC_PAYWALL_AI_BASE_URL", astraServer.URL)
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", editorServer.URL)
 	cmd := newPaywallsEditCmd()
 	rt := newSessionTestRuntime(rcServer.URL)
 	cmd.SetContext(WithRuntime(context.Background(), rt))
@@ -240,9 +240,9 @@ func TestPaywallsEdit_ExplicitSessionOverridesDefault(t *testing.T) {
 		t.Fatalf("edit with --session failed: %v", err)
 	}
 
-	astra.mu.Lock()
-	received := append([]string(nil), astra.received...)
-	astra.mu.Unlock()
+	editor.mu.Lock()
+	received := append([]string(nil), editor.received...)
+	editor.mu.Unlock()
 	if len(received) != 1 || received[0] != "sess_explicit" {
 		t.Fatalf("--session did not drive the request session id: %v", received)
 	}

--- a/internal/cli/paywalls_ai_session_test.go
+++ b/internal/cli/paywalls_ai_session_test.go
@@ -60,6 +60,7 @@ func TestRunPaywallAI_FailedRunPersistsSessionID(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session"+paywallSessionSuffix)
 	session := newTestSession()
+	session.TraceID = "trace_prev"
 	if err := savePaywallAISession(sessionPath, session); err != nil {
 		t.Fatal(err)
 	}
@@ -76,6 +77,9 @@ func TestRunPaywallAI_FailedRunPersistsSessionID(t *testing.T) {
 	}
 	if stored.SessionID != "sess_minted" {
 		t.Fatalf("failed run did not persist session id: got %q, want sess_minted", stored.SessionID)
+	}
+	if stored.TraceID != "trace_prev" {
+		t.Fatalf("failed run cleared the last good TraceID: got %q, want trace_prev", stored.TraceID)
 	}
 }
 

--- a/internal/cli/paywalls_ai_session_test.go
+++ b/internal/cli/paywalls_ai_session_test.go
@@ -1,0 +1,249 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/revenuecat/cli/internal/config"
+	"github.com/revenuecat/cli/internal/output"
+	"github.com/revenuecat/cli/internal/paywallai"
+)
+
+func newSessionTestRuntime(rcBaseURL string) *Runtime {
+	return &Runtime{
+		Globals: &Globals{JSON: true, NoInput: true, Version: "test"},
+		Config:  &config.Config{APIKey: "sk_test", ProjectID: "proj", BaseURL: rcBaseURL},
+		Ctx:     context.Background(),
+		Out:     output.NewRenderer(io.Discard, io.Discard, true, true, false, ""),
+	}
+}
+
+func newTestSession() *paywallAISession {
+	rev := 0
+	return &paywallAISession{
+		Version:   1,
+		ProjectID: "proj",
+		PaywallID: "pw_test",
+		Revision:  &rev,
+		Paywall: paywallai.PaywallData{
+			DefaultLocale:           "en_US",
+			ComponentsConfig:        json.RawMessage(`{"base":{}}`),
+			ComponentsLocalizations: json.RawMessage(`{"en_US":{}}`),
+		},
+		UIConfig:         json.RawMessage(minimalUIConfig),
+		ProductVariables: map[string]string{},
+		SessionItems:     json.RawMessage(`{}`),
+	}
+}
+
+func astraFailingServer(t *testing.T, startedSessionID string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: {\"type\":\"run.started\",\"session_id\":%q}\n\n", startedSessionID)
+		fmt.Fprintf(w, "data: {\"type\":\"run.failed\",\"session_id\":%q,\"error\":{\"code\":\"internal\",\"message\":\"boom\"}}\n\n", startedSessionID)
+	}))
+}
+
+func TestRunPaywallAI_FailedRunPersistsSessionID(t *testing.T) {
+	astra := astraFailingServer(t, "sess_minted")
+	defer astra.Close()
+
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session"+paywallSessionSuffix)
+	session := newTestSession()
+	if err := savePaywallAISession(sessionPath, session); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := newSessionTestRuntime("https://rc.invalid")
+	opts := paywallAIOptions{baseURL: astra.URL, sessionPath: sessionPath, prompt: "make it blue", timeout: 30 * time.Second}
+	if err := runPaywallAI(context.Background(), rt, opts, session); err == nil {
+		t.Fatal("expected the failed run to return an error")
+	}
+
+	stored, err := loadPaywallAISession(rt, sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.SessionID != "sess_minted" {
+		t.Fatalf("failed run did not persist session id: got %q, want sess_minted", stored.SessionID)
+	}
+}
+
+func TestRunPaywallAI_EmptyRunStartedKeepsStoredSessionID(t *testing.T) {
+	astra := astraFailingServer(t, "")
+	defer astra.Close()
+
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session"+paywallSessionSuffix)
+	session := newTestSession()
+	session.SessionID = "sess_existing"
+	if err := savePaywallAISession(sessionPath, session); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := newSessionTestRuntime("https://rc.invalid")
+	opts := paywallAIOptions{baseURL: astra.URL, sessionPath: sessionPath, prompt: "keep going", timeout: 30 * time.Second}
+	if err := runPaywallAI(context.Background(), rt, opts, session); err == nil {
+		t.Fatal("expected the failed run to return an error")
+	}
+
+	stored, err := loadPaywallAISession(rt, sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.SessionID != "sess_existing" {
+		t.Fatalf("empty run_started wiped the stored session id: got %q, want sess_existing", stored.SessionID)
+	}
+}
+
+type rcPaywallMock struct {
+	mu       sync.Mutex
+	revision int
+}
+
+func (m *rcPaywallMock) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			m.mu.Lock()
+			rev := m.revision
+			m.mu.Unlock()
+			fmt.Fprintf(w, `{"id":"pw_test","offering_id":"","created_at":1,"components":{"published":null,"draft":{"revision":%d,"components_config":{"base":{}},"components_localizations":{"en_US":{}},"default_locale":"en_US"}}}`, rev)
+		case http.MethodPatch:
+			var body struct {
+				Revision int `json:"revision"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			m.mu.Lock()
+			m.revision = body.Revision + 1
+			rev := m.revision
+			m.mu.Unlock()
+			fmt.Fprintf(w, `{"id":"pw_test","offering_id":"","created_at":1,"components":{"published":null,"draft":{"revision":%d,"components_config":{"base":{}},"components_localizations":{"en_US":{}},"default_locale":"en_US"}}}`, rev)
+		default:
+			http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+		}
+	}))
+}
+
+type astraEchoServer struct {
+	mu       sync.Mutex
+	received []string
+	minted   int
+}
+
+func (s *astraEchoServer) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			SessionID string `json:"session_id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		s.mu.Lock()
+		s.received = append(s.received, body.SessionID)
+		sid := body.SessionID
+		if sid == "" {
+			s.minted++
+			sid = fmt.Sprintf("sess_minted_%d", s.minted)
+		}
+		s.mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		paywall := `{"default_locale":"en_US","offering_id":null,"components_config":{"designed":true},"components_localizations":{"en_US":{}}}`
+		fmt.Fprintf(w, "data: {\"type\":\"run.started\",\"session_id\":%q}\n\n", sid)
+		fmt.Fprintf(w, "data: {\"type\":\"turn.snapshot\",\"session_id\":%q,\"turn_index\":0,\"paywall\":%s,\"activity\":[]}\n\n", sid, paywall)
+		fmt.Fprintf(w, "data: {\"type\":\"run.completed\",\"session_id\":%q,\"trace_id\":\"tr1\",\"paywall\":%s,\"activity\":[]}\n\n", sid, paywall)
+	}))
+}
+
+func runEditTurn(t *testing.T, configDir, astraURL, rcURL, paywallID string) {
+	t.Helper()
+	t.Setenv("RC_CONFIG_DIR", configDir)
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", astraURL)
+	cmd := newPaywallsEditCmd()
+	rt := newSessionTestRuntime(rcURL)
+	cmd.SetContext(WithRuntime(context.Background(), rt))
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{paywallID, "--prompt", "make it pop"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("edit turn failed: %v", err)
+	}
+}
+
+func TestPaywallsEdit_AutoContinuesSessionAcrossTurns(t *testing.T) {
+	rc := &rcPaywallMock{}
+	rcServer := rc.server(t)
+	defer rcServer.Close()
+	astra := &astraEchoServer{}
+	astraServer := astra.server(t)
+	defer astraServer.Close()
+
+	configDir := t.TempDir()
+	runEditTurn(t, configDir, astraServer.URL, rcServer.URL, "pw_test")
+	runEditTurn(t, configDir, astraServer.URL, rcServer.URL, "pw_test")
+
+	astra.mu.Lock()
+	received := append([]string(nil), astra.received...)
+	astra.mu.Unlock()
+
+	if len(received) != 2 {
+		t.Fatalf("expected 2 editor turns, got %d: %v", len(received), received)
+	}
+	if received[0] != "" {
+		t.Fatalf("turn 1 should send an empty session id (fresh conversation), got %q", received[0])
+	}
+	if received[1] == "" {
+		t.Fatal("turn 2 sent an empty session id — the conversation was not continued")
+	}
+	if received[1] != "sess_minted_1" {
+		t.Fatalf("turn 2 should resend the id minted on turn 1 (sess_minted_1), got %q", received[1])
+	}
+}
+
+func TestPaywallsEdit_ExplicitSessionOverridesDefault(t *testing.T) {
+	rc := &rcPaywallMock{}
+	rcServer := rc.server(t)
+	defer rcServer.Close()
+	astra := &astraEchoServer{}
+	astraServer := astra.server(t)
+	defer astraServer.Close()
+
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "custom"+paywallSessionSuffix)
+	stored := newTestSession()
+	stored.SessionID = "sess_explicit"
+	if err := savePaywallAISession(sessionPath, stored); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	t.Setenv("RC_PAYWALL_AI_BASE_URL", astraServer.URL)
+	cmd := newPaywallsEditCmd()
+	rt := newSessionTestRuntime(rcServer.URL)
+	cmd.SetContext(WithRuntime(context.Background(), rt))
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--session", sessionPath, "--prompt", "tweak it"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("edit with --session failed: %v", err)
+	}
+
+	astra.mu.Lock()
+	received := append([]string(nil), astra.received...)
+	astra.mu.Unlock()
+	if len(received) != 1 || received[0] != "sess_explicit" {
+		t.Fatalf("--session did not drive the request session id: %v", received)
+	}
+}


### PR DESCRIPTION
Follow-up `rc paywalls edit` turns were each starting a fresh Astra session, so one design conversation fragmented into many. The backend reuses whatever session id the client resends (minting only on an empty id) — the CLI just wasn't resending it. Now `edit <paywall-id>` auto-continues the paywall's stored session (revision-guarded; `--session` still overrides), and the id is persisted even when a turn fails.

DX-939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only paywall AI session file behavior and stream event handling; no auth or production API contract changes beyond resending the existing editor session id.
> 
> **Overview**
> Follow-up **`rc paywalls edit <paywall-id>`** turns now **resume the default session file** when its draft revision still matches RevenueCat, instead of always re-seeding from the server and sending an empty editor session id. If the file is missing or the revision diverged, behavior stays **seed fresh** (same as before for stale state).
> 
> **Stream handling** saves the minted **`session_id`** on **`run.started`** and **`run.failed`**, without clearing it when the event sends an empty id, and without wiping **`trace_id`** on failure (so **`rewind`** still works). **`--session`** still overrides the default path.
> 
> New tests cover multi-turn continuity, explicit session files, and failed-run persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 410f401d89229654ac387b019138592fc1e7f25a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->