### PR TITLE
paywalls: add agent steering guidance to command descriptions

### DIFF
--- a/internal/cli/fonts.go
+++ b/internal/cli/fonts.go
@@ -112,11 +112,9 @@ func newFontsUploadCmd() *cobra.Command {
 The response's font_key (RCFM:…) is the reference. The server registers the
 font project-wide automatically — no further setup call is needed.
 
-A paywall uses the font when a text component's font_name is set to the
-font_key. Two routes: name the key explicitly in an rc paywalls edit prompt
-("set headings to font_name RCFM:…") — the editor does not list custom fonts,
-so always name the key — or PATCH the components directly (see rc paywalls
---help for the recipe).
+Use the font through rc paywalls edit: name the key explicitly in the prompt
+and say which text to apply it to ("set headings to font_name RCFM:…"). The
+editor does not list custom fonts, so always name the key.
 
 Preview screenshots may not render CLI-referenced custom fonts; verify in the
 dashboard builder URL.`,

--- a/internal/cli/fonts.go
+++ b/internal/cli/fonts.go
@@ -49,7 +49,7 @@ func loadFont(path string) (api.FontCreate, error) {
 func newFontsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fonts",
-		Short: "Manage project fonts",
+		Short: "Manage custom fonts for paywalls",
 	}
 	cmd.AddCommand(newFontsUploadCmd(), newFontsListCmd())
 	return cmd
@@ -107,7 +107,20 @@ func newFontsUploadCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "upload <file>",
 		Short: "Upload a font to the project for use in paywalls",
-		Args:  cobra.ExactArgs(1),
+		Long: `Uploads a ttf/otf font file to the project.
+
+The response's font_key (RCFM:…) is the reference. The server registers the
+font project-wide automatically — no further setup call is needed.
+
+A paywall uses the font when a text component's font_name is set to the
+font_key. Two routes: name the key explicitly in an rc paywalls edit prompt
+("set headings to font_name RCFM:…") — the editor does not list custom fonts,
+so always name the key — or PATCH the components directly (see rc paywalls
+--help for the recipe).
+
+Preview screenshots may not render CLI-referenced custom fonts; verify in the
+dashboard builder URL.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)

--- a/internal/cli/media_assets.go
+++ b/internal/cli/media_assets.go
@@ -114,23 +114,11 @@ func newMediaAssetsUploadCmd() *cobra.Command {
 		Short: "Upload an image to the project Media Gallery",
 		Long: `Uploads an image to the project Media Gallery for use in paywalls.
 
-Compose the reference URL as asset_base_url + "/" + object_name from the
-upload response. Per-rendition URLs come from formats.<name>.object_name.
-Reuse the original URL for any rendition missing from the response.
+The reference URL is asset_base_url + "/" + object_name from the upload
+response; the command prints it after the upload.
 
-An image component's source needs exactly these fields — all required, no
-extra keys, https URLs from the upload response only:
-
-  "source": {"light": {"width", "height", "original", "webp",
-             "webp_low_res", "heic", "heic_low_res"}}
-
-A background image takes this form:
-
-  {"type": "image", "value": {"light": {…}}, "fit_mode": "fill"}
-
-Two routes to place it: paste the URL into an rc paywalls edit prompt for the
-editor to place it, or PATCH the components directly (see rc paywalls --help
-for the recipe).`,
+Place it through rc paywalls edit: paste the URL into the prompt and say
+where it goes ("use https://assets.pawwalls.com/… as the hero image").`,
 		Example: `  rc media-assets upload ./hero.png
   rc media-assets upload ./hero.png --json`,
 		Args: cobra.ExactArgs(1),

--- a/internal/cli/media_assets.go
+++ b/internal/cli/media_assets.go
@@ -53,7 +53,7 @@ func loadMediaAsset(path string) (api.CreateMediaAssetJSONBody, error) {
 func newMediaAssetsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "media-assets",
-		Short: "Manage project media assets",
+		Short: "Manage project images for paywalls (Media Gallery)",
 	}
 	cmd.AddCommand(newMediaAssetsUploadCmd(), newMediaAssetsListCmd())
 	return cmd
@@ -119,7 +119,26 @@ func newMediaAssetsUploadCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "upload <file>",
 		Short: "Upload an image to the project Media Gallery",
-		Args:  cobra.ExactArgs(1),
+		Long: `Uploads an image to the project Media Gallery for use in paywalls.
+
+Compose the reference URL as asset_base_url + "/" + object_name from the
+upload response. Per-rendition URLs come from formats.<name>.object_name.
+Reuse the original URL for any rendition missing from the response.
+
+An image component's source needs exactly these fields — all required, no
+extra keys, https URLs from the upload response only:
+
+  "source": {"light": {"width", "height", "original", "webp",
+             "webp_low_res", "heic", "heic_low_res"}}
+
+A background image takes this form:
+
+  {"type": "image", "value": {"light": {…}}, "fit_mode": "fill"}
+
+Two routes to place it: paste the URL into an rc paywalls edit prompt for the
+editor to place it, or PATCH the components directly (see rc paywalls --help
+for the recipe).`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)

--- a/internal/cli/media_assets.go
+++ b/internal/cli/media_assets.go
@@ -114,11 +114,9 @@ func newMediaAssetsUploadCmd() *cobra.Command {
 		Short: "Upload an image to the project Media Gallery",
 		Long: `Uploads an image to the project Media Gallery for use in paywalls.
 
-The reference URL is asset_base_url + "/" + object_name from the upload
-response; the command prints it after the upload.
-
-Place it through rc paywalls edit: paste the URL into the prompt and say
-where it goes ("use https://assets.pawwalls.com/… as the hero image").`,
+The upload response includes the asset URL. Use that URL to place the image
+in a paywall through rc paywalls edit: paste it into the prompt and say where
+it goes ("use https://assets.pawwalls.com/… as the hero image").`,
 		Example: `  rc media-assets upload ./hero.png
   rc media-assets upload ./hero.png --json`,
 		Args: cobra.ExactArgs(1),

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -36,9 +36,10 @@ huge instruction dumps. Give short general direction. Be specific only about
 concrete brand facts (colors, fonts, images, tone). Leave layout and design
 decisions to the editor. When editing, make one theme of change per turn.
 
-Never accept the first result. Every completed turn writes a preview
-screenshot; judge it against the direction. Expect 2-4 edit turns before the
-design is right. Undo a bad turn with rc paywalls rewind.
+Iterating is the normal workflow: expect several edit turns until the result
+is acceptable, not a perfect first try. Every completed turn writes a preview
+screenshot; judge it against the direction and keep editing until it matches.
+Undo a bad turn with rc paywalls rewind.
 
 Custom assets: upload the app's real fonts with rc fonts upload and real
 images (logo, hero) with rc media-assets upload BEFORE designing, then

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -49,7 +49,7 @@ only.
 To wire uploaded assets without an editor turn, PATCH the draft directly:
 
   rc api GET "/projects/<p>/paywalls/<id>?expand=components"  # read draft + revision
-  # edit components_config: set image source / font_name
+  # edit components_config: set image source
   rc api PATCH /projects/<p>/paywalls/<id> --body @body.json  # revision, components_config,
                                                               # components_localizations, default_locale
 

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -46,17 +46,6 @@ reference them — see those commands' help for the exact wiring. The editor
 cannot ingest local files itself; --image attachments are visual references
 only.
 
-To wire uploaded assets without an editor turn, PATCH the draft directly:
-
-  rc api GET "/projects/<p>/paywalls/<id>?expand=components"  # read draft + revision
-  # edit components_config: set image source
-  rc api PATCH /projects/<p>/paywalls/<id> --body @body.json  # revision, components_config,
-                                                              # components_localizations, default_locale
-
-A direct PATCH bumps the draft revision, so any open --session diverges and
-the next edit starts fresh. Wire assets before or between AI sessions, or via
-an edit prompt.
-
 Publishing is customer-facing: review the preview screenshot and the builder
 URL, get the user's approval, then rc paywalls publish.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -18,6 +18,47 @@ func newPaywallsCmd() *cobra.Command {
 		Use:     "paywalls",
 		Aliases: []string{"paywall"},
 		Short:   "Create and inspect paywalls",
+		Long: `Design, iterate on, and publish paywalls.
+
+The design workflow: generate a draft with rc paywalls generate, look at the
+preview screenshot it writes, iterate with rc paywalls edit on the SAME
+--session, and run rc paywalls publish only after the user reviewed and
+approved the design.
+
+Ground the design in the app's brand before generating. Read the app's theme
+and brand files first. Collect exact hex colors, font choices, tone words,
+and real feature names. Pass brand docs via --attachment DESIGN.md, app
+screenshots via --image (max 3), and audience or product context via
+--context.
+
+Do not over-prompt. The Paywall AI editor produces worse designs from huge
+instruction dumps. Give short general direction. Be specific only about
+concrete brand facts (colors, fonts, images, tone). Leave layout and design
+decisions to the editor. When editing, make one theme of change per turn.
+
+Never accept the first result. Every completed turn writes a preview
+screenshot; judge it against the direction. Expect 2-4 edit turns before the
+design is right. Undo a bad turn with rc paywalls rewind.
+
+Custom assets: upload the app's real fonts with rc fonts upload and real
+images (logo, hero) with rc media-assets upload BEFORE designing, then
+reference them — see those commands' help for the exact wiring. The editor
+cannot ingest local files itself; --image attachments are visual references
+only.
+
+To wire uploaded assets without an editor turn, PATCH the draft directly:
+
+  rc api GET "/projects/<p>/paywalls/<id>?expand=components"  # read draft + revision
+  # edit components_config: set image source / font_name
+  rc api PATCH /projects/<p>/paywalls/<id> --body @body.json  # revision, components_config,
+                                                              # components_localizations, default_locale
+
+A direct PATCH bumps the draft revision, so any open --session diverges and
+the next edit starts fresh. Wire assets before or between AI sessions, or via
+an edit prompt.
+
+Publishing is customer-facing: review the preview screenshot and the builder
+URL, get the user's approval, then rc paywalls publish.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			if !guidedMode() || rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
@@ -111,7 +152,8 @@ func newPaywallsPublishCmd() *cobra.Command {
 		Short: "Publish the current paywall draft",
 		Long: `Publishes the current draft and makes its components available to RevenueCat SDKs.
 
-This changes the customer-facing paywall. Review the draft before publishing.
+This changes what customers see. Review the preview screenshot and the
+dashboard builder URL, and get the user's approval before publishing.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
 		Example: `  rc paywalls publish pw_abc
@@ -229,7 +271,11 @@ func newPaywallsShowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show [id]",
 		Short: "Show a paywall",
-		Args:  cobra.MaximumNArgs(1),
+		Long: `Prints paywall metadata: offering, timestamps, publish state.
+
+For design work, look at the session preview screenshot and the dashboard
+builder URL instead — show returns metadata, not visuals.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -31,8 +31,8 @@ and real feature names. Pass brand docs via --attachment DESIGN.md, app
 screenshots via --image (max 3), and audience or product context via
 --context.
 
-Do not over-prompt. The Paywall AI editor produces worse designs from huge
-instruction dumps. Give short general direction. Be specific only about
+Do not over-prompt. rc paywalls generate and edit produce worse designs from
+huge instruction dumps. Give short general direction. Be specific only about
 concrete brand facts (colors, fonts, images, tone). Leave layout and design
 decisions to the editor. When editing, make one theme of change per turn.
 

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -23,18 +23,7 @@ func newPaywallsCmd() *cobra.Command {
 The design workflow: generate a draft with rc paywalls generate, look at the
 preview screenshot it writes, iterate with rc paywalls edit on the SAME
 --session, and run rc paywalls publish only after the user reviewed and
-approved the design.
-
-Ground the design in the app's brand before generating. Read the app's theme
-and brand files first. Collect exact hex colors, font choices, tone words,
-and real feature names. Pass brand docs via --attachment DESIGN.md, app
-screenshots via --image (max 3), and audience or product context via
---context.
-
-Do not over-prompt. rc paywalls generate and edit produce worse designs from
-huge instruction dumps. Give short general direction. Be specific only about
-concrete brand facts (colors, fonts, images, tone). Leave layout and design
-decisions to the editor. When editing, make one theme of change per turn.
+approved the design. See generate's and edit's help for how to prompt well.
 
 Iterating is the normal workflow: expect several edit turns until the result
 is acceptable, not a perfect first try. Every completed turn writes a preview
@@ -43,9 +32,7 @@ Undo a bad turn with rc paywalls rewind.
 
 Custom assets: upload the app's real fonts with rc fonts upload and real
 images (logo, hero) with rc media-assets upload BEFORE designing, then
-reference them — see those commands' help for the exact wiring. The editor
-cannot ingest local files itself; --image attachments are visual references
-only.
+reference them in prompts — see those commands' help for the exact wiring.
 
 Publishing is customer-facing: review the preview screenshot and the builder
 URL, get the user's approval, then rc paywalls publish.`,

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -136,7 +136,9 @@ turns until the design is right. The draft stays unpublished; review it and
 run rc paywalls publish.
 
 Do not generate blind: read the app's theme and brand files and collect app
-screenshots before the first turn. Keep the prompt SHORT — a few sentences of
+screenshots before the first turn. If the app ships custom fonts (.ttf/.otf
+in the codebase), upload them with rc fonts upload first and name the
+returned font_key in prompts. Keep the prompt SHORT — a few sentences of
 general direction plus concrete brand facts (exact hex colors, font names,
 tone words, real feature names). Do not write huge instruction dumps or
 dictate the full layout; long prompts make the editor produce worse designs —
@@ -262,6 +264,9 @@ Using it well:
   - Pass design references: --attachment DESIGN.md folds text style guides
     into the direction; --attachment screenshot.png (or --image) attaches
     visually, up to 3 images total.
+  - Use the app's real fonts: upload .ttf/.otf files from the codebase with
+    rc fonts upload (rc fonts list shows existing ones), then name the
+    font_key in the prompt and say which text to apply it to.
   - Keep the SAME --session file across turns — it is the conversation
     memory. A lost session file starts the design conversation over.
   - The Paywall AI editor may reply with a clarifying question instead of a design (it

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -288,8 +288,9 @@ Using it well:
     with another edit turn on the same session.
   - Each completed turn writes a preview screenshot next to the session file
     (and a dark-mode one when the design has dark mode); its path is shown in
-    the output. Judge it against the direction before the next turn; name
-    what is wrong in the next prompt instead of repeating the old one.
+    the output. Look at it after every turn and judge it against the
+    direction; in the next prompt, describe what is still wrong rather than
+    resending the previous prompt.
   - Turns take one to several minutes and stream progress; run with an
     extended timeout (--timeout) or in the background rather than polling.
   - Undo the last turn:  rc paywalls rewind --session <file>`,

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -133,9 +133,18 @@ edit turn. Each completed turn also writes a preview screenshot next to the
 session file (plus a dark-mode one when the design has dark mode); its path is
 shown in the output — look at it after every turn and keep iterating with edit
 turns until the design is right. The draft stays unpublished; review it and
-run rc paywalls publish.`,
+run rc paywalls publish.
+
+Do not generate blind: read the app's theme and brand files and collect app
+screenshots before the first turn. Keep the prompt SHORT — a few sentences of
+general direction plus concrete brand facts (exact hex colors, font names,
+tone words, real feature names). Do not write huge instruction dumps or
+dictate the full layout; long prompts make the editor produce worse designs —
+leave design decisions to it. Put reference material in flags, not prose:
+brand docs via --attachment, screenshots via --image, audience via --context.`,
 		Example: `  rc paywalls generate
   rc paywalls generate --name "Summer sale" --prompt "A calm annual-first paywall"
+  rc paywalls generate --prompt "Warm and minimal, annual-first. Background #0E1B2A, headings in Sora." --attachment DESIGN.md --image home.png
   rc paywalls generate --offering-id ofrng_default --prompt "Match our brand" --image brand.png --json --no-input`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -241,11 +250,15 @@ completed turn saves the design back onto the RevenueCat draft
 
 Using it well:
 
-  - Write a SPECIFIC prompt: exact hex colors, font vibe, tone words, real
-    feature names, and what to avoid. Read the app's theme files and the
-    session JSON for grounding first — but only ever CHANGE the design
-    through this command; hand-editing the session file gets clobbered by
-    the next turn or fails the revision guard.
+  - Keep the prompt SHORT and specific about brand facts: exact hex colors,
+    font names, tone words, real feature names, and what to avoid. Do not
+    dictate the full layout — long instruction dumps make the editor produce
+    worse designs; leave design decisions to it.
+  - Make ONE theme of change per turn (layout OR color OR copy), so each
+    screenshot is judgeable.
+  - Read the app's theme files and the session JSON for grounding first — but
+    only ever CHANGE the design through this command; hand-editing the
+    session file gets clobbered by the next turn or fails the revision guard.
   - Pass design references: --attachment DESIGN.md folds text style guides
     into the direction; --attachment screenshot.png (or --image) attaches
     visually, up to 3 images total.
@@ -256,8 +269,8 @@ Using it well:
     with another edit turn on the same session.
   - Each completed turn writes a preview screenshot next to the session file
     (and a dark-mode one when the design has dark mode); its path is shown in
-    the output. Look at it after every turn: judge the result against the
-    direction, then follow up with more edit turns until it looks right.
+    the output. Judge it against the direction before the next turn; name
+    what is wrong in the next prompt instead of repeating the old one.
   - Turns take one to several minutes and stream progress; run with an
     extended timeout (--timeout) or in the background rather than polling.
   - Undo the last turn:  rc paywalls rewind --session <file>`,
@@ -399,7 +412,12 @@ func newPaywallsRewindCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rewind --session <file>",
 		Short: "Undo the last Paywall AI editor action",
-		Args:  cobra.NoArgs,
+		Long: `Use rewind when the last turn made the design worse: rewind, then re-prompt
+with more specific direction on the same --session.
+
+Only the last editor action is undone. Preview screenshots from the rewound
+turn are removed.`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			if sessionPath == "" {

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -138,12 +138,17 @@ run rc paywalls publish.
 Do not generate blind: read the app's theme and brand files and collect app
 screenshots before the first turn. If the app ships custom fonts (.ttf/.otf
 in the codebase), upload them with rc fonts upload first and name the
-returned font_key in prompts. Keep the prompt SHORT — a few sentences of
-general direction plus concrete brand facts (exact hex colors, font names,
-tone words, real feature names). Do not write huge instruction dumps or
-dictate the full layout; long prompts make the editor produce worse designs —
-leave design decisions to it. Put reference material in flags, not prose:
-brand docs via --attachment, screenshots via --image, audience via --context.`,
+returned font_key in prompts. When real assets fit the design (the app's
+logo, hero or feature images), upload them with rc media-assets upload first
+and paste the returned URL into the prompt for the editor to place — --image
+attachments are visual references only, never placed in the design.
+
+Keep the prompt SHORT — a few sentences of general direction plus concrete
+brand facts (exact hex colors, font names, tone words, real feature names).
+Do not write huge instruction dumps or dictate the full layout; long prompts
+make the editor produce worse designs — leave design decisions to it. Put
+reference material in flags, not prose: brand docs via --attachment,
+screenshots via --image, audience via --context.`,
 		Example: `  rc paywalls generate
   rc paywalls generate --name "Summer sale" --prompt "A calm annual-first paywall"
   rc paywalls generate --prompt "Warm and minimal, annual-first. Background #0E1B2A, headings in Sora." --attachment DESIGN.md --image home.png
@@ -267,6 +272,10 @@ Using it well:
   - Use the app's real fonts: upload .ttf/.otf files from the codebase with
     rc fonts upload (rc fonts list shows existing ones), then name the
     font_key in the prompt and say which text to apply it to.
+  - Use the app's real images where they fit: upload the logo or hero images
+    with rc media-assets upload (rc media-assets list shows existing ones),
+    then paste the returned URL into the prompt and say where to place it —
+    --image attachments are visual references only, never placed.
   - Keep the SAME --session file across turns — it is the conversation
     memory. A lost session file starts the design conversation over.
   - The Paywall AI editor may reply with a clarifying question instead of a design (it

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -289,8 +289,7 @@ Using it well:
   - Each completed turn writes a preview screenshot next to the session file
     (and a dark-mode one when the design has dark mode); its path is shown in
     the output. Look at it after every turn and judge it against the
-    direction; in the next prompt, describe what is still wrong rather than
-    resending the previous prompt.
+    direction; in the next prompt, describe what is still wrong.
   - Turns take one to several minutes and stream progress; run with an
     extended timeout (--timeout) or in the background rather than polling.
   - Undo the last turn:  rc paywalls rewind --session <file>`,


### PR DESCRIPTION
Adds Long descriptions to paywalls, paywalls generate, paywalls edit, paywalls rewind, paywalls show, fonts upload, and media-assets upload to steer AI agents on workflow, prompting discipline, and asset wiring.

I feel it consistently generates better paywalls.

e.g. prompt
```
create a modern premium-feeling paywall using rc-local CLI for my ReadingJourney app (this codebase), put the paywall in Drago Testing project
```

<img width="556" height="1019" alt="Screenshot 2026-08-11 at 13 15 52" src="https://github.com/user-attachments/assets/19d63380-f822-440b-8d7a-eb566e1ee682" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CLI help strings only; no API, auth, or runtime logic is modified.
> 
> **Overview**
> Expands **cobra help text** (no behavior changes) so AI agents using `rc` get explicit workflow and prompting guidance when they read `--help`.
> 
> The **`paywalls`** group gains a **Long** description covering generate → preview screenshot → **same `--session`** edit loop → user-approved **publish**, plus pre-uploading fonts/images via **`fonts upload`** and **`media-assets upload`**.
> 
> **`paywalls generate`** and **`paywalls edit`** Long text now stress short, brand-fact prompts (not layout dumps), one theme per edit turn, wiring **`font_key`** and gallery URLs, and that **`--image`** is reference-only. **`generate`** adds a richer example with `--attachment` and `--image`.
> 
> **`paywalls publish`**, **`show`**, and **`rewind`** clarify customer-facing risk, that **`show`** is metadata not visuals, and rewind + re-prompt on the same session.
> 
> **`fonts`** / **`media-assets`** Short labels are paywall-oriented; **upload** Long text explains **`RCFM:`** keys, prompt wiring for edit, and dashboard verification for custom fonts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dc426dc5ff5c5b31f08d7ed20bce5c15809372e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->