### PR TITLE
fix(cli): make products create store-aware (--type / --duration / --title) (DX-920)

### DIFF
--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -230,8 +230,10 @@ store exactly (required).
 app's store decides which --type values are valid.
 --type is the Product type; valid values depend on the app's store. Test Store
 accepts subscription, consumable, non_consumable; App Store accepts subscription,
-one_time, non_renewing_subscription; Play Store, Amazon, and Stripe accept
-subscription and one_time (required; picker shown in a terminal).
+one_time, consumable, non_consumable, non_renewing_subscription; Play Store
+accepts subscription, one_time, consumable, non_consumable; Amazon, Stripe, and
+other stores accept subscription and one_time (required; picker shown in a
+terminal).
 --title is the Customer-facing Product title (required for Test Store Products).
 --duration is an ISO 8601 duration, e.g. P1M, P1Y. It is required for Test Store
 subscription Products; subscription parameters are only supported for Test Store
@@ -299,6 +301,9 @@ products.`,
 			if duration != "" && !isTestStoreApp(app) {
 				return fmt.Errorf("--duration and other subscription parameters are only supported for Test Store products, but app %s is a %s app", appID, app.Type)
 			}
+			if duration != "" && isTestStoreApp(app) && productType != "subscription" {
+				return fmt.Errorf("--duration is only valid for a Test Store subscription product, not a %s product", productType)
+			}
 			body := api.ProductCreate{
 				StoreIdentifier: storeID,
 				// Sent verbatim: Test Store takes consumable/non_consumable but reads back
@@ -328,9 +333,9 @@ products.`,
 	return cmd
 }
 
-// productTypesForStore returns the ProductType values accepted for an app's
-// store. non_renewing_subscription is App Store only (khepri __validate_product_type);
-// the sets' union must cover the ProductType enum (TestProductTypeStoreSetsCoverEnum).
+// productTypesForStore returns the product types each store's API accepts. These
+// aren't in the flat ProductType enum, so they're encoded here; the sets' union
+// must stay covering the enum (TestProductTypeStoreSetsCoverEnum).
 func productTypesForStore(appType api.AppType) []api.ProductType {
 	switch string(appType) {
 	case string(api.TestStoreAppTypeTestStore):
@@ -343,7 +348,16 @@ func productTypesForStore(appType api.AppType) []api.ProductType {
 		return []api.ProductType{
 			api.ProductTypeSubscription,
 			api.ProductTypeOneTime,
+			api.ProductTypeConsumable,
+			api.ProductTypeNonConsumable,
 			api.ProductTypeNonRenewingSubscription,
+		}
+	case string(api.PlayStoreAppTypePlayStore):
+		return []api.ProductType{
+			api.ProductTypeSubscription,
+			api.ProductTypeOneTime,
+			api.ProductTypeConsumable,
+			api.ProductTypeNonConsumable,
 		}
 	default:
 		return []api.ProductType{

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -226,12 +226,17 @@ func newProductsCreateCmd() *cobra.Command {
 
 --store-id is the Product identifier on the platform store; it must match the
 store exactly (required).
---type must be "subscription" or "one_time" (Non-Subscription Purchases)
-(required; picker shown in a terminal).
---app-id is the RevenueCat app ID (required; picker shown in a terminal).
---title is the Customer-facing Product title required by Test Store Products.
---duration (subscriptions only) is an ISO 8601 duration, e.g. P1M, P1Y.`,
-		Example: `  rc products create --store-id premium_monthly --type subscription --app-id app_x --title "Premium Monthly" --duration P1M
+--app-id is the RevenueCat app ID (required; picker shown in a terminal). The
+app's store decides which --type values are valid.
+--type is the Product type; valid values depend on the app's store. Test Store
+accepts subscription, consumable, non_consumable; App Store and Play Store
+accept subscription, one_time, non_renewing_subscription (required; picker shown
+in a terminal).
+--title is the Customer-facing Product title (required for Test Store Products).
+--duration is an ISO 8601 duration, e.g. P1M, P1Y. Subscription parameters are
+only supported for Test Store products.`,
+		Example: `  rc products create --store-id premium_monthly --type subscription --app-id test_app --title "Premium Monthly" --duration P1M
+  rc products create --store-id coins_100 --type consumable --app-id test_app --title "100 Coins"
   rc products create --store-id com.example.once --type one_time --app-id app_x --display-name "Unlock Everything"`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -241,21 +246,6 @@ store exactly (required).
 			}
 			if storeID == "" {
 				return fmt.Errorf("--store-id is required")
-			}
-			if productType == "" {
-				if rt.Globals.NoInput || !tui.IsInteractive() {
-					return fmt.Errorf("--type is required (subscription or one_time)")
-				}
-				sel := huh.NewSelect[string]().Title("Type").Options(
-					huh.NewOption("Subscription", "subscription"),
-					huh.NewOption("One-time purchase", "one_time"),
-				).Value(&productType)
-				if err := tui.Form(false).Field(sel).Run(); err != nil {
-					return err
-				}
-			}
-			if productType != "subscription" && productType != "one_time" {
-				return fmt.Errorf("--type must be 'subscription' or 'one_time', got %q", productType)
 			}
 			client, err := rt.API()
 			if err != nil {
@@ -275,12 +265,41 @@ store exactly (required).
 			if err != nil {
 				return err
 			}
+			app, err := client.Apps.Get(cmd.Context(), projectID, appID)
+			if err != nil {
+				return err
+			}
+			allowed := productTypesForStore(app.Type)
+			if productType == "" {
+				if rt.Globals.NoInput || !tui.IsInteractive() {
+					return fmt.Errorf("--type is required (%s)", strings.Join(productTypeValues(allowed), ", "))
+				}
+				opts := make([]huh.Option[string], len(allowed))
+				for i, t := range allowed {
+					opts[i] = huh.NewOption(productTypeLabel(t), string(t))
+				}
+				sel := huh.NewSelect[string]().Title("Type").Options(opts...).Value(&productType)
+				if err := tui.Form(false).Field(sel).Run(); err != nil {
+					return err
+				}
+			}
+			if !containsProductType(allowed, productType) {
+				return fmt.Errorf("--type must be one of %s for a %s app, got %q", strings.Join(productTypeValues(allowed), ", "), app.Type, productType)
+			}
+			if isTestStoreApp(app) && title == "" {
+				return fmt.Errorf("--title is required for Test Store products")
+			}
+			if duration != "" && !isTestStoreApp(app) {
+				return fmt.Errorf("--duration and other subscription parameters are only supported for Test Store products, but app %s is a %s app", appID, app.Type)
+			}
 			body := api.ProductCreate{
 				StoreIdentifier: storeID,
-				Type:            productType,
-				AppID:           appID,
-				DisplayName:     displayName,
-				Title:           title,
+				// Sent verbatim: Test Store takes consumable/non_consumable but reads back
+				// as one_time + is_consumable, so the sent type is the authoritative one.
+				Type:        productType,
+				AppID:       appID,
+				DisplayName: displayName,
+				Title:       title,
 			}
 			if productType == "subscription" && duration != "" {
 				body.Subscription = &api.ProductSubscriptionInput{Duration: api.Duration(duration)}
@@ -294,12 +313,68 @@ store exactly (required).
 		},
 	}
 	cmd.Flags().StringVar(&storeID, "store-id", "", "store product identifier (required)")
-	cmd.Flags().StringVar(&productType, "type", "", "product type: subscription or one_time (picker shown in TTY if omitted)")
+	cmd.Flags().StringVar(&productType, "type", "", "product type (valid values depend on the app's store; picker shown in TTY if omitted)")
 	cmd.Flags().StringVar(&appID, "app-id", "", "app ID to associate with (picker shown in TTY if omitted)")
 	cmd.Flags().StringVar(&displayName, "display-name", "", "human-readable display name")
 	cmd.Flags().StringVar(&title, "title", "", "user-facing product title (required for Test Store products)")
-	cmd.Flags().StringVar(&duration, "duration", "", "subscription duration as ISO 8601 (e.g. P1M, P1Y)")
+	cmd.Flags().StringVar(&duration, "duration", "", "subscription duration as ISO 8601 (e.g. P1M, P1Y); Test Store products only")
 	return cmd
+}
+
+// productTypesForStore returns the ProductType values accepted for an app's
+// store. Test Store takes granular consumable/non_consumable; the App/Play
+// stores take one_time and non_renewing_subscription. The union across stores
+// must cover the ProductType enum (see TestProductTypeStoreSetsCoverEnum).
+func productTypesForStore(appType api.AppType) []api.ProductType {
+	if string(appType) == string(api.TestStoreAppTypeTestStore) {
+		return []api.ProductType{
+			api.ProductTypeSubscription,
+			api.ProductTypeConsumable,
+			api.ProductTypeNonConsumable,
+		}
+	}
+	return []api.ProductType{
+		api.ProductTypeSubscription,
+		api.ProductTypeOneTime,
+		api.ProductTypeNonRenewingSubscription,
+	}
+}
+
+func productTypeValues(types []api.ProductType) []string {
+	out := make([]string, len(types))
+	for i, t := range types {
+		out[i] = string(t)
+	}
+	return out
+}
+
+func containsProductType(types []api.ProductType, value string) bool {
+	for _, t := range types {
+		if string(t) == value {
+			return true
+		}
+	}
+	return false
+}
+
+func productTypeLabel(t api.ProductType) string {
+	switch t {
+	case api.ProductTypeSubscription:
+		return "Subscription"
+	case api.ProductTypeOneTime:
+		return "One-time purchase"
+	case api.ProductTypeConsumable:
+		return "Consumable"
+	case api.ProductTypeNonConsumable:
+		return "Non-consumable"
+	case api.ProductTypeNonRenewingSubscription:
+		return "Non-renewing subscription"
+	}
+	return string(t)
+}
+
+func isTestStoreApp(app *api.App) bool {
+	return app != nil && string(app.Type) == string(api.TestStoreAppTypeTestStore)
 }
 
 func newProductsPricesCmd() *cobra.Command {

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -271,7 +271,7 @@ only supported for Test Store products.`,
 			}
 			allowed := productTypesForStore(app.Type)
 			if productType == "" {
-				if rt.Globals.NoInput || !tui.IsInteractive() {
+				if rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
 					return fmt.Errorf("--type is required (%s)", strings.Join(productTypeValues(allowed), ", "))
 				}
 				opts := make([]huh.Option[string], len(allowed))
@@ -322,11 +322,12 @@ only supported for Test Store products.`,
 }
 
 // productTypesForStore returns the ProductType values accepted for an app's
-// store. Test Store takes granular consumable/non_consumable; the App/Play
-// stores take one_time and non_renewing_subscription. The union across stores
-// must cover the ProductType enum (see TestProductTypeStoreSetsCoverEnum).
+// store. Test Store and Web Billing take granular consumable/non_consumable;
+// the App/Play stores take one_time and non_renewing_subscription. The union
+// across stores must cover the ProductType enum (see TestProductTypeStoreSetsCoverEnum).
 func productTypesForStore(appType api.AppType) []api.ProductType {
-	if string(appType) == string(api.TestStoreAppTypeTestStore) {
+	switch string(appType) {
+	case string(api.TestStoreAppTypeTestStore), string(api.RCBillingAppTypeRcBilling):
 		return []api.ProductType{
 			api.ProductTypeSubscription,
 			api.ProductTypeConsumable,

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -270,7 +270,7 @@ only supported for Test Store products.`,
 				return err
 			}
 			if string(app.Type) == string(api.RCBillingAppTypeRcBilling) {
-				return fmt.Errorf("Web Billing products can't be created via the API; configure them in the RevenueCat dashboard")
+				return fmt.Errorf("can't create Web Billing products via the API; configure them in the RevenueCat dashboard")
 			}
 			allowed := productTypesForStore(app.Type)
 			if productType == "" {

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -229,12 +229,13 @@ store exactly (required).
 --app-id is the RevenueCat app ID (required; picker shown in a terminal). The
 app's store decides which --type values are valid.
 --type is the Product type; valid values depend on the app's store. Test Store
-accepts subscription, consumable, non_consumable; App Store and Play Store
-accept subscription, one_time, non_renewing_subscription (required; picker shown
-in a terminal).
+accepts subscription, consumable, non_consumable; App Store accepts subscription,
+one_time, non_renewing_subscription; Play Store, Amazon, and Stripe accept
+subscription and one_time (required; picker shown in a terminal).
 --title is the Customer-facing Product title (required for Test Store Products).
---duration is an ISO 8601 duration, e.g. P1M, P1Y. Subscription parameters are
-only supported for Test Store products.`,
+--duration is an ISO 8601 duration, e.g. P1M, P1Y. It is required for Test Store
+subscription Products; subscription parameters are only supported for Test Store
+products.`,
 		Example: `  rc products create --store-id premium_monthly --type subscription --app-id test_app --title "Premium Monthly" --duration P1M
   rc products create --store-id coins_100 --type consumable --app-id test_app --title "100 Coins"
   rc products create --store-id com.example.once --type one_time --app-id app_x --display-name "Unlock Everything"`,
@@ -292,6 +293,9 @@ only supported for Test Store products.`,
 			if isTestStoreApp(app) && title == "" {
 				return fmt.Errorf("--title is required for Test Store products")
 			}
+			if isTestStoreApp(app) && productType == "subscription" && duration == "" {
+				return fmt.Errorf("--duration is required for Test Store subscription products (e.g. P1M, P1Y)")
+			}
 			if duration != "" && !isTestStoreApp(app) {
 				return fmt.Errorf("--duration and other subscription parameters are only supported for Test Store products, but app %s is a %s app", appID, app.Type)
 			}
@@ -325,21 +329,27 @@ only supported for Test Store products.`,
 }
 
 // productTypesForStore returns the ProductType values accepted for an app's
-// store. Test Store takes granular consumable/non_consumable; the App/Play
-// stores take one_time and non_renewing_subscription. The union across stores
-// must cover the ProductType enum (see TestProductTypeStoreSetsCoverEnum).
+// store. non_renewing_subscription is App Store only (khepri __validate_product_type);
+// the sets' union must cover the ProductType enum (TestProductTypeStoreSetsCoverEnum).
 func productTypesForStore(appType api.AppType) []api.ProductType {
-	if string(appType) == string(api.TestStoreAppTypeTestStore) {
+	switch string(appType) {
+	case string(api.TestStoreAppTypeTestStore):
 		return []api.ProductType{
 			api.ProductTypeSubscription,
 			api.ProductTypeConsumable,
 			api.ProductTypeNonConsumable,
 		}
-	}
-	return []api.ProductType{
-		api.ProductTypeSubscription,
-		api.ProductTypeOneTime,
-		api.ProductTypeNonRenewingSubscription,
+	case string(api.AppStoreAppTypeAppStore):
+		return []api.ProductType{
+			api.ProductTypeSubscription,
+			api.ProductTypeOneTime,
+			api.ProductTypeNonRenewingSubscription,
+		}
+	default:
+		return []api.ProductType{
+			api.ProductTypeSubscription,
+			api.ProductTypeOneTime,
+		}
 	}
 }
 

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -269,6 +269,9 @@ only supported for Test Store products.`,
 			if err != nil {
 				return err
 			}
+			if string(app.Type) == string(api.RCBillingAppTypeRcBilling) {
+				return fmt.Errorf("Web Billing products can't be created via the API; configure them in the RevenueCat dashboard")
+			}
 			allowed := productTypesForStore(app.Type)
 			if productType == "" {
 				if rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
@@ -322,12 +325,11 @@ only supported for Test Store products.`,
 }
 
 // productTypesForStore returns the ProductType values accepted for an app's
-// store. Test Store and Web Billing take granular consumable/non_consumable;
-// the App/Play stores take one_time and non_renewing_subscription. The union
-// across stores must cover the ProductType enum (see TestProductTypeStoreSetsCoverEnum).
+// store. Test Store takes granular consumable/non_consumable; the App/Play
+// stores take one_time and non_renewing_subscription. The union across stores
+// must cover the ProductType enum (see TestProductTypeStoreSetsCoverEnum).
 func productTypesForStore(appType api.AppType) []api.ProductType {
-	switch string(appType) {
-	case string(api.TestStoreAppTypeTestStore), string(api.RCBillingAppTypeRcBilling):
+	if string(appType) == string(api.TestStoreAppTypeTestStore) {
 		return []api.ProductType{
 			api.ProductTypeSubscription,
 			api.ProductTypeConsumable,

--- a/internal/cli/products_create_test.go
+++ b/internal/cli/products_create_test.go
@@ -69,19 +69,24 @@ func TestProductsCreate_TypeAcceptanceByStore(t *testing.T) {
 		{"app_store subscription", "app_store", "subscription", true},
 		{"app_store one_time", "app_store", "one_time", true},
 		{"app_store non_renewing_subscription", "app_store", "non_renewing_subscription", true},
-		{"app_store consumable", "app_store", "consumable", false},
-		{"app_store non_consumable", "app_store", "non_consumable", false},
+		{"app_store consumable", "app_store", "consumable", true},
+		{"app_store non_consumable", "app_store", "non_consumable", true},
 
 		{"play_store subscription", "play_store", "subscription", true},
 		{"play_store one_time", "play_store", "one_time", true},
 		{"play_store non_renewing_subscription", "play_store", "non_renewing_subscription", false},
-		{"play_store consumable", "play_store", "consumable", false},
-		{"play_store non_consumable", "play_store", "non_consumable", false},
+		{"play_store consumable", "play_store", "consumable", true},
+		{"play_store non_consumable", "play_store", "non_consumable", true},
 
 		{"amazon one_time", "amazon", "one_time", true},
 		{"amazon non_renewing_subscription", "amazon", "non_renewing_subscription", false},
+		{"amazon consumable", "amazon", "consumable", false},
 		{"stripe subscription", "stripe", "subscription", true},
 		{"stripe non_renewing_subscription", "stripe", "non_renewing_subscription", false},
+		{"roku non_renewing_subscription", "roku", "non_renewing_subscription", false},
+		{"roku subscription", "roku", "subscription", true},
+		{"roku one_time", "roku", "one_time", true},
+		{"roku consumable", "roku", "consumable", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -158,6 +163,20 @@ func TestProductsCreate_DurationRejectedOnAppStore(t *testing.T) {
 	}
 }
 
+func TestProductsCreate_DurationRejectedOnTestStoreNonSubscription(t *testing.T) {
+	requests, _, err := runProductsCreate(t, "test_store",
+		"--store-id", "sid", "--type", "consumable", "--app-id", "app", "--title", "T", "--duration", "P1M")
+	if err == nil {
+		t.Fatal("expected client-side rejection for --duration on a Test Store consumable")
+	}
+	if !strings.Contains(err.Error(), "--duration") {
+		t.Fatalf("error should mention --duration, got: %v", err)
+	}
+	if postedProducts(requests) {
+		t.Fatalf("--duration reached the server on a Test Store consumable: %v", requests)
+	}
+}
+
 func TestProductsCreate_RejectsWebBilling(t *testing.T) {
 	requests, _, err := runProductsCreate(t, "rc_billing",
 		"--store-id", "sid", "--type", "subscription", "--app-id", "app", "--title", "T")
@@ -201,6 +220,31 @@ func TestProductsCreate_DurationRequiredForTestStoreSubscription(t *testing.T) {
 	}
 	if postedProducts(requests) {
 		t.Fatalf("missing --duration still reached the server: %v", requests)
+	}
+}
+
+func TestProductsCreate_TypeRequiredWhenNonInteractive(t *testing.T) {
+	requests, _, err := runProductsCreate(t, "app_store",
+		"--store-id", "sid", "--app-id", "app")
+	if err == nil {
+		t.Fatal("expected client-side rejection for missing --type when non-interactive")
+	}
+	if !strings.Contains(err.Error(), "--type is required") {
+		t.Fatalf("error should mention --type is required, got: %v", err)
+	}
+	if postedProducts(requests) {
+		t.Fatalf("missing --type still reached the create endpoint: %v", requests)
+	}
+}
+
+func TestProductsCreate_TitleNotRequiredForNonTestStore(t *testing.T) {
+	requests, _, err := runProductsCreate(t, "app_store",
+		"--store-id", "sid", "--type", "one_time", "--app-id", "app")
+	if err != nil {
+		t.Fatalf("unexpected error creating a non-Test-store product without --title: %v", err)
+	}
+	if !postedProducts(requests) {
+		t.Fatalf("create did not reach the server: %v", requests)
 	}
 }
 

--- a/internal/cli/products_create_test.go
+++ b/internal/cli/products_create_test.go
@@ -150,6 +150,20 @@ func TestProductsCreate_DurationRejectedOnAppStore(t *testing.T) {
 	}
 }
 
+func TestProductsCreate_RejectsWebBilling(t *testing.T) {
+	requests, _, err := runProductsCreate(t, "rc_billing",
+		"--store-id", "sid", "--type", "subscription", "--app-id", "app", "--title", "T")
+	if err == nil {
+		t.Fatal("expected client-side rejection creating a Web Billing product")
+	}
+	if !strings.Contains(err.Error(), "Web Billing") {
+		t.Fatalf("error should explain Web Billing can't be created, got: %v", err)
+	}
+	if postedProducts(requests) {
+		t.Fatalf("Web Billing create reached the server: %v", requests)
+	}
+}
+
 func TestProductsCreate_DurationAcceptedOnTestStore(t *testing.T) {
 	requests, body, err := runProductsCreate(t, "test_store",
 		"--store-id", "sid", "--type", "subscription", "--app-id", "app", "--title", "T", "--duration", "P1M")

--- a/internal/cli/products_create_test.go
+++ b/internal/cli/products_create_test.go
@@ -74,14 +74,22 @@ func TestProductsCreate_TypeAcceptanceByStore(t *testing.T) {
 
 		{"play_store subscription", "play_store", "subscription", true},
 		{"play_store one_time", "play_store", "one_time", true},
-		{"play_store non_renewing_subscription", "play_store", "non_renewing_subscription", true},
+		{"play_store non_renewing_subscription", "play_store", "non_renewing_subscription", false},
 		{"play_store consumable", "play_store", "consumable", false},
 		{"play_store non_consumable", "play_store", "non_consumable", false},
+
+		{"amazon one_time", "amazon", "one_time", true},
+		{"amazon non_renewing_subscription", "amazon", "non_renewing_subscription", false},
+		{"stripe subscription", "stripe", "subscription", true},
+		{"stripe non_renewing_subscription", "stripe", "non_renewing_subscription", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			requests, body, err := runProductsCreate(t, tc.appType,
-				"--store-id", "sid", "--type", tc.productType, "--app-id", "app", "--title", "T")
+			args := []string{"--store-id", "sid", "--type", tc.productType, "--app-id", "app", "--title", "T"}
+			if tc.appType == "test_store" && tc.productType == "subscription" {
+				args = append(args, "--duration", "P1M")
+			}
+			requests, body, err := runProductsCreate(t, tc.appType, args...)
 			if tc.accepted {
 				if err != nil {
 					t.Fatalf("expected accept, got error: %v", err)
@@ -179,6 +187,20 @@ func TestProductsCreate_DurationAcceptedOnTestStore(t *testing.T) {
 	}
 	if sub["duration"] != "P1M" {
 		t.Fatalf("outgoing duration = %v, want P1M", sub["duration"])
+	}
+}
+
+func TestProductsCreate_DurationRequiredForTestStoreSubscription(t *testing.T) {
+	requests, _, err := runProductsCreate(t, "test_store",
+		"--store-id", "sid", "--type", "subscription", "--app-id", "app", "--title", "T")
+	if err == nil {
+		t.Fatal("expected client-side rejection for missing --duration on a Test Store subscription")
+	}
+	if !strings.Contains(err.Error(), "--duration") {
+		t.Fatalf("error should mention --duration, got: %v", err)
+	}
+	if postedProducts(requests) {
+		t.Fatalf("missing --duration still reached the server: %v", requests)
 	}
 }
 

--- a/internal/cli/products_create_test.go
+++ b/internal/cli/products_create_test.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+func runProductsCreate(t *testing.T, appType string, args ...string) (requests []string, createBody map[string]any, err error) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/projects/proj/apps/app":
+			_, _ = io.WriteString(w, `{"id":"app","name":"App","type":"`+appType+`","object":"app","project_id":"proj","created_at":1}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/projects/proj/products":
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &createBody)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"id":"prod_1","store_identifier":"sid","type":"one_time","app_id":"app","object":"product","created_at":1}`)
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	t.Setenv("RC_BASE_URL", srv.URL)
+	var out, errOut bytes.Buffer
+	root := NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	base := []string{"products", "create", "--api-key", "sk_test", "--project-id", "proj", "--no-input", "--json"}
+	root.SetArgs(append(base, args...))
+	err = root.ExecuteContext(context.Background())
+	return requests, createBody, err
+}
+
+func postedProducts(requests []string) bool {
+	for _, r := range requests {
+		if r == "POST /projects/proj/products" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestProductsCreate_TypeAcceptanceByStore(t *testing.T) {
+	cases := []struct {
+		name        string
+		appType     string
+		productType string
+		accepted    bool
+	}{
+		{"test_store subscription", "test_store", "subscription", true},
+		{"test_store consumable", "test_store", "consumable", true},
+		{"test_store non_consumable", "test_store", "non_consumable", true},
+		{"test_store one_time", "test_store", "one_time", false},
+		{"test_store non_renewing_subscription", "test_store", "non_renewing_subscription", false},
+
+		{"app_store subscription", "app_store", "subscription", true},
+		{"app_store one_time", "app_store", "one_time", true},
+		{"app_store non_renewing_subscription", "app_store", "non_renewing_subscription", true},
+		{"app_store consumable", "app_store", "consumable", false},
+		{"app_store non_consumable", "app_store", "non_consumable", false},
+
+		{"play_store subscription", "play_store", "subscription", true},
+		{"play_store one_time", "play_store", "one_time", true},
+		{"play_store non_renewing_subscription", "play_store", "non_renewing_subscription", true},
+		{"play_store consumable", "play_store", "consumable", false},
+		{"play_store non_consumable", "play_store", "non_consumable", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			requests, body, err := runProductsCreate(t, tc.appType,
+				"--store-id", "sid", "--type", tc.productType, "--app-id", "app", "--title", "T")
+			if tc.accepted {
+				if err != nil {
+					t.Fatalf("expected accept, got error: %v", err)
+				}
+				if !postedProducts(requests) {
+					t.Fatalf("accepted type did not reach the create endpoint: %v", requests)
+				}
+				if got, _ := body["type"].(string); got != tc.productType {
+					t.Fatalf("outgoing type = %q, want %q", got, tc.productType)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected client-side rejection, got nil error")
+			}
+			if postedProducts(requests) {
+				t.Fatalf("rejected type still reached the create endpoint: %v", requests)
+			}
+		})
+	}
+}
+
+func TestProductTypeStoreSetsCoverEnum(t *testing.T) {
+	stores := []api.AppType{
+		api.AppType(api.TestStoreAppTypeTestStore),
+		api.AppType(api.AppStoreAppTypeAppStore),
+		api.AppType(api.PlayStoreAppTypePlayStore),
+	}
+	seen := map[api.ProductType]bool{}
+	for _, s := range stores {
+		for _, pt := range productTypesForStore(s) {
+			if !pt.Valid() {
+				t.Errorf("store %s offers invalid product type %q", s, pt)
+			}
+			seen[pt] = true
+		}
+	}
+	enum := []api.ProductType{
+		api.ProductTypeConsumable,
+		api.ProductTypeNonConsumable,
+		api.ProductTypeNonRenewingSubscription,
+		api.ProductTypeOneTime,
+		api.ProductTypeSubscription,
+	}
+	for _, pt := range enum {
+		if !seen[pt] {
+			t.Errorf("ProductType %q is in the catalog enum but no store offers it", pt)
+		}
+	}
+	if len(seen) != len(enum) {
+		t.Errorf("store sets offer %d distinct types, catalog enum has %d", len(seen), len(enum))
+	}
+}
+
+func TestProductsCreate_DurationRejectedOnAppStore(t *testing.T) {
+	requests, _, err := runProductsCreate(t, "app_store",
+		"--store-id", "sid", "--type", "subscription", "--app-id", "app", "--title", "T", "--duration", "P1M")
+	if err == nil {
+		t.Fatal("expected client-side rejection for --duration on an App Store app")
+	}
+	if !strings.Contains(err.Error(), "Test Store") {
+		t.Fatalf("error should explain Test Store restriction, got: %v", err)
+	}
+	if postedProducts(requests) {
+		t.Fatalf("--duration reached the server on an App Store app: %v", requests)
+	}
+}
+
+func TestProductsCreate_DurationAcceptedOnTestStore(t *testing.T) {
+	requests, body, err := runProductsCreate(t, "test_store",
+		"--store-id", "sid", "--type", "subscription", "--app-id", "app", "--title", "T", "--duration", "P1M")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !postedProducts(requests) {
+		t.Fatalf("create did not reach the server: %v", requests)
+	}
+	sub, ok := body["subscription"].(map[string]any)
+	if !ok {
+		t.Fatalf("outgoing body missing subscription: %v", body)
+	}
+	if sub["duration"] != "P1M" {
+		t.Fatalf("outgoing duration = %v, want P1M", sub["duration"])
+	}
+}
+
+func TestProductsCreate_TitleRequiredForTestStore(t *testing.T) {
+	requests, _, err := runProductsCreate(t, "test_store",
+		"--store-id", "sid", "--type", "subscription", "--app-id", "app")
+	if err == nil {
+		t.Fatal("expected client-side rejection for missing --title on a Test Store app")
+	}
+	if !strings.Contains(err.Error(), "--title") {
+		t.Fatalf("error should mention --title, got: %v", err)
+	}
+	if postedProducts(requests) {
+		t.Fatalf("missing --title still reached the server: %v", requests)
+	}
+}

--- a/internal/cli/project_setup_cli_test.go
+++ b/internal/cli/project_setup_cli_test.go
@@ -78,6 +78,11 @@ func TestAppsKeys_ReturnsTypedPublicSDKKeys(t *testing.T) {
 
 func TestProductsCreate_SendsTestStoreTitleAndDuration(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/projects/proj/apps/app_test" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":"app_test","name":"Test","type":"test_store","object":"app","project_id":"proj","created_at":1}`)
+			return
+		}
 		if r.Method != http.MethodPost || r.URL.Path != "/projects/proj/products" {
 			http.Error(w, "unexpected request", http.StatusNotFound)
 			return

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -20,7 +20,7 @@ type PickerItem struct {
 //
 //   - arg non-empty          → return as-is, no network call
 //   - arg empty + TTY        → fetch items, show searchable picker
-//   - arg empty + --no-input → error: "<noun> ID is required"
+//   - arg empty + --no-input/--json → error: "<noun> ID is required"
 //
 // Pass argAt(args, i) as arg so commands with multiple positional IDs follow
 // the same pattern regardless of how many positions they need.
@@ -28,7 +28,7 @@ func requireID(rt *Runtime, arg, noun string, fetch func() ([]PickerItem, error)
 	if arg != "" {
 		return arg, nil
 	}
-	if rt.Globals.NoInput || !tui.IsInteractive() {
+	if rt.Globals.NoInput || rt.Globals.JSON || !tui.IsInteractive() {
 		return "", fmt.Errorf("%s ID is required", noun)
 	}
 	items, err := fetch()


### PR DESCRIPTION
`rc products create` couldn't create a non-subscription Test Store product — the accepted `--type` values (`subscription`/`one_time`) didn't overlap what the Test Store API accepts (`subscription`/`consumable`/`non_consumable`), so no value worked. It also advertised a `--duration` example that fails on real store apps.

Now the app is resolved first so the store is known, and `--type` is validated per store (sourced from the ProductType enum, sent verbatim — no silent mapping). `--duration`/subscription params are rejected client-side on non-Test-Store apps with a message naming the store, and `--title` is required up front for Test Store. Includes a drift-guard test so the accepted set can't fall out of sync with the enum.

Note: non-Apple/Play stores fall into the default set (`subscription`/`one_time`/`non_renewing_subscription`) — flag if web-billing needs different.

DX-920

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes product-create validation and API payload shaping in the CLI; mistakes could block valid creates or send wrong types, but impact is localized to this command and is heavily tested.
> 
> **Overview**
> **`rc products create`** now loads the target app before validating flags, so **`--type`**, **`--title`**, and **`--duration`** rules match each store instead of assuming only `subscription` / `one_time`.
> 
> **`--type`** is checked against per-store allowed sets (Test Store: subscription/consumable/non_consumable; App Store and Play with broader enums; default stores: subscription/one_time). The interactive picker lists only valid types for that app. Types are sent to the API verbatim (no silent mapping). **Web Billing (`rc_billing`)** apps are rejected with a dashboard message.
> 
> **Test Store** products require **`--title`**; Test Store **subscriptions** require **`--duration`**. **`--duration`** is rejected on non–Test Store apps and on non-subscription Test Store products.
> 
> **`requireID`** no longer opens interactive pickers when **`--json`** is set (same as **`--no-input`**).
> 
> New **`products_create_test.go`** covers store/type matrix, duration/title rules, Web Billing rejection, and a drift guard so store type sets stay aligned with the **`ProductType`** enum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54264ee326d2b6f70941968bbb02f6c90437e2d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->