### PR TITLE
paywalls delete: guard attached/published paywalls behind --force

### DIFF
--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -214,7 +214,7 @@ rc paywalls edit <paywall-id>|--session <file> --prompt  # AI-edit any paywall (
 rc paywalls rewind --session <file>                      # undo the last editor action
 rc paywalls publish [id]                                 # publish the current draft; confirmation/--yes
 rc paywalls unpublish [id]                               # remove the published paywall; confirmation/--yes
-rc paywalls delete <id>
+rc paywalls delete <id> [--force]                        # attached/published paywalls refuse to delete without --force
 
 # Rico (AI assistant)
 rc rico chat [message]                                   # streaming chat window in a TTY (--plain for a line loop)

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -256,16 +256,22 @@ func newPaywallsShowCmd() *cobra.Command {
 }
 
 func newPaywallsDeleteCmd() *cobra.Command {
-	return &cobra.Command{
+	var force bool
+	cmd := &cobra.Command{
 		Use:   "delete [id]",
 		Short: "Delete a paywall",
 		Long: `Permanently deletes a paywall.
 
 Reversibility: irreversible. Recreate the paywall if it is deleted.
 
+A paywall that is attached to an offering or published refuses to delete
+unless --force is passed — --yes alone is not enough. It may be live or
+someone else's in-progress work; get explicit consent from the user first.
+
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc paywalls delete pw_old --yes`,
-		Args:    cobra.MaximumNArgs(1),
+		Example: `  rc paywalls delete pw_old --yes
+  rc paywalls delete pw_attached --force --yes`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -282,17 +288,42 @@ Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`
 			if err != nil {
 				return err
 			}
-			args = []string{pickedID}
-			if err := confirmOrAbort(rt, fmt.Sprintf("Delete paywall %q?", args[0])); err != nil {
+			paywall, err := client.Paywalls.Get(cmd.Context(), projectID, pickedID)
+			if err != nil {
 				return err
 			}
-			if err := client.Paywalls.Delete(cmd.Context(), projectID, args[0]); err != nil {
+			if !force {
+				switch {
+				case paywall.PublishedAt != nil:
+					return WithHint(
+						fmt.Errorf("paywall %s is published — customers may be seeing it", pickedID),
+						"Deletion is irreversible. Unpublish it first (rc paywalls unpublish "+pickedID+") and detach it from its offering in the dashboard, or re-run with --force after the user explicitly confirms this paywall should be destroyed.",
+					)
+				case paywall.OfferingID != "":
+					return WithHint(
+						fmt.Errorf("paywall %s is attached to offering %s and may be someone's in-progress work", pickedID, paywall.OfferingID),
+						"Deletion is irreversible. Re-run with --force only after the user explicitly confirms this paywall should be destroyed. To free the offering for a new design instead, generate a standalone draft (rc paywalls generate without --offering-id) and attach it in the dashboard.",
+					)
+				}
+			}
+			if paywall.PublishedAt != nil {
+				rt.Out.Warn("This paywall is published — customers may be seeing it.")
+			}
+			if paywall.OfferingID != "" {
+				rt.Out.Warn(fmt.Sprintf("Attached to offering %s.", paywall.OfferingID))
+			}
+			if err := confirmOrAbort(rt, fmt.Sprintf("Permanently delete paywall %s?", paywallPickerLabel(*paywall))); err != nil {
 				return err
 			}
-			rt.Out.Success(fmt.Sprintf("Deleted %s", args[0]))
-			return rt.Out.Render(map[string]any{"ok": true, "id": args[0]})
+			if err := client.Paywalls.Delete(cmd.Context(), projectID, pickedID); err != nil {
+				return err
+			}
+			rt.Out.Success(fmt.Sprintf("Deleted %s", pickedID))
+			return rt.Out.Render(map[string]any{"ok": true, "id": pickedID})
 		},
 	}
+	cmd.Flags().BoolVar(&force, "force", false, "delete even when the paywall is attached to an offering or published")
+	return cmd
 }
 
 // wrapPaywallActionGateError explains the beta gate on the paywall

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -172,7 +172,7 @@ run rc paywalls publish.`,
 				if opts.offeringID != "" && errors.As(err, &apiErr) && apiErr.Status == 409 {
 					return WithHint(
 						fmt.Errorf("creating draft paywall: offering %s already has a paywall (an offering can only have one): %w", opts.offeringID, err),
-						"Generate against another offering, omit --offering-id to create a standalone draft and attach it in the dashboard later, or delete the existing paywall (rc paywalls list, then rc paywalls delete <id>).",
+						"omit --offering-id to generate a standalone draft and attach it in the dashboard later, or generate against another offering. Do NOT delete the existing paywall to clear the way: deletion is irreversible and it may be someone else's in-progress work — inspect it first (rc paywalls show <id>) and get explicit consent from the user before any rc paywalls delete.",
 					)
 				}
 				return fmt.Errorf("creating draft paywall: %w", err)

--- a/internal/cli/paywalls_delete_test.go
+++ b/internal/cli/paywalls_delete_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPaywallsDeleteRequiresForceForAttachedOrPublished(t *testing.T) {
+	paywalls := map[string]string{
+		"pw_attached":   `{"object":"paywall","id":"pw_attached","name":"Hero","offering_id":"ofrng_x","created_at":1700000000000,"published_at":null}`,
+		"pw_published":  `{"object":"paywall","id":"pw_published","name":"Live","offering_id":"ofrng_live","created_at":1700000000000,"published_at":1700000000000}`,
+		"pw_standalone": `{"object":"paywall","id":"pw_standalone","created_at":1700000000000,"published_at":null}`,
+	}
+	var deletedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		id := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+		switch r.Method {
+		case http.MethodGet:
+			io.WriteString(w, paywalls[id])
+		case http.MethodDelete:
+			deletedPaths = append(deletedPaths, r.URL.Path)
+			io.WriteString(w, `{}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	t.Setenv("RC_BASE_URL", server.URL)
+
+	del := func(args ...string) error {
+		root := NewRootCmd("test")
+		root.SetOut(io.Discard)
+		root.SetErr(&bytes.Buffer{})
+		root.SetArgs(append([]string{"paywalls", "delete"}, append(args, "--yes", "--api-key", "sk_test", "--project-id", "proj")...))
+		return root.ExecuteContext(context.Background())
+	}
+
+	for _, id := range []string{"pw_attached", "pw_published"} {
+		if err := del(id); err == nil {
+			t.Fatalf("%s should require --force", id)
+		}
+	}
+	if len(deletedPaths) != 0 {
+		t.Fatalf("refusals must not issue DELETE, got %v", deletedPaths)
+	}
+
+	if err := del("pw_standalone"); err != nil {
+		t.Fatalf("standalone draft should delete without --force: %v", err)
+	}
+	if err := del("pw_attached", "--force"); err != nil {
+		t.Fatalf("--force should delete attached paywall: %v", err)
+	}
+	want := []string{"/projects/proj/paywalls/pw_standalone", "/projects/proj/paywalls/pw_attached"}
+	if len(deletedPaths) != 2 || deletedPaths[0] != want[0] || deletedPaths[1] != want[1] {
+		t.Fatalf("DELETE paths = %v, want %v", deletedPaths, want)
+	}
+}


### PR DESCRIPTION
Fixes [PWAI-352](https://linear.app/revenuecat/issue/PWAI-352/protect-against-agents-deleting-paywalls-gate-rc-paywalls-delete)

Prevents `rc paywalls delete` from removing attached or published paywalls without an explicit `--force` flag, so agents cannot silently destroy live or in-progress work.

#### `--json` warning
```
> ./rc-local paywalls delete pwa895c605402a4420 --json
{
  "error": {
    "type": "cli_error",
    "message": "paywall pwa895c605402a4420 is published — customers may be seeing it",
    "exit_code": 1,
    "hint": "Deletion is irreversible. Unpublish it first (rc paywalls unpublish pwa895c605402a4420) and detach it from its offering in the dashboard, or re-run with --force after the user explicitly confirms this paywall should be destroyed."
  },
  "schema_version": 1
}
```

#### Interactive mode warning
```
> ./rc-local paywalls delete pwa895c605402a4420
· Using project: Drago Testing (proj275ac756)
✗ paywall pwa895c605402a4420 is published — customers may be seeing it
Hint: Deletion is irreversible. Unpublish it first (rc paywalls unpublish pwa895c605402a4420) and detach it from its offering in the dashboard, or re-run with --force after the user explicitly confirms this paywall should be destroyed.
```

#### Works as expected when paywall is unpublished and not attached to an offering
```
> ./rc-local paywalls delete pwa895c605402a4420
· Using project: Drago Testing (proj275ac756)

┃ Permanently delete paywall RJ+ test · standalone · 2026-08-10 · draft?
┃
┃                              Yes     No
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes destructive CLI behavior and agent guidance around paywall deletion; mistakes are irreversible, but the new guards reduce accidental deletion of live or attached paywalls.
> 
> **Overview**
> **`rc paywalls delete`** now loads the paywall first and **blocks deletion** when it is **published** or **attached to an offering**, unless **`--force`** is set. **`--yes` does not bypass** that guard—only an explicit **`--force`** after user consent.
> 
> Refusals return **`WithHint`** messages (unpublish/detach in the dashboard, or re-run with **`--force`**). With **`--force`**, the CLI still **warns** about live or attached state before the permanent-delete confirmation, which uses a richer **`paywallPickerLabel`**.
> 
> Docs and **`paywalls generate`**’s offering-already-has-paywall (**409**) hint are updated to steer agents away from deleting in-progress work; **`paywalls_delete_test`** covers refusal vs standalone vs **`--force`** delete paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9daf7419944551a2a76e44e28c6dec6c6bc74d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

