### PR TITLE
fix(cli): apple setup no longer aborts before key setup on bundle-registration failure (DX-921)

### DIFF
--- a/internal/cli/apps_apple.go
+++ b/internal/cli/apps_apple.go
@@ -89,16 +89,34 @@ func ensureAppStoreAppRecord(ctx context.Context, rt *Runtime, apple appleConnec
 		Run(); err != nil {
 		return err
 	}
+	return createAppStoreAppRecord(ctx, rt, apple, session, bundleID, name, sku)
+}
+
+// createAppStoreAppRecord registers the bundle ID and creates the ASC app.
+// Failures here never abort: keys are account-level, so key setup still
+// proceeds — the caller only warns.
+func createAppStoreAppRecord(ctx context.Context, rt *Runtime, apple appleConnectClient, session *appleconnect.Session, bundleID, name, sku string) error {
 	rt.Out.Info("Registering bundle ID " + bundleID + " in the Developer Portal…")
 	if err := apple.RegisterBundleID(ctx, session, bundleID, name); err != nil {
-		return err
+		warnAppRecordFailed(rt, bundleID, err)
+		return nil
 	}
 	rt.Out.Info("Creating the App Store Connect app…")
 	if err := apple.CreateApp(ctx, session, name, bundleID, sku); err != nil {
-		return err
+		warnAppRecordFailed(rt, bundleID, err)
+		return nil
 	}
 	rt.Out.Success("Created App Store Connect app " + name + " (" + bundleID + ")")
 	return nil
+}
+
+func warnAppRecordFailed(rt *Runtime, bundleID string, err error) {
+	if strings.Contains(strings.ToLower(err.Error()), "not available") {
+		rt.Out.Warn("Bundle ID " + bundleID + " is not available — it is likely already registered under another Apple team or reserved, so the app record could not be created here.")
+	} else {
+		rt.Out.Warn("Could not create the App Store Connect app record: " + err.Error())
+	}
+	rt.Out.Warn("Continuing with key setup. The earlier check looks for the App Store Connect app record, not Developer Portal bundle registration — create the app in App Store Connect before configuring products.")
 }
 
 // keyDecisionLabel names the user's choice for a key so the transcript

--- a/internal/cli/apps_apple_test.go
+++ b/internal/cli/apps_apple_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -149,6 +150,72 @@ func (f *fakeAppleCheckClient) RegisterBundleID(context.Context, *appleconnect.S
 func (f *fakeAppleCheckClient) CreateApp(context.Context, *appleconnect.Session, string, string, string) error {
 	f.mutated = true
 	return errors.New("unexpected App Store Connect app creation")
+}
+
+func TestCreateAppStoreAppRecord_NonFatalOnAppleFailure(t *testing.T) {
+	cases := []struct {
+		name        string
+		registerErr error
+		createErr   error
+		wantCreate  bool
+		wantWarn    string
+	}{
+		{
+			name:        "register bundle id fails",
+			registerErr: errors.New(`An App ID with Identifier 'com.example.app' is not available.`),
+			wantCreate:  false,
+			wantWarn:    "is not available",
+		},
+		{
+			name:       "create app fails",
+			createErr:  errors.New("boom"),
+			wantCreate: true,
+			wantWarn:   "Could not create the App Store Connect app record: boom",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			apple := &fakeAppleSetupClient{registerErr: tc.registerErr, createErr: tc.createErr}
+			var stdout, stderr bytes.Buffer
+			rt := &Runtime{
+				Globals: &Globals{},
+				Out:     output.NewRenderer(&stdout, &stderr, false, true, false, ""),
+			}
+			if err := createAppStoreAppRecord(context.Background(), rt, apple, &appleconnect.Session{}, "com.example.app", "Example", "com.example.app"); err != nil {
+				t.Fatalf("createAppStoreAppRecord returned error, want nil (non-fatal): %v", err)
+			}
+			if !apple.registerCalled {
+				t.Fatal("RegisterBundleID was not called")
+			}
+			if apple.createCalled != tc.wantCreate {
+				t.Fatalf("CreateApp called = %v, want %v", apple.createCalled, tc.wantCreate)
+			}
+			if !strings.Contains(stderr.String(), tc.wantWarn) {
+				t.Fatalf("warning = %q, want it to contain %q", stderr.String(), tc.wantWarn)
+			}
+			if !strings.Contains(stderr.String(), "Continuing with key setup") {
+				t.Fatalf("warning = %q, want it to mention continuing with key setup", stderr.String())
+			}
+		})
+	}
+}
+
+type fakeAppleSetupClient struct {
+	fakeAppleCheckClient
+	registerErr    error
+	createErr      error
+	registerCalled bool
+	createCalled   bool
+}
+
+func (f *fakeAppleSetupClient) RegisterBundleID(context.Context, *appleconnect.Session, string, string) error {
+	f.registerCalled = true
+	return f.registerErr
+}
+
+func (f *fakeAppleSetupClient) CreateApp(context.Context, *appleconnect.Session, string, string, string) error {
+	f.createCalled = true
+	return f.createErr
 }
 
 func equalStrings(left, right []string) bool {


### PR DESCRIPTION
`rc apps apple setup` hard-aborted on Developer Portal bundle-ID registration (e.g. Apple 409 "not available") before ever reaching the keys the user asked for — despite the code's own contract that a missing app record "never blocks key setup." The register/create-app step is now non-fatal (warns and continues to key setup), and the 409 is explained ("likely already registered under another team or reserved") instead of surfacing the raw portal error.

DX-921

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX and error-handling only in the Apple setup path; no changes to auth, API contracts, or key upload logic beyond not aborting early.
> 
> **Overview**
> **`rc apps apple setup`** used to **fail the whole command** when Developer Portal bundle-ID registration or App Store Connect app creation failed (e.g. Apple 409 “not available”), even though the flow is meant to treat a missing app record as **non-blocking** for account-level key setup.
> 
> The register/create step is moved into **`createAppStoreAppRecord`**, which **warns and returns success** on those Apple errors so setup **continues to key creation**. **`warnAppRecordFailed`** maps “not available” to a clearer message (likely another team or reserved) and reminds users to create the ASC app before products. Tests cover register vs create failures and expected warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 155427437a7caffd02b0efca0794cdf4a95af110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->