### PR TITLE
fix(auth): stop RC_API_KEY from shadowing an OAuth login (DX-940)

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -27,11 +27,13 @@ import (
 const DefaultBaseURL = "https://api.revenuecat.com/v2"
 
 type Options struct {
-	APIKey       string
-	BaseURL      string
-	HTTPClient   *http.Client
-	UserAgent    string
-	ExtraHeaders http.Header
+	APIKey  string
+	BaseURL string
+	// CredentialSource names where APIKey came from, for auth-error hints only.
+	CredentialSource string
+	HTTPClient       *http.Client
+	UserAgent        string
+	ExtraHeaders     http.Header
 }
 
 type cacheEntry struct {
@@ -40,12 +42,13 @@ type cacheEntry struct {
 }
 
 type Client struct {
-	baseURL      *url.URL
-	apiKey       string
-	http         *http.Client
-	userAgent    string
-	extraHeaders http.Header
-	cache        sync.Map // url string → cacheEntry; GET-only, session-scoped
+	baseURL          *url.URL
+	apiKey           string
+	credentialSource string
+	http             *http.Client
+	userAgent        string
+	extraHeaders     http.Header
+	cache            sync.Map // url string → cacheEntry; GET-only, session-scoped
 
 	Projects        *ProjectsService
 	Customers       *CustomersService
@@ -89,7 +92,7 @@ func NewClient(opts Options) *Client {
 	if ua == "" {
 		ua = "revenuecat-cli/dev"
 	}
-	c := &Client{baseURL: u, apiKey: opts.APIKey, http: hc, userAgent: ua, extraHeaders: opts.ExtraHeaders}
+	c := &Client{baseURL: u, apiKey: opts.APIKey, credentialSource: opts.CredentialSource, http: hc, userAgent: ua, extraHeaders: opts.ExtraHeaders}
 	c.Projects = &ProjectsService{c: c}
 	c.Customers = &CustomersService{c: c}
 	c.Entitlements = &EntitlementsService{c: c}
@@ -168,7 +171,7 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any) err
 	}
 
 	if resp.StatusCode >= 400 {
-		return parseError(resp)
+		return c.annotateError(parseError(resp))
 	}
 	if out == nil || resp.StatusCode == http.StatusNoContent {
 		return nil
@@ -185,6 +188,14 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any) err
 		}
 	}
 	return json.Unmarshal(data, out)
+}
+
+// annotateError stamps the client's credential source onto an APIError.
+func (c *Client) annotateError(err error) error {
+	if ae, ok := err.(*APIError); ok {
+		ae.CredentialSource = c.credentialSource
+	}
+	return err
 }
 
 // Page wraps cursor-paginated list responses.
@@ -253,7 +264,7 @@ func (c *Client) Raw(ctx context.Context, method, path string, body []byte) ([]b
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		return nil, resp.StatusCode, parseError(resp)
+		return nil, resp.StatusCode, c.annotateError(parseError(resp))
 	}
 	data, err := io.ReadAll(resp.Body)
 	return data, resp.StatusCode, err

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strconv"
+	"strings"
 )
 
 // APIError is the typed error returned for all non-2xx API responses.
@@ -29,6 +31,9 @@ type APIError struct {
 	Retryable         bool   `json:"retryable,omitempty"`
 	RequestID         string `json:"-"`                     // X-Request-Id header, not in body
 	RetryAfterSeconds int    `json:"retry_after,omitempty"` // Retry-After header on 429
+
+	// CredentialSource names where the request's credential came from; set by the client, not the wire.
+	CredentialSource string `json:"-"`
 }
 
 func (e *APIError) Error() string {
@@ -69,9 +74,12 @@ func parseError(resp *http.Response) error {
 // Hint returns an actionable next step for the user, given the error type +
 // status. Returns empty when nothing useful can be said.
 func (e *APIError) Hint() string {
+	if scope := MissingScope(e.Message); scope != "" {
+		return e.scopeHint(scope)
+	}
 	switch e.Type {
 	case "unauthorized", "authentication_error":
-		return "Your API key may be revoked or expired. Run `rc login` again, or set RC_API_KEY."
+		return e.authHint()
 	case "rate_limit_exceeded":
 		if e.RetryAfterSeconds > 0 {
 			return fmt.Sprintf("Rate limited. Retry after %d seconds.", e.RetryAfterSeconds)
@@ -80,6 +88,50 @@ func (e *APIError) Hint() string {
 	}
 	if e.Status >= 500 {
 		return "API issue. Retry, or check https://status.revenuecat.com."
+	}
+	return ""
+}
+
+func (e *APIError) credentialSourceNote() string {
+	switch e.CredentialSource {
+	case "env":
+		return " The active credential came from the RC_API_KEY environment variable — check your shell env (e.g. ~/.zshrc), or run `rc login`."
+	case "flag":
+		return " The active credential came from the --api-key flag; pass a key with the required scope, or run `rc login`."
+	case "oauth":
+		return " Run `rc login` again to refresh your session."
+	default:
+		return " Run `rc login` again, or set RC_API_KEY to a key with the required scope."
+	}
+}
+
+func (e *APIError) authHint() string {
+	return "Your credential may be revoked, expired, or missing a required scope." + e.credentialSourceNote()
+}
+
+func (e *APIError) scopeHint(scope string) string {
+	return fmt.Sprintf("The active credential is missing the %q scope.", scope) + e.credentialSourceNote()
+}
+
+// scopeTokenRe matches scope identifiers like "project_configuration:read_write".
+var scopeTokenRe = regexp.MustCompile(`[A-Za-z0-9_*]+:[A-Za-z0-9_*]+(?::[A-Za-z0-9_*]+)?`)
+
+// MissingScope extracts the scope named in a permission/scope error message, or "" if none.
+func MissingScope(msg string) string {
+	if msg == "" || !strings.Contains(strings.ToLower(msg), "scope") {
+		return ""
+	}
+	for _, q := range []byte{'`', '"', '\''} {
+		if i := strings.IndexByte(msg, q); i >= 0 {
+			if j := strings.IndexByte(msg[i+1:], q); j > 0 {
+				if cand := strings.TrimSpace(msg[i+1 : i+1+j]); cand != "" {
+					return cand
+				}
+			}
+		}
+	}
+	if m := scopeTokenRe.FindString(msg); m != "" {
+		return m
 	}
 	return ""
 }

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -1,0 +1,56 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+func TestMissingScope(t *testing.T) {
+	cases := map[string]string{
+		"You are not authorized":                                     "",
+		"missing required scope: `project_configuration:read_write`": "project_configuration:read_write",
+		"insufficient scope 'products:read_write'":                   "products:read_write",
+		"token requires the *:*:read_write scope":                    "*:*:read_write",
+		"resource not found":                                         "",
+	}
+	for msg, want := range cases {
+		if got := api.MissingScope(msg); got != want {
+			t.Errorf("MissingScope(%q) = %q, want %q", msg, got, want)
+		}
+	}
+}
+
+func TestAPIError_ScopeHintNamesEnv(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"type":"unauthorized","message":"missing required scope: 'products:read_write'"}`))
+	}))
+	defer srv.Close()
+
+	c := api.NewClient(api.Options{APIKey: "sk_env", BaseURL: srv.URL, CredentialSource: "env"})
+	_, err := c.Projects.List(context.Background())
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want APIError, got %v", err)
+	}
+	hint := apiErr.Hint()
+	if !strings.Contains(hint, "products:read_write") {
+		t.Errorf("hint should name the missing scope, got %q", hint)
+	}
+	if !strings.Contains(hint, "RC_API_KEY") {
+		t.Errorf("hint should point at RC_API_KEY for an env credential, got %q", hint)
+	}
+}
+
+func TestAPIError_UnauthorizedHintMentionsLogin(t *testing.T) {
+	e := &api.APIError{Status: 401, Type: "unauthorized", Message: "bad key"}
+	if hint := e.Hint(); !strings.Contains(hint, "rc login") {
+		t.Errorf("hint should mention rc login, got %q", hint)
+	}
+}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -417,7 +417,7 @@ Shows which credential is in control (the OAuth login, an RC_API_KEY env var, th
 				rt.Out.Field("Credential", credSource.Describe())
 			}
 			if conflict != nil {
-				rt.Out.Warn(conflict["message"].(string))
+				rt.warnCredentialConflict(credSource)
 			}
 			if showScopes && authenticated {
 				if scopesKnown {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -329,18 +330,23 @@ To remove the profile entirely, use: rc profiles delete <name>`,
 }
 
 func newAuthStatusCmd() *cobra.Command {
-	return &cobra.Command{
+	var showScopes bool
+	cmd := &cobra.Command{
 		Use:     "status",
 		Aliases: []string{"whoami"},
 		Short:   "Show the current authentication state",
-		Long:    `Displays the active profile, cached account identity when known, auth method, and project context. If a project is configured, validates that it is still accessible.`,
+		Long: `Displays the active profile, cached account identity when known, auth method, and project context. If a project is configured, validates that it is still accessible.
+
+Shows which credential is in control (the OAuth login, an RC_API_KEY env var, the --api-key flag, or a stored key) and warns when more than one is present. Pass --scopes to surface the active credential's scopes before attempting writes.`,
 		Example: `  rc auth status
-  rc auth status --json`,
+  rc auth status --json
+  rc auth status --scopes --json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 
 			profileName := config.ProfileName(rt.Globals.Profile)
-			authenticated := rt.Config.BearerToken() != ""
+			token, credSource := rt.Config.Credential()
+			authenticated := token != ""
 			projectStatus := "not_configured"
 			if authenticated && rt.Config.ProjectID != "" {
 				projectStatus = "unavailable"
@@ -354,8 +360,8 @@ func newAuthStatusCmd() *cobra.Command {
 			}
 
 			var method string
-			switch {
-			case rt.Config.IsOAuth():
+			switch credSource {
+			case config.SourceOAuth:
 				if rt.Config.TokenExpiresAt.IsZero() {
 					method = "oauth"
 				} else if time.Now().After(rt.Config.TokenExpiresAt) {
@@ -363,10 +369,32 @@ func newAuthStatusCmd() *cobra.Command {
 				} else {
 					method = fmt.Sprintf("oauth (expires %s)", rt.Config.TokenExpiresAt.Local().Format("2006-01-02 15:04"))
 				}
-			case rt.Config.APIKey != "":
+			case config.SourceFlag, config.SourceEnv, config.SourceProfile:
 				method = "api_key"
 			default:
 				method = "none"
+			}
+
+			present := rt.Config.PresentCredentialSources()
+			var conflict map[string]any
+			if len(present) > 1 {
+				ignored := make([]string, 0, len(present)-1)
+				for _, s := range present {
+					if s != credSource {
+						ignored = append(ignored, string(s))
+					}
+				}
+				conflict = map[string]any{
+					"active_source":   string(credSource),
+					"ignored_sources": ignored,
+					"message":         credentialConflictMessage(credSource, present),
+				}
+			}
+
+			var scopes []string
+			scopesKnown := false
+			if showScopes && authenticated {
+				scopes, scopesKnown = credentialScopes(token)
 			}
 
 			identity := rt.Config.AccountEmail
@@ -385,6 +413,20 @@ func newAuthStatusCmd() *cobra.Command {
 				rt.Out.Success(fmt.Sprintf("Logged in (profile: %s)", profileName))
 				rt.Out.Info("Account identity is not cached for this login")
 			}
+			if authenticated {
+				rt.Out.Field("Credential", credSource.Describe())
+			}
+			if conflict != nil {
+				rt.Out.Warn(conflict["message"].(string))
+			}
+			if showScopes && authenticated {
+				if scopesKnown {
+					rt.Out.Field("Scopes", strings.Join(scopes, ", "))
+				} else {
+					rt.Out.Field("Scopes", "unknown")
+					rt.Out.Hint("Scopes can't be read locally for this credential; the API exposes no token-introspection endpoint yet. A write that needs a missing scope will name it.")
+				}
+			}
 			if projectStatus == "not_found" {
 				rt.Out.Warn(fmt.Sprintf("Configured project %s is no longer accessible; run `rc projects use`", rt.Config.ProjectID))
 			} else if projectStatus == "unavailable" {
@@ -394,18 +436,79 @@ func newAuthStatusCmd() *cobra.Command {
 			if !rt.Out.IsJSON() {
 				return nil
 			}
-			return rt.Out.Render(map[string]any{
-				"profile":        profileName,
-				"authenticated":  authenticated,
-				"account_email":  rt.Config.AccountEmail,
-				"account_name":   rt.Config.AccountName,
-				"method":         method,
-				"project_id":     rt.Config.ProjectID,
-				"project_status": projectStatus,
-				"base_url":       rt.Config.BaseURL,
-			})
+			out := map[string]any{
+				"profile":           profileName,
+				"authenticated":     authenticated,
+				"account_email":     rt.Config.AccountEmail,
+				"account_name":      rt.Config.AccountName,
+				"method":            method,
+				"credential_source": string(credSource),
+				"project_id":        rt.Config.ProjectID,
+				"project_status":    projectStatus,
+				"base_url":          rt.Config.BaseURL,
+			}
+			if conflict != nil {
+				out["credential_conflict"] = conflict
+			}
+			if showScopes {
+				if scopesKnown {
+					out["scopes"] = scopes
+				} else {
+					out["scopes"] = nil
+					out["scopes_available"] = false
+				}
+			}
+			return rt.Out.Render(out)
 		},
 	}
+	cmd.Flags().BoolVar(&showScopes, "scopes", false, "show the active credential's scopes (when determinable)")
+	return cmd
+}
+
+// credentialScopes best-effort reports the scopes of the active credential.
+//
+// TODO(DX-940): read authoritative scopes once the API gains a token-introspection endpoint.
+func credentialScopes(token string) (scopes []string, ok bool) {
+	return jwtScopes(token)
+}
+
+// jwtScopes extracts scopes from a JWT's scope/scp/scopes claim; ok=false for non-JWTs.
+func jwtScopes(token string) (scopes []string, ok bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, false
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, false
+	}
+	for _, key := range []string{"scope", "scp", "scopes"} {
+		v, present := claims[key]
+		if !present {
+			continue
+		}
+		switch t := v.(type) {
+		case string:
+			if fields := strings.Fields(t); len(fields) > 0 {
+				return fields, true
+			}
+		case []any:
+			var out []string
+			for _, item := range t {
+				if s, isStr := item.(string); isStr && s != "" {
+					out = append(out, s)
+				}
+			}
+			if len(out) > 0 {
+				return out, true
+			}
+		}
+	}
+	return nil, false
 }
 
 func loginWithAPIKeyInteractive(ctx context.Context, rt *Runtime) error {
@@ -424,7 +527,7 @@ func loginWithAPIKeyInteractive(ctx context.Context, rt *Runtime) error {
 }
 
 func loginWithAPIKey(ctx context.Context, rt *Runtime, key string) error {
-	rt.Config.APIKey = key
+	rt.Config.SetAPIKey(key)
 	rt.Config.TokenType = ""
 	rt.Config.AccessToken = ""
 	rt.Config.RefreshToken = ""

--- a/internal/cli/auth_login_test.go
+++ b/internal/cli/auth_login_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,11 +11,161 @@ import (
 	"testing"
 
 	"github.com/revenuecat/cli/internal/cli"
+	"github.com/revenuecat/cli/internal/config"
 )
 
-// runAuthCmd is runCmdInConfigDir but keeps RC_BASE_URL pointed at a test
-// server, so login can validate a key against a stub. The keyring is mocked
-// process-wide (see TestMain), so credentials never touch the real keychain.
+func runStatus(t *testing.T, configDir string, args ...string) (string, string) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	root := cli.NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	root.SetArgs(append([]string{"auth", "status"}, args...))
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("auth status failed: %v", err)
+	}
+	return out.String(), errb.String()
+}
+
+func TestAuthStatus_OAuthNotShadowedByEnvAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", dir)
+	t.Setenv("RC_PROFILE", "")
+	t.Setenv("RC_PROJECT_ID", "")
+	t.Setenv("RC_BASE_URL", "")
+	t.Setenv("RC_API_KEY", "")
+	if err := config.Save("default", &config.Config{TokenType: "oauth", AccessToken: "oauth_at", RefreshToken: "oauth_rt"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RC_API_KEY", "sk_under_scoped")
+
+	stdout, _ := runStatus(t, dir, "--json", "--no-input")
+	var st struct {
+		Data struct {
+			Method           string         `json:"method"`
+			CredentialSource string         `json:"credential_source"`
+			Conflict         map[string]any `json:"credential_conflict"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &st); err != nil {
+		t.Fatalf("status not JSON: %v\n%s", err, stdout)
+	}
+	if st.Data.Method != "oauth" {
+		t.Errorf("method should be oauth, got %q", st.Data.Method)
+	}
+	if st.Data.CredentialSource != "oauth" {
+		t.Errorf("credential_source should be oauth, got %q", st.Data.CredentialSource)
+	}
+	if st.Data.Conflict == nil {
+		t.Fatal("expected a credential_conflict field when OAuth + RC_API_KEY coexist")
+	}
+	if got, _ := st.Data.Conflict["active_source"].(string); got != "oauth" {
+		t.Errorf("conflict active_source should be oauth, got %q", got)
+	}
+}
+
+func TestAuthStatus_ConflictWarnsOnStderr(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", dir)
+	t.Setenv("RC_PROFILE", "")
+	t.Setenv("RC_PROJECT_ID", "")
+	t.Setenv("RC_BASE_URL", "")
+	t.Setenv("RC_API_KEY", "")
+	if err := config.Save("default", &config.Config{TokenType: "oauth", AccessToken: "oauth_at"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RC_API_KEY", "sk_under_scoped")
+
+	_, stderr := runStatus(t, dir, "--no-input")
+	if !strings.Contains(stderr, "RC_API_KEY") {
+		t.Errorf("stderr should warn about the RC_API_KEY conflict, got %q", stderr)
+	}
+}
+
+func TestAuthStatus_EnvKeyReportedAsEnvSource(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", dir)
+	t.Setenv("RC_PROFILE", "")
+	t.Setenv("RC_PROJECT_ID", "")
+	t.Setenv("RC_BASE_URL", "")
+	t.Setenv("RC_API_KEY", "sk_ci")
+
+	stdout, _ := runStatus(t, dir, "--json", "--no-input")
+	var st struct {
+		Data struct {
+			Method           string         `json:"method"`
+			CredentialSource string         `json:"credential_source"`
+			Conflict         map[string]any `json:"credential_conflict"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &st); err != nil {
+		t.Fatalf("status not JSON: %v\n%s", err, stdout)
+	}
+	if st.Data.Method != "api_key" || st.Data.CredentialSource != "env" {
+		t.Errorf("want api_key/env, got %q/%q", st.Data.Method, st.Data.CredentialSource)
+	}
+	if st.Data.Conflict != nil {
+		t.Errorf("no conflict expected with only RC_API_KEY, got %v", st.Data.Conflict)
+	}
+}
+
+func TestAuthStatus_ScopesFromJWT(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", dir)
+	t.Setenv("RC_PROFILE", "")
+	t.Setenv("RC_PROJECT_ID", "")
+	t.Setenv("RC_BASE_URL", "")
+	t.Setenv("RC_API_KEY", "")
+
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"scope":"projects:read_write products:read_write"}`))
+	jwt := "aGVhZGVy." + payload + ".c2ln"
+	if err := config.Save("default", &config.Config{TokenType: "oauth", AccessToken: jwt}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _ := runStatus(t, dir, "--scopes", "--json", "--no-input")
+	var st struct {
+		Data struct {
+			Scopes []string `json:"scopes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &st); err != nil {
+		t.Fatalf("status not JSON: %v\n%s", err, stdout)
+	}
+	if len(st.Data.Scopes) != 2 || st.Data.Scopes[0] != "projects:read_write" {
+		t.Errorf("want the two JWT scopes, got %v", st.Data.Scopes)
+	}
+}
+
+func TestAuthStatus_ScopesUnavailableForOpaqueKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", dir)
+	t.Setenv("RC_PROFILE", "")
+	t.Setenv("RC_PROJECT_ID", "")
+	t.Setenv("RC_BASE_URL", "")
+	t.Setenv("RC_API_KEY", "")
+	if err := config.Save("default", &config.Config{APIKey: "sk_opaque"}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _ := runStatus(t, dir, "--scopes", "--json", "--no-input")
+	var st struct {
+		Data struct {
+			Scopes          []string `json:"scopes"`
+			ScopesAvailable *bool    `json:"scopes_available"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &st); err != nil {
+		t.Fatalf("status not JSON: %v\n%s", err, stdout)
+	}
+	if st.Data.Scopes != nil {
+		t.Errorf("scopes should be null for an opaque key, got %v", st.Data.Scopes)
+	}
+	if st.Data.ScopesAvailable == nil || *st.Data.ScopesAvailable {
+		t.Errorf("scopes_available should be false for an opaque key")
+	}
+}
+
 func runAuthCmd(t *testing.T, configDir, baseURL string, args ...string) (string, string, error) {
 	t.Helper()
 	t.Setenv("RC_CONFIG_DIR", configDir)
@@ -53,8 +204,6 @@ func statusAuthenticated(t *testing.T, dir, baseURL string) bool {
 	return st.Data.Authenticated
 }
 
-// A valid API key is validated against the API, then persisted so later
-// commands (here, status) see an authenticated session.
 func TestAuthLogin_APIKeyValidatesAndPersists(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.URL.Path, "projects") {
@@ -76,8 +225,6 @@ func TestAuthLogin_APIKeyValidatesAndPersists(t *testing.T) {
 	}
 }
 
-// A rejected key fails fast with a clear error and must not be written to the
-// profile.
 func TestAuthLogin_BadAPIKeyFailsAndDoesNotPersist(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -74,9 +74,7 @@ Agent-friendly entrypoints:
 			if err != nil {
 				return err
 			}
-			if g.APIKey != "" {
-				cfg.APIKey = g.APIKey
-			}
+			cfg.SetFlagAPIKey(g.APIKey)
 			if g.ProjectID != "" {
 				cfg.ProjectID = g.ProjectID
 			}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -46,7 +46,8 @@ type Runtime struct {
 	Out     *output.Renderer
 	Ctx     context.Context
 
-	client *api.Client
+	client             *api.Client
+	warnedCredConflict bool
 }
 
 func WithRuntime(ctx context.Context, r *Runtime) context.Context {
@@ -73,21 +74,51 @@ func (r *Runtime) API() (*api.Client, error) {
 		r.silentRefresh()
 	}
 
-	if r.Config.BearerToken() == "" {
+	token, source := r.Config.Credential()
+	if token == "" {
 		return nil, ErrNotAuthenticated
 	}
+	r.warnCredentialConflict(source)
 	if b := r.Config.BaseURL; b != "" {
 		if u, err := url.Parse(b); err != nil || u.Scheme == "" || u.Host == "" {
 			return nil, fmt.Errorf("invalid base URL %q (RC_BASE_URL or profile base_url): expected an absolute URL like https://api.revenuecat.com/v2", b)
 		}
 	}
 	r.client = api.NewClient(api.Options{
-		APIKey:       r.Config.BearerToken(), // works for both API keys and OAuth tokens
-		BaseURL:      r.Config.BaseURL,
-		UserAgent:    userAgent(r.Globals.Version),
-		ExtraHeaders: customHeaders(),
+		APIKey:           token, // works for both API keys and OAuth tokens
+		CredentialSource: string(source),
+		BaseURL:          r.Config.BaseURL,
+		UserAgent:        userAgent(r.Globals.Version),
+		ExtraHeaders:     customHeaders(),
 	})
 	return r.client, nil
+}
+
+// warnCredentialConflict warns once per run when more than one credential source is present.
+func (r *Runtime) warnCredentialConflict(active config.CredentialSource) {
+	if r.warnedCredConflict {
+		return
+	}
+	present := r.Config.PresentCredentialSources()
+	if len(present) < 2 {
+		return
+	}
+	r.warnedCredConflict = true
+	r.Out.AlwaysWarn(credentialConflictMessage(active, present))
+}
+
+func credentialConflictMessage(active config.CredentialSource, present []config.CredentialSource) string {
+	var ignored []string
+	for _, s := range present {
+		if s != active {
+			ignored = append(ignored, s.Describe())
+		}
+	}
+	msg := "Multiple credentials found — using " + active.Describe()
+	if len(ignored) > 0 {
+		msg += "; ignoring " + strings.Join(ignored, " and ")
+	}
+	return msg + "."
 }
 
 func customHeaders() http.Header {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,36 @@ type Config struct {
 	envAPIKey    envOverride
 	envProjectID envOverride
 	envBaseURL   envOverride
+
+	// flagAPIKey holds an --api-key value for this invocation; never serialized.
+	flagAPIKey string
+}
+
+// CredentialSource names where the active credential came from.
+type CredentialSource string
+
+const (
+	SourceFlag    CredentialSource = "flag"
+	SourceOAuth   CredentialSource = "oauth"
+	SourceEnv     CredentialSource = "env"
+	SourceProfile CredentialSource = "profile"
+	SourceNone    CredentialSource = "none"
+)
+
+// Describe returns a human-readable phrase naming the source.
+func (s CredentialSource) Describe() string {
+	switch s {
+	case SourceFlag:
+		return "the --api-key flag"
+	case SourceOAuth:
+		return "the OAuth login in this profile"
+	case SourceEnv:
+		return "the RC_API_KEY environment variable"
+	case SourceProfile:
+		return "the API key stored in this profile"
+	default:
+		return "no credential"
+	}
 }
 
 // envOverride records that Load replaced a field with an env-var value,
@@ -53,13 +83,63 @@ type envOverride struct {
 	set       bool
 }
 
-// BearerToken returns whichever auth credential should be sent as the
-// Authorization: Bearer header. OAuth access token takes priority.
+// BearerToken returns the auth credential for the Authorization: Bearer header.
 func (c *Config) BearerToken() string {
+	tok, _ := c.Credential()
+	return tok
+}
+
+// Credential resolves the active auth credential and reports its source.
+func (c *Config) Credential() (token string, source CredentialSource) {
+	if c.flagAPIKey != "" {
+		return c.flagAPIKey, SourceFlag
+	}
 	if c.TokenType == "oauth" && c.AccessToken != "" {
-		return c.AccessToken
+		return c.AccessToken, SourceOAuth
+	}
+	if c.envAPIKey.set && c.envAPIKey.env != "" {
+		return c.envAPIKey.env, SourceEnv
+	}
+	if k := c.storedAPIKey(); k != "" {
+		return k, SourceProfile
+	}
+	return "", SourceNone
+}
+
+// storedAPIKey is the API key on disk, ignoring any RC_API_KEY override.
+func (c *Config) storedAPIKey() string {
+	if c.envAPIKey.set {
+		return c.envAPIKey.disk
 	}
 	return c.APIKey
+}
+
+// PresentCredentialSources lists every available credential source, highest precedence first.
+func (c *Config) PresentCredentialSources() []CredentialSource {
+	var s []CredentialSource
+	if c.flagAPIKey != "" {
+		s = append(s, SourceFlag)
+	}
+	if c.TokenType == "oauth" && c.AccessToken != "" {
+		s = append(s, SourceOAuth)
+	}
+	if c.envAPIKey.set && c.envAPIKey.env != "" {
+		s = append(s, SourceEnv)
+	}
+	if c.storedAPIKey() != "" {
+		s = append(s, SourceProfile)
+	}
+	return s
+}
+
+// SetFlagAPIKey records an --api-key value for this invocation.
+func (c *Config) SetFlagAPIKey(key string) { c.flagAPIKey = key }
+
+// SetAPIKey sets an explicit stored API key, clearing any flag or env override.
+func (c *Config) SetAPIKey(key string) {
+	c.APIKey = key
+	c.flagAPIKey = ""
+	c.envAPIKey = envOverride{}
 }
 
 // IsOAuth reports whether this profile holds OAuth credentials.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/revenuecat/cli/internal/config"
 )
 
-// setEnv sets envs and registers cleanup. Cleaner than per-test t.Setenv calls
-// when many vars are touched at once.
 func setEnv(t *testing.T, pairs map[string]string) {
 	t.Helper()
 	for k, v := range pairs {
@@ -86,7 +84,6 @@ func TestSave_WritesWithOwnerOnlyPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// 0o600 is the contract — the file contains an API key.
 	if mode := info.Mode().Perm(); mode != 0o600 {
 		t.Errorf("want mode 0600, got %o", mode)
 	}
@@ -102,7 +99,6 @@ func TestLoad_EnvOverridesFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Now layer env on top.
 	t.Setenv("RC_API_KEY", "env_key")
 	t.Setenv("RC_PROJECT_ID", "env_proj")
 	t.Setenv("RC_BASE_URL", "https://env.example")
@@ -127,19 +123,16 @@ func TestActiveProfilePointer_RoundTrip(t *testing.T) {
 	t.Setenv("RC_CONFIG_DIR", dir)
 	t.Setenv("RC_PROFILE", "")
 
-	// Create two profiles.
 	for _, name := range []string{"default", "staging"} {
 		if err := config.Save(name, &config.Config{APIKey: "k_" + name}); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// No pointer yet → fall back to "default".
 	if got := config.ProfileName(""); got != "default" {
 		t.Errorf("with no pointer file, want 'default', got %q", got)
 	}
 
-	// Set staging as active.
 	if err := config.SetActiveProfile("staging"); err != nil {
 		t.Fatal(err)
 	}
@@ -147,14 +140,12 @@ func TestActiveProfilePointer_RoundTrip(t *testing.T) {
 		t.Errorf("after SetActiveProfile(staging), want 'staging', got %q", got)
 	}
 
-	// Env var beats pointer.
 	t.Setenv("RC_PROFILE", "default")
 	if got := config.ProfileName(""); got != "default" {
 		t.Errorf("env should beat pointer, got %q", got)
 	}
 	t.Setenv("RC_PROFILE", "")
 
-	// Explicit arg beats both.
 	if got := config.ProfileName("override"); got != "override" {
 		t.Errorf("explicit arg should beat pointer, got %q", got)
 	}
@@ -218,34 +209,26 @@ func TestLoad_CorruptFileErrors(t *testing.T) {
 	}
 }
 
-// Env vars (RC_API_KEY etc.) are one-shot overrides. A command that saves the
-// config for an unrelated reason must not bake the ephemeral env value into the
-// profile — but an explicit change to a field must still persist.
 func TestSave_DoesNotPersistEnvOverrides(t *testing.T) {
 	dir := t.TempDir()
 	setEnv(t, map[string]string{
 		"RC_CONFIG_DIR": dir, "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": "",
 	})
 
-	// Seed a profile that already has a real API key + project on disk.
 	if err := config.Save("default", &config.Config{APIKey: "sk_disk", ProjectID: "proj_disk"}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Reload with env overrides in play, then change only the project (as
-	// `rc projects use` would) and save.
 	setEnv(t, map[string]string{"RC_API_KEY": "sk_env", "RC_PROJECT_ID": "proj_env"})
 	cfg, err := config.Load("default")
 	if err != nil {
 		t.Fatal(err)
 	}
-	cfg.ProjectID = "proj_chosen" // explicit command change
+	cfg.ProjectID = "proj_chosen"
 	if err := config.Save("default", cfg); err != nil {
 		t.Fatal(err)
 	}
 
-	// Reload without env: the ephemeral API key must be gone, the explicit
-	// project change must have stuck.
 	setEnv(t, map[string]string{"RC_API_KEY": "", "RC_PROJECT_ID": ""})
 	got, err := config.Load("default")
 	if err != nil {
@@ -259,7 +242,123 @@ func TestSave_DoesNotPersistEnvOverrides(t *testing.T) {
 	}
 }
 
-// A profile name must not escape the config dir via path separators or "..".
+func saveOAuthProfile(t *testing.T, name string) {
+	t.Helper()
+	if err := config.Save(name, &config.Config{
+		TokenType:    "oauth",
+		AccessToken:  "oauth_access_token",
+		RefreshToken: "oauth_refresh_token",
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCredential_OAuthBeatsEnvAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": dir, "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+	saveOAuthProfile(t, "default")
+
+	t.Setenv("RC_API_KEY", "sk_under_scoped_env")
+	cfg, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, src := cfg.Credential()
+	if src != config.SourceOAuth {
+		t.Errorf("want source oauth, got %q", src)
+	}
+	if tok != "oauth_access_token" {
+		t.Errorf("want the OAuth token, got %q", tok)
+	}
+	if cfg.BearerToken() != "oauth_access_token" {
+		t.Errorf("BearerToken should be the OAuth token, got %q", cfg.BearerToken())
+	}
+	present := cfg.PresentCredentialSources()
+	if len(present) != 2 || present[0] != config.SourceOAuth || present[1] != config.SourceEnv {
+		t.Errorf("want [oauth env] present, got %v", present)
+	}
+}
+
+func TestCredential_EnvUsedWhenNoLogin(t *testing.T) {
+	dir := t.TempDir()
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": dir, "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+
+	t.Setenv("RC_API_KEY", "sk_ci_env")
+	cfg, err := config.Load("never-saved")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, src := cfg.Credential()
+	if src != config.SourceEnv || tok != "sk_ci_env" {
+		t.Errorf("CI path: want env/sk_ci_env, got %q/%q", src, tok)
+	}
+	if got := cfg.PresentCredentialSources(); len(got) != 1 || got[0] != config.SourceEnv {
+		t.Errorf("want only [env], got %v", got)
+	}
+}
+
+func TestCredential_StoredProfileKey(t *testing.T) {
+	dir := t.TempDir()
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": dir, "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+	if err := config.Save("default", &config.Config{APIKey: "sk_disk"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok, src := cfg.Credential(); src != config.SourceProfile || tok != "sk_disk" {
+		t.Errorf("want profile/sk_disk, got %q/%q", src, tok)
+	}
+}
+
+func TestCredential_FlagBeatsEverything(t *testing.T) {
+	dir := t.TempDir()
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": dir, "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+	saveOAuthProfile(t, "default")
+
+	t.Setenv("RC_API_KEY", "sk_env")
+	cfg, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.SetFlagAPIKey("sk_flag")
+	tok, src := cfg.Credential()
+	if src != config.SourceFlag || tok != "sk_flag" {
+		t.Errorf("flag should win, got %q/%q", src, tok)
+	}
+	present := cfg.PresentCredentialSources()
+	if len(present) != 3 {
+		t.Errorf("want flag+oauth+env present, got %v", present)
+	}
+}
+
+func TestSetAPIKey_SupersedesEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": dir, "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+
+	t.Setenv("RC_API_KEY", "sk_env")
+	cfg, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.SetAPIKey("sk_typed")
+	if tok, src := cfg.Credential(); src != config.SourceProfile || tok != "sk_typed" {
+		t.Errorf("want profile/sk_typed after SetAPIKey, got %q/%q", src, tok)
+	}
+	if err := config.Save("default", cfg); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RC_API_KEY", "")
+	got, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.APIKey != "sk_typed" {
+		t.Errorf("SetAPIKey value should persist to disk, got %q", got.APIKey)
+	}
+}
+
 func TestProfileName_RejectsPathTraversal(t *testing.T) {
 	dir := t.TempDir()
 	setEnv(t, map[string]string{"RC_CONFIG_DIR": dir, "RC_PROFILE": "", "RC_API_KEY": ""})

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -482,6 +482,14 @@ func (r *Renderer) Warn(msg string) {
 	fmt.Fprintln(r.stderr, r.style(r.warn, "! ")+msg)
 }
 
+// AlwaysWarn writes a warning to stderr even in --json mode.
+func (r *Renderer) AlwaysWarn(msg string) {
+	if r.quiet {
+		return
+	}
+	fmt.Fprintln(r.stderr, r.style(r.warn, "! ")+msg)
+}
+
 func (r *Renderer) Error(msg string) {
 	if r.json {
 		return


### PR DESCRIPTION
An ambient `RC_API_KEY` (e.g. exported in a shell profile) could take over even after an interactive OAuth login, and `auth status` misreported the active method — so writes failed on missing scopes with no clue why. Credential precedence is now explicit (`--api-key` flag → profile OAuth → `RC_API_KEY` → stored key), a conflict warns to stderr (kept out of `--json` stdout), errors name the missing scope and the credential's source, and `auth status --scopes` reports scopes best-effort.

Note: true fail-early on scopes needs a backend scope-introspection endpoint (`TODO(DX-940)`); API keys are opaque today.

DX-940

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which credential is sent on every API request and how login/status report auth; behavior is more predictable but wrong precedence could still block access until users adjust env or flags.
> 
> **Overview**
> Fixes a case where an ambient **`RC_API_KEY`** could win over a profile **OAuth** login, so writes failed on missing scopes while **`auth status`** looked like the wrong credential was active.
> 
> **Credential resolution** is now explicit: **`--api-key`** → profile OAuth → **`RC_API_KEY`** → stored profile key. **`Config.Credential()`** reports the active token and source; **`--api-key`** is tracked via **`SetFlagAPIKey`** instead of overwriting stored keys.
> 
> When multiple credentials exist, the CLI **warns once** (stderr, including under **`--json`**) and **`auth status`** surfaces **`credential_source`** plus optional **`credential_conflict`** in JSON. **`auth status --scopes`** best-effort lists scopes from JWT claims; opaque API keys report **`scopes_available: false`**.
> 
> **API errors** name the missing scope when the message includes one, and hints mention whether the active credential came from env, flag, OAuth, or the profile. The API client stamps **`CredentialSource`** onto **`APIError`** for those hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57813529443282e4fd0ce64545c7a5abd7508f35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->