### PR TITLE
fix(cli): unify --help + home screen grouping (group on the command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ without raw API calls.
 | `--profile <name>` | Config profile (precedence: flag → `$RC_PROFILE` → `rc profiles use` → `"default"`) |
 | `--api-key <key>` | Override profile key (`$RC_API_KEY`) |
 | `--yes, -y` | Skip confirmation prompts |
-| `--all` | Show every command in help, not just the common ones |
+| `--all` | Also show experimental (unreleased) commands in help |
 | `--no-color` | Disable ANSI color (also respects `$NO_COLOR`) |
 | `--format <expr>` | jq expression applied to `--json` output |
 

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -30,7 +30,7 @@ the code when adding/renaming a command.
    `internal/cli/surface.go`):
    - **human** — in the `humanSurface` allowlist, shown in `rc --help`. Keep
      this list tight; it's the first thing a person sees. Currently:
-     `paywalls`, `capital`, `apps`, `auth`, `projects`, `version` (+ `login`).
+     `paywalls`, `apps`, `auth`, `projects`, `version` (+ `login`).
    - **agent-only** (default) — hidden from `rc --help`, but present in
      `rc commands --schemas` and fully runnable. Most resource commands live
      here: humans reach them through guided flows/pickers; agents discover
@@ -95,7 +95,7 @@ names; there's no list endpoint.
 ```
 # Onboarding entry points (the two scoped npx surfaces)
 rc setup                                                 # one-shot agent-driven bootstrap; featured in --help/home/README, runs non-interactively for the prompt
-rc capital setup                                         # RevenueCat Capital = App Store Connect key flow (wraps apps apple setup)
+rc capital setup                                         # EXPERIMENTAL (hidden from --help/schema until Capital ships): App Store Connect key flow (wraps apps apple setup)
 rc                                                       # bare rc -> getting-started help; --all reveals every command
 
 # Auth / meta

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -30,8 +30,9 @@ the code when adding/renaming a command.
    `internal/cli/surface.go`):
    - **default** — shown in `rc --help`, in `rc commands`/`rc schema`, and runnable.
    - **experimental** (`surface: "experimental"` annotation) — hidden from `--help`
-     *and* `rc commands`/`rc schema` until the feature ships; still runnable.
-     `rc --all` / `RC_SURFACE=full` reveals experimental commands in `--help`.
+     until the feature ships (revealed by `rc --all` / `RC_SURFACE=full`), but
+     still present in `rc commands` / `rc schema` marked `"experimental": true`
+     so agents can detect it and choose to skip it. Still runnable.
    Hidden never means disabled — a skill naming an experimental command still works.
 
 ## Verified API truths (from `internal/api/testdata/v2/`)

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -26,20 +26,13 @@ the code when adding/renaming a command.
    purchases for the full SE-debug view.
 8. **Don't invent verbs the API can't fulfill.** Verified against fixtures.
 9. **Surface tiers scope who sees what, not who can run what.** Every command
-   is one of three tiers (set via the `surface` annotation, enforced in
+   is one of two tiers (set via the `surface` annotation, enforced in
    `internal/cli/surface.go`):
-   - **human** — in the `humanSurface` allowlist, shown in `rc --help`. Keep
-     this list tight; it's the first thing a person sees. Currently:
-     `paywalls`, `apps`, `auth`, `projects`, `version` (+ `login`).
-   - **agent-only** (default) — hidden from `rc --help`, but present in
-     `rc commands --schemas` and fully runnable. Most resource commands live
-     here: humans reach them through guided flows/pickers; agents discover
-     them through the schema channel.
-   - **experimental** (`surface: "experimental"` annotation) — hidden from `--help` *and*
-     schema, still runnable. For under-DX-tested commands. Promote to a real
-     tier once tested.
-   `rc --all` / `RC_SURFACE=full` reveals everything to humans. Hidden never
-   means disabled — skills naming an agent-only command keep working.
+   - **default** — shown in `rc --help`, in `rc commands`/`rc schema`, and runnable.
+   - **experimental** (`surface: "experimental"` annotation) — hidden from `--help`
+     *and* `rc commands`/`rc schema` until the feature ships; still runnable.
+     `rc --all` / `RC_SURFACE=full` reveals experimental commands in `--help`.
+   Hidden never means disabled — a skill naming an experimental command still works.
 
 ## Verified API truths (from `internal/api/testdata/v2/`)
 
@@ -96,7 +89,7 @@ names; there's no list endpoint.
 # Onboarding entry points (the two scoped npx surfaces)
 rc setup                                                 # one-shot agent-driven bootstrap; featured in --help/home/README, runs non-interactively for the prompt
 rc capital setup                                         # EXPERIMENTAL (hidden from --help/schema until Capital ships): App Store Connect key flow (wraps apps apple setup)
-rc                                                       # bare rc -> getting-started help; --all reveals every command
+rc                                                       # bare rc -> getting-started help; --all reveals experimental commands
 
 # Auth / meta
 rc auth login                                            # browser OAuth or API key; offers MCP-token import on npx runs; rc login is a hidden alias

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -89,7 +89,7 @@ names; there's no list endpoint.
 ```
 # Onboarding entry points (the two scoped npx surfaces)
 rc setup                                                 # one-shot agent-driven bootstrap; featured in --help/home/README, runs non-interactively for the prompt
-rc capital setup                                         # EXPERIMENTAL (hidden from --help/schema until Capital ships): App Store Connect key flow (wraps apps apple setup)
+rc capital setup                                         # EXPERIMENTAL (hidden from --help until Capital ships): App Store Connect key flow (wraps apps apple setup)
 rc                                                       # bare rc -> getting-started help; --all reveals experimental commands
 
 # Auth / meta

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -35,7 +35,7 @@ the code when adding/renaming a command.
      `rc commands --schemas` and fully runnable. Most resource commands live
      here: humans reach them through guided flows/pickers; agents discover
      them through the schema channel.
-   - **punted** (`surface: "punted"` annotation) — hidden from `--help` *and*
+   - **experimental** (`surface: "experimental"` annotation) — hidden from `--help` *and*
      schema, still runnable. For under-DX-tested commands. Promote to a real
      tier once tested.
    `rc --all` / `RC_SURFACE=full` reveals everything to humans. Hidden never

--- a/internal/cli/capital.go
+++ b/internal/cli/capital.go
@@ -22,6 +22,7 @@ Your Apple credentials go from your machine directly to Apple and are never
 saved or sent to RevenueCat.`,
 		Example: `  rc capital setup
   rc capital setup appl_1a2b3c`,
+		Annotations: map[string]string{annotationSurface: surfaceExperimental},
 	}
 	// Reuse the Apple credential workflow verbatim: the "setup" subcommand is
 	// the same guided flow shipped as `rc apps apple setup`.

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -52,29 +52,21 @@ var commandGroups = []*cobra.Group{
 	{ID: "advanced", Title: "Advanced"},
 }
 
-// commandGroupByName maps each top-level command to its group. Hidden aliases
-// are included so no empty "Additional Commands" section renders.
-var commandGroupByName = map[string]string{
-	"auth": "start", "login": "start", "whoami": "start", "projects": "start",
-	"profiles": "start", "browse": "start", "open": "start", "setup": "start",
-	"paywalls": "design", "fonts": "design", "media-assets": "design",
-	"offerings": "catalog", "products": "catalog", "packages": "catalog", "entitlements": "catalog",
-	"customer": "revenue", "subscriptions": "revenue", "purchases": "revenue",
-	"invoices": "revenue", "charts": "revenue", "metrics": "revenue",
-	"apps": "integrations", "capital": "integrations", "webhooks": "integrations",
-	"rico": "ai", "skills": "ai",
-	"api": "advanced", "audit": "advanced", "schema": "advanced",
-	"commands": "advanced", "version": "advanced",
-}
-
-// applyCommandGroups registers the groups and assigns every command to one.
-func applyCommandGroups(root *cobra.Command) {
-	root.AddGroup(commandGroups...)
-	for _, c := range root.Commands() {
-		if g, ok := commandGroupByName[c.Name()]; ok {
-			c.GroupID = g
+// groupTitle returns a group's display title from commandGroups, the single
+// source of truth shared by `rc --help` and the home screen.
+func groupTitle(id string) string {
+	for _, g := range commandGroups {
+		if g.ID == id {
+			return g.Title
 		}
 	}
+	return id
+}
+
+// applyCommandGroups registers the help groups. Each command's GroupID is set
+// where it's added to root (see NewRootCmd), so grouping lives on the command.
+func applyCommandGroups(root *cobra.Command) {
+	root.AddGroup(commandGroups...)
 	root.SetHelpCommandGroupID("advanced")
 	root.SetCompletionCommandGroupID("advanced")
 }

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -43,12 +43,12 @@ const rcUsageTemplate = `{{rcHead "Usage:"}}{{if .Runnable}}
 
 // commandGroups define the sections of `rc --help`, in display order.
 var commandGroups = []*cobra.Group{
-	{ID: "start", Title: "Getting started"},
-	{ID: "design", Title: "Paywalls & design"},
-	{ID: "catalog", Title: "Catalog"},
-	{ID: "revenue", Title: "Customers & revenue"},
-	{ID: "integrations", Title: "Apps & integrations"},
-	{ID: "ai", Title: "AI & automation"},
+	{ID: "start", Title: "Get started"},
+	{ID: "design", Title: "Design paywalls"},
+	{ID: "catalog", Title: "Manage your catalog"},
+	{ID: "revenue", Title: "Understand customers & revenue"},
+	{ID: "integrations", Title: "Connect apps & integrations"},
+	{ID: "ai", Title: "Set up & automate"},
 	{ID: "advanced", Title: "Advanced"},
 }
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -46,9 +46,9 @@ var commandGroups = []*cobra.Group{
 	{ID: "start", Title: "Get started"},
 	{ID: "design", Title: "Design paywalls"},
 	{ID: "catalog", Title: "Manage your catalog"},
-	{ID: "revenue", Title: "Understand customers & revenue"},
+	{ID: "revenue", Title: "Manage customers & revenue"},
 	{ID: "integrations", Title: "Connect apps & integrations"},
-	{ID: "ai", Title: "Set up & automate"},
+	{ID: "ai", Title: "Automate with AI"},
 	{ID: "advanced", Title: "Advanced"},
 }
 

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -57,7 +57,7 @@ func TestRootHelp_KeepsFullGlobalFlagDescriptions(t *testing.T) {
 		}
 	}
 	// Root commands render in labeled groups, not one flat "Available Commands" list.
-	for _, want := range []string{"Get started", "Understand customers & revenue", "Advanced"} {
+	for _, want := range []string{"Get started", "Manage customers & revenue", "Advanced"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("root help missing command group %q:\n%s", want, out)
 		}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -57,7 +57,7 @@ func TestRootHelp_KeepsFullGlobalFlagDescriptions(t *testing.T) {
 		}
 	}
 	// Root commands render in labeled groups, not one flat "Available Commands" list.
-	for _, want := range []string{"Getting started", "Customers & revenue", "Advanced"} {
+	for _, want := range []string{"Get started", "Understand customers & revenue", "Advanced"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("root help missing command group %q:\n%s", want, out)
 		}

--- a/internal/cli/home.go
+++ b/internal/cli/home.go
@@ -16,6 +16,9 @@ type homeGroup struct {
 // homeMap is the curated command catalog shown once authenticated. Groups key
 // into commandGroups so titles and order match `rc --help`.
 var homeMap = []homeGroup{
+	{"start", [][2]string{
+		{"rc setup", "set up RevenueCat for a new app"},
+	}},
 	{"design", [][2]string{
 		{"rc paywalls generate", "design a paywall with AI"},
 		{"rc paywalls edit", "refine an existing paywall"},
@@ -34,7 +37,6 @@ var homeMap = []homeGroup{
 		{"rc apps", "connect App Store & Google Play"},
 	}},
 	{"ai", [][2]string{
-		{"rc setup", "set up RevenueCat for a new app"},
 		{"rc skills install", "AI workflows for coding agents"},
 		{"rc rico", "ask RevenueCat's AI ✨"},
 	}},

--- a/internal/cli/home.go
+++ b/internal/cli/home.go
@@ -9,25 +9,32 @@ import (
 )
 
 type homeGroup struct {
-	title string
-	rows  [][2]string // {command, description}
+	groupID string      // key into commandGroups; title comes from there
+	rows    [][2]string // {command, description}
 }
 
-// homeMap is the curated command catalog shown once authenticated.
+// homeMap is the curated command catalog shown once authenticated. Groups key
+// into commandGroups so titles and order match `rc --help`.
 var homeMap = []homeGroup{
-	{"Build", [][2]string{
+	{"design", [][2]string{
+		{"rc paywalls generate", "design a paywall with AI"},
+		{"rc paywalls edit", "refine an existing paywall"},
+	}},
+	{"catalog", [][2]string{
 		{"rc offerings list", "offerings & their packages"},
 		{"rc products list", "products across your stores"},
 		{"rc entitlements list", "entitlements & their products"},
 	}},
-	{"Inspect", [][2]string{
+	{"revenue", [][2]string{
 		{"rc customer show <id>", "a full customer view"},
 		{"rc charts show mrr", "MRR, actives, conversion"},
 		{"rc metrics", "project overview at a glance"},
 	}},
-	{"Automate & set up", [][2]string{
-		{"rc setup", "set up RevenueCat for a new app"},
+	{"integrations", [][2]string{
 		{"rc apps", "connect App Store & Google Play"},
+	}},
+	{"ai", [][2]string{
+		{"rc setup", "set up RevenueCat for a new app"},
 		{"rc skills install", "AI workflows for coding agents"},
 		{"rc rico", "ask RevenueCat's AI ✨"},
 	}},
@@ -57,13 +64,6 @@ func writeHomeScreen(w io.Writer, rt *Runtime) {
 			b.WriteString("\n")
 		}
 
-		b.WriteString(paint(output.ToneAccent, "✨ Paywalls — design with AI") + "\n")
-		b.WriteString(homeRows(paint, [][2]string{
-			{"rc paywalls generate", "start from a prompt"},
-			{"rc paywalls edit", "refine an existing paywall"},
-		}, 0))
-		b.WriteString("\n")
-
 		mapWidth := 0
 		for _, g := range homeMap {
 			for _, r := range g.rows {
@@ -76,7 +76,7 @@ func writeHomeScreen(w io.Writer, rt *Runtime) {
 			if i > 0 {
 				b.WriteString("\n")
 			}
-			b.WriteString(label(g.title) + "\n")
+			b.WriteString(label(groupTitle(g.groupID)) + "\n")
 			b.WriteString(homeRows(paint, g.rows, mapWidth))
 		}
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -127,39 +127,49 @@ Agent-friendly entrypoints:
 		return nil
 	}
 
-	root.AddCommand(
-		newSetupCmd(),
-		newCapitalCmd(),
-		newOpenCmd(),
-		newAuthCmd(),
-		loginAlias,
-		whoamiAlias,
-		newProfilesCmd(),
-		newProjectsCmd(),
-		newBrowseCmd(),
-		newCustomersCmd(),
-		newEntitlementsCmd(),
-		newOfferingsCmd(),
-		newProductsCmd(),
-		newSubscriptionsCmd(),
-		newPurchasesCmd(),
-		newInvoicesCmd(),
-		newWebhooksCmd(),
-		newPaywallsCmd(),
-		newMediaAssetsCmd(),
-		newFontsCmd(),
-		newRicoCmd(),
-		newChartsCmd(),
-		newMetricsCmd(),
-		newAuditCmd(),
-		newAppsCmd(),
-		newPackagesCmd(),
-		newAPICmd(),
-		newSkillsCmd(),
-		newSchemaCmd(root),
-		newCommandsCmd(root),
-		newVersionCmd(),
-	)
+	// Each command declares its help group here; GroupID lives on the command
+	// (not a separate lookup), so adding a command means grouping it in one place.
+	// Group IDs must exist in commandGroups (enforced by TestEveryCommandHasARegisteredGroup).
+	grouped := []struct {
+		cmd   *cobra.Command
+		group string
+	}{
+		{newSetupCmd(), "start"},
+		{newCapitalCmd(), "integrations"},
+		{newOpenCmd(), "start"},
+		{newAuthCmd(), "start"},
+		{loginAlias, "start"},
+		{whoamiAlias, "start"},
+		{newProfilesCmd(), "start"},
+		{newProjectsCmd(), "start"},
+		{newBrowseCmd(), "start"},
+		{newCustomersCmd(), "revenue"},
+		{newEntitlementsCmd(), "catalog"},
+		{newOfferingsCmd(), "catalog"},
+		{newProductsCmd(), "catalog"},
+		{newSubscriptionsCmd(), "revenue"},
+		{newPurchasesCmd(), "revenue"},
+		{newInvoicesCmd(), "revenue"},
+		{newWebhooksCmd(), "integrations"},
+		{newPaywallsCmd(), "design"},
+		{newMediaAssetsCmd(), "design"},
+		{newFontsCmd(), "design"},
+		{newRicoCmd(), "ai"},
+		{newChartsCmd(), "revenue"},
+		{newMetricsCmd(), "revenue"},
+		{newAuditCmd(), "advanced"},
+		{newAppsCmd(), "integrations"},
+		{newPackagesCmd(), "catalog"},
+		{newAPICmd(), "advanced"},
+		{newSkillsCmd(), "ai"},
+		{newSchemaCmd(root), "advanced"},
+		{newCommandsCmd(root), "advanced"},
+		{newVersionCmd(), "advanced"},
+	}
+	for _, g := range grouped {
+		g.cmd.GroupID = g.group
+		root.AddCommand(g.cmd)
+	}
 
 	root.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		return usageError{suggestFlag(cmd, err)}

--- a/internal/cli/root_gettingstarted_test.go
+++ b/internal/cli/root_gettingstarted_test.go
@@ -53,7 +53,7 @@ func TestBareRC_LoggedInNoProject_NudgesProject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"logged in", "no project selected", "Pick a project", "rc projects use", "Build", "rc paywalls generate"} {
+	for _, want := range []string{"logged in", "no project selected", "Pick a project", "rc projects use", "Paywalls & design", "rc paywalls generate"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("logged-in/no-project home missing %q:\n%s", want, out)
 		}
@@ -71,8 +71,8 @@ func TestBareRC_LoggedInWithProject_ShowsCommandMap(t *testing.T) {
 	for _, want := range []string{
 		"project proj_abc",
 		"app.revenuecat.com/projects/abc", // dashboard deep-link (prefix stripped)
-		"Build", "Inspect", "Automate & set up",
-		"✨ Paywalls — design with AI", "rc paywalls generate", "rc paywalls edit",
+		"Paywalls & design", "Catalog", "Customers & revenue", "Apps & integrations", "AI & automation",
+		"rc paywalls generate", "rc paywalls edit",
 		"rc customer show <id>",
 	} {
 		if !strings.Contains(out, want) {

--- a/internal/cli/root_gettingstarted_test.go
+++ b/internal/cli/root_gettingstarted_test.go
@@ -53,7 +53,7 @@ func TestBareRC_LoggedInNoProject_NudgesProject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"logged in", "no project selected", "Pick a project", "rc projects use", "Paywalls & design", "rc paywalls generate"} {
+	for _, want := range []string{"logged in", "no project selected", "Pick a project", "rc projects use", "Design paywalls", "rc paywalls generate"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("logged-in/no-project home missing %q:\n%s", want, out)
 		}
@@ -71,7 +71,7 @@ func TestBareRC_LoggedInWithProject_ShowsCommandMap(t *testing.T) {
 	for _, want := range []string{
 		"project proj_abc",
 		"app.revenuecat.com/projects/abc", // dashboard deep-link (prefix stripped)
-		"Paywalls & design", "Catalog", "Customers & revenue", "Apps & integrations", "AI & automation",
+		"Design paywalls", "Manage your catalog", "Understand customers & revenue", "Connect apps & integrations", "Set up & automate",
 		"rc paywalls generate", "rc paywalls edit",
 		"rc customer show <id>",
 	} {

--- a/internal/cli/root_gettingstarted_test.go
+++ b/internal/cli/root_gettingstarted_test.go
@@ -71,8 +71,8 @@ func TestBareRC_LoggedInWithProject_ShowsCommandMap(t *testing.T) {
 	for _, want := range []string{
 		"project proj_abc",
 		"app.revenuecat.com/projects/abc", // dashboard deep-link (prefix stripped)
-		"Design paywalls", "Manage your catalog", "Understand customers & revenue", "Connect apps & integrations", "Set up & automate",
-		"rc paywalls generate", "rc paywalls edit",
+		"Get started", "Design paywalls", "Manage your catalog", "Manage customers & revenue", "Connect apps & integrations", "Automate with AI",
+		"rc setup", "rc paywalls generate", "rc paywalls edit",
 		"rc customer show <id>",
 	} {
 		if !strings.Contains(out, want) {

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -66,7 +66,7 @@ func commandTreeWithSchemas(c *cobra.Command) map[string]any {
 	tree := commandSchema(c)
 	subs := []map[string]any{}
 	for _, sc := range c.Commands() {
-		if puntedFromSchema(sc) {
+		if experimentalFromSchema(sc) {
 			continue
 		}
 		subs = append(subs, commandTreeWithSchemas(sc))
@@ -108,7 +108,7 @@ func commandSchema(c *cobra.Command) map[string]any {
 
 	subs := []map[string]any{}
 	for _, sc := range c.Commands() {
-		if puntedFromSchema(sc) {
+		if experimentalFromSchema(sc) {
 			continue
 		}
 		subs = append(subs, map[string]any{
@@ -158,7 +158,7 @@ func inferCapabilities(c *cobra.Command) []string {
 		acc.add(canonicalVerb(c.Name()))
 	}
 	for _, sc := range c.Commands() {
-		if puntedFromSchema(sc) {
+		if experimentalFromSchema(sc) {
 			continue
 		}
 		collectCapabilities(sc, []string{sc.Name()}, acc)
@@ -171,7 +171,7 @@ func collectCapabilities(c *cobra.Command, path []string, acc *capAccumulator) {
 		acc.add(capLabel(path))
 	}
 	for _, sc := range c.Commands() {
-		if puntedFromSchema(sc) {
+		if experimentalFromSchema(sc) {
 			continue
 		}
 		collectCapabilities(sc, append(append([]string{}, path...), sc.Name()), acc)
@@ -251,7 +251,7 @@ func commandPath(c *cobra.Command) string {
 func commandTree(c *cobra.Command) map[string]any {
 	subs := []map[string]any{}
 	for _, sc := range c.Commands() {
-		if puntedFromSchema(sc) {
+		if experimentalFromSchema(sc) {
 			continue
 		}
 		subs = append(subs, commandTree(sc))

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -122,6 +122,7 @@ func commandSchema(c *cobra.Command) map[string]any {
 	schema := map[string]any{
 		"name":         c.Name(),
 		"path":         commandPath(c),
+		"group":        c.GroupID,
 		"aliases":      c.Aliases,
 		"use":          c.Use,
 		"short":        c.Short,
@@ -258,6 +259,7 @@ func commandTree(c *cobra.Command) map[string]any {
 	tree := map[string]any{
 		"name":         c.Name(),
 		"path":         commandPath(c),
+		"group":        c.GroupID,
 		"short":        c.Short,
 		"aliases":      c.Aliases,
 		"runnable":     c.Runnable(),

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -66,9 +66,6 @@ func commandTreeWithSchemas(c *cobra.Command) map[string]any {
 	tree := commandSchema(c)
 	subs := []map[string]any{}
 	for _, sc := range c.Commands() {
-		if experimentalFromSchema(sc) {
-			continue
-		}
 		subs = append(subs, commandTreeWithSchemas(sc))
 	}
 	tree["commands"] = subs
@@ -108,15 +105,16 @@ func commandSchema(c *cobra.Command) map[string]any {
 
 	subs := []map[string]any{}
 	for _, sc := range c.Commands() {
-		if experimentalFromSchema(sc) {
-			continue
-		}
-		subs = append(subs, map[string]any{
+		sub := map[string]any{
 			"name":     sc.Name(),
 			"short":    sc.Short,
 			"aliases":  sc.Aliases,
 			"runnable": sc.Runnable(),
-		})
+		}
+		if experimentalFromSchema(sc) {
+			sub["experimental"] = true
+		}
+		subs = append(subs, sub)
 	}
 
 	schema := map[string]any{
@@ -133,6 +131,9 @@ func commandSchema(c *cobra.Command) map[string]any {
 		"subcommands":  subs,
 		"runnable":     c.Runnable(),
 		"capabilities": inferCapabilities(c),
+	}
+	if experimentalFromSchema(c) {
+		schema["experimental"] = true
 	}
 	addHumanRequirement(schema, c)
 	return schema
@@ -251,9 +252,6 @@ func commandPath(c *cobra.Command) string {
 func commandTree(c *cobra.Command) map[string]any {
 	subs := []map[string]any{}
 	for _, sc := range c.Commands() {
-		if experimentalFromSchema(sc) {
-			continue
-		}
 		subs = append(subs, commandTree(sc))
 	}
 	tree := map[string]any{
@@ -265,6 +263,9 @@ func commandTree(c *cobra.Command) map[string]any {
 		"runnable":     c.Runnable(),
 		"capabilities": inferCapabilities(c),
 		"commands":     subs,
+	}
+	if experimentalFromSchema(c) {
+		tree["experimental"] = true
 	}
 	addHumanRequirement(tree, c)
 	return tree

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -111,7 +111,7 @@ func commandSchema(c *cobra.Command) map[string]any {
 			"aliases":  sc.Aliases,
 			"runnable": sc.Runnable(),
 		}
-		if experimentalFromSchema(sc) {
+		if isExperimental(sc) {
 			sub["experimental"] = true
 		}
 		subs = append(subs, sub)
@@ -132,7 +132,7 @@ func commandSchema(c *cobra.Command) map[string]any {
 		"runnable":     c.Runnable(),
 		"capabilities": inferCapabilities(c),
 	}
-	if experimentalFromSchema(c) {
+	if isExperimental(c) {
 		schema["experimental"] = true
 	}
 	addHumanRequirement(schema, c)
@@ -159,7 +159,7 @@ func inferCapabilities(c *cobra.Command) []string {
 		acc.add(canonicalVerb(c.Name()))
 	}
 	for _, sc := range c.Commands() {
-		if experimentalFromSchema(sc) {
+		if isExperimental(sc) {
 			continue
 		}
 		collectCapabilities(sc, []string{sc.Name()}, acc)
@@ -172,7 +172,7 @@ func collectCapabilities(c *cobra.Command, path []string, acc *capAccumulator) {
 		acc.add(capLabel(path))
 	}
 	for _, sc := range c.Commands() {
-		if experimentalFromSchema(sc) {
+		if isExperimental(sc) {
 			continue
 		}
 		collectCapabilities(sc, append(append([]string{}, path...), sc.Name()), acc)
@@ -264,7 +264,7 @@ func commandTree(c *cobra.Command) map[string]any {
 		"capabilities": inferCapabilities(c),
 		"commands":     subs,
 	}
-	if experimentalFromSchema(c) {
+	if isExperimental(c) {
 		tree["experimental"] = true
 	}
 	addHumanRequirement(tree, c)

--- a/internal/cli/schema_test.go
+++ b/internal/cli/schema_test.go
@@ -95,7 +95,7 @@ func TestInferCapabilities_DriftGuard(t *testing.T) {
 
 	var walk func(c *cobra.Command)
 	walk = func(c *cobra.Command) {
-		if experimentalFromSchema(c) {
+		if isExperimental(c) {
 			return
 		}
 
@@ -106,7 +106,7 @@ func TestInferCapabilities_DriftGuard(t *testing.T) {
 		if len(c.Commands()) > 0 {
 			caps := inferCapabilities(c)
 			for _, sc := range c.Commands() {
-				if experimentalFromSchema(sc) || !sc.Runnable() {
+				if isExperimental(sc) || !sc.Runnable() {
 					continue
 				}
 				want := canonicalVerb(sc.Name())
@@ -126,7 +126,7 @@ func TestInferCapabilities_DriftGuard(t *testing.T) {
 
 func hasRunnableDescendant(c *cobra.Command) bool {
 	for _, sc := range c.Commands() {
-		if experimentalFromSchema(sc) {
+		if isExperimental(sc) {
 			continue
 		}
 		if sc.Runnable() || hasRunnableDescendant(sc) {

--- a/internal/cli/schema_test.go
+++ b/internal/cli/schema_test.go
@@ -95,7 +95,7 @@ func TestInferCapabilities_DriftGuard(t *testing.T) {
 
 	var walk func(c *cobra.Command)
 	walk = func(c *cobra.Command) {
-		if puntedFromSchema(c) {
+		if experimentalFromSchema(c) {
 			return
 		}
 
@@ -106,7 +106,7 @@ func TestInferCapabilities_DriftGuard(t *testing.T) {
 		if len(c.Commands()) > 0 {
 			caps := inferCapabilities(c)
 			for _, sc := range c.Commands() {
-				if puntedFromSchema(sc) || !sc.Runnable() {
+				if experimentalFromSchema(sc) || !sc.Runnable() {
 					continue
 				}
 				want := canonicalVerb(sc.Name())
@@ -126,7 +126,7 @@ func TestInferCapabilities_DriftGuard(t *testing.T) {
 
 func hasRunnableDescendant(c *cobra.Command) bool {
 	for _, sc := range c.Commands() {
-		if puntedFromSchema(sc) {
+		if experimentalFromSchema(sc) {
 			continue
 		}
 		if sc.Runnable() || hasRunnableDescendant(sc) {

--- a/internal/cli/surface.go
+++ b/internal/cli/surface.go
@@ -8,14 +8,15 @@ import (
 )
 
 // Command surface: --help shows the full command set; only the experimental tier
-// (commands not yet DX-tested) is held back, and `rc --all` reveals those too.
-// Back-compat aliases stay hidden via their own Hidden flag — curateSurface
-// never un-hides them.
+// (commands not yet DX-tested, e.g. `capital setup`) is held back, and `rc --all`
+// reveals those too. Back-compat aliases stay hidden via their own Hidden flag —
+// curateSurface never un-hides them.
 //
 // Two annotation tiers via "surface":
 //   - default: shown in --help, commands/schema, and runnable
-//   - experimental: hidden from --help and schema until DX-tested (the one-shot
-//     `setup` orchestrator); `rc --all` shows it in help but never schema
+//   - experimental: hidden from --help until DX-tested, but still present in
+//     commands/schema marked "experimental": true (and left out of inferred
+//     capabilities); `rc --all` reveals it in help
 
 const (
 	annotationSurface   = "surface"
@@ -52,9 +53,8 @@ func curateSurface(root *cobra.Command, all bool) {
 	}
 }
 
-// experimentalFromSchema reports whether a command is hidden even from agent
-// discovery. Only the experimental tier qualifies; agent-only commands are hidden
-// from help but must still appear in commands/schema.
-func experimentalFromSchema(c *cobra.Command) bool {
+// isExperimental reports the experimental tier: hidden from --help, but still
+// shown in commands/schema (tagged) and left out of inferred capabilities.
+func isExperimental(c *cobra.Command) bool {
 	return c.Annotations[annotationSurface] == surfaceExperimental
 }

--- a/internal/cli/surface.go
+++ b/internal/cli/surface.go
@@ -7,19 +7,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Command surface: --help shows the full command set; only the punted tier
+// Command surface: --help shows the full command set; only the experimental tier
 // (commands not yet DX-tested) is held back, and `rc --all` reveals those too.
 // Back-compat aliases stay hidden via their own Hidden flag — curateSurface
 // never un-hides them.
 //
 // Two annotation tiers via "surface":
 //   - default: shown in --help, commands/schema, and runnable
-//   - punted: hidden from --help and schema until DX-tested (the one-shot
+//   - experimental: hidden from --help and schema until DX-tested (the one-shot
 //     `setup` orchestrator); `rc --all` shows it in help but never schema
 
 const (
-	annotationSurface = "surface"
-	surfacePunted     = "punted"
+	annotationSurface   = "surface"
+	surfaceExperimental = "experimental"
 )
 
 func showAllSurface(root *cobra.Command) bool {
@@ -30,7 +30,7 @@ func showAllSurface(root *cobra.Command) bool {
 	return all
 }
 
-// applySurfaceProfile hides the punted tier from --help unless --all (or
+// applySurfaceProfile hides the experimental tier from --help unless --all (or
 // RC_SURFACE=full) is set. Everything else is visible. Runs after flags parse.
 func applySurfaceProfile(root *cobra.Command) {
 	if testing.Testing() {
@@ -41,20 +41,20 @@ func applySurfaceProfile(root *cobra.Command) {
 }
 
 // curateSurface applies the visibility rule. Split out of applySurfaceProfile
-// so it's testable without the testing.Testing() short-circuit. Only punted
+// so it's testable without the testing.Testing() short-circuit. Only experimental
 // commands are touched; aliases and every other command keep their own Hidden
 // state (so the full surface shows and aliases stay hidden).
 func curateSurface(root *cobra.Command, all bool) {
 	for _, cmd := range root.Commands() {
-		if cmd.Annotations[annotationSurface] == surfacePunted {
+		if cmd.Annotations[annotationSurface] == surfaceExperimental {
 			cmd.Hidden = !all
 		}
 	}
 }
 
-// puntedFromSchema reports whether a command is hidden even from agent
-// discovery. Only the punted tier qualifies; agent-only commands are hidden
+// experimentalFromSchema reports whether a command is hidden even from agent
+// discovery. Only the experimental tier qualifies; agent-only commands are hidden
 // from help but must still appear in commands/schema.
-func puntedFromSchema(c *cobra.Command) bool {
-	return c.Annotations[annotationSurface] == surfacePunted
+func experimentalFromSchema(c *cobra.Command) bool {
+	return c.Annotations[annotationSurface] == surfaceExperimental
 }

--- a/internal/cli/surface_test.go
+++ b/internal/cli/surface_test.go
@@ -64,3 +64,24 @@ func TestCurateSurface(t *testing.T) {
 		t.Error("--all should reveal a punted command")
 	}
 }
+
+func TestEveryCommandHasARegisteredGroup(t *testing.T) {
+	valid := map[string]bool{}
+	for _, g := range commandGroups {
+		valid[g.ID] = true
+	}
+	root := NewRootCmd("test")
+	for _, c := range root.Commands() {
+		switch c.Name() {
+		case "help", "completion":
+			continue
+		}
+		if c.GroupID == "" {
+			t.Errorf("command %q has no group — set one in NewRootCmd's grouped table", c.Name())
+			continue
+		}
+		if !valid[c.GroupID] {
+			t.Errorf("command %q has group %q not in commandGroups", c.Name(), c.GroupID)
+		}
+	}
+}

--- a/internal/cli/surface_test.go
+++ b/internal/cli/surface_test.go
@@ -85,3 +85,20 @@ func TestEveryCommandHasARegisteredGroup(t *testing.T) {
 		}
 	}
 }
+
+func TestSchemaExposesExperimentalMarked(t *testing.T) {
+	root := NewRootCmd("test")
+	tree := commandTreeWithSchemas(root)
+	var capital map[string]any
+	for _, c := range tree["commands"].([]map[string]any) {
+		if c["name"] == "capital" {
+			capital = c
+		}
+	}
+	if capital == nil {
+		t.Fatal("experimental command 'capital' should still appear in the schema so agents can detect it")
+	}
+	if capital["experimental"] != true {
+		t.Errorf("'capital' should be marked experimental in the schema, got %v", capital["experimental"])
+	}
+}

--- a/internal/cli/surface_test.go
+++ b/internal/cli/surface_test.go
@@ -10,7 +10,7 @@ import (
 // --help, agents/JSON see everything. These guard the two invariants that
 // keep that honest.
 
-// Agent discovery (rc commands --schemas) must include every non-punted
+// Agent discovery (rc commands --schemas) must include every non-experimental
 // command, including setup (agents run it non-interactively for the prompt).
 func TestCommandSurface_SchemaIncludesAgentCommands(t *testing.T) {
 	root := NewRootCmd("test")
@@ -28,10 +28,10 @@ func TestCommandSurface_SchemaIncludesAgentCommands(t *testing.T) {
 
 // The human-help curation runs behind a testing.Testing() short-circuit, so
 // this drives curateSurface directly: the full surface shows by default, a
-// punted command is held back until --all, and aliases stay hidden.
+// experimental command is held back until --all, and aliases stay hidden.
 func TestCurateSurface(t *testing.T) {
 	root := NewRootCmd("test")
-	root.AddCommand(&cobra.Command{Use: "x-punted", Annotations: map[string]string{annotationSurface: surfacePunted}})
+	root.AddCommand(&cobra.Command{Use: "x-experimental", Annotations: map[string]string{annotationSurface: surfaceExperimental}})
 	hidden := func(name string) bool {
 		for _, c := range root.Commands() {
 			if c.Name() == name {
@@ -55,13 +55,13 @@ func TestCurateSurface(t *testing.T) {
 	if !hidden("login") {
 		t.Error("the back-compat 'login' alias should stay hidden")
 	}
-	if !hidden("x-punted") {
-		t.Error("a punted command should be hidden by default")
+	if !hidden("x-experimental") {
+		t.Error("a experimental command should be hidden by default")
 	}
 
 	curateSurface(root, true) // rc --all
-	if hidden("x-punted") {
-		t.Error("--all should reveal a punted command")
+	if hidden("x-experimental") {
+		t.Error("--all should reveal a experimental command")
 	}
 }
 


### PR DESCRIPTION
The bare-`rc` home screen and `rc --help` used different, inconsistent groupings — home showed "Build"/"Inspect" and a separate paywalls block. The command→group mapping was also a separate map that could drift from the command list.

Grouping is now a single source of truth **on the command**, with task/verb-based titles aligned to RevenueCat's docs IA:
- Each command is registered with its group (`GroupID`) in one table; the separate `commandGroupByName` map is gone.
- `--help` and the home screen both render from the canonical `commandGroups` (same titles + order).
- `rc commands --json` reports `group` per command (agent-discoverable).
- A drift-guard test fails if any command is ungrouped or uses an unknown group.

Titles/placement were checked against docs.revenuecat.com: "Manage customers & revenue" (docs: *Manage Customers*; the group has refund/cancel/grant actions), `setup` under **Get started**, catalog = *Product Catalog*, paywalls own the fonts/media assets.

## What it looks like now (home + `--help` share these)

```
Get started
  rc setup               set up RevenueCat for a new app

Design paywalls
  rc paywalls generate   design a paywall with AI
  rc paywalls edit       refine an existing paywall

Manage your catalog
  rc offerings list      offerings & their packages
  rc products list       products across your stores
  rc entitlements list   entitlements & their products

Manage customers & revenue
  rc customer show <id>  a full customer view
  rc charts show mrr     MRR, actives, conversion
  rc metrics             project overview at a glance

Connect apps & integrations
  rc apps                connect App Store & Google Play

Automate with AI
  rc skills install      AI workflows for coding agents
  rc rico                ask RevenueCat's AI
```

`rc --help` also shows an **Advanced** group (api/audit/commands/schema/version).

Machine surface:
```
$ rc commands --json | jq '.data.commands[] | {name, group}'
{ "name": "paywalls",  "group": "design" }
{ "name": "offerings", "group": "catalog" }
{ "name": "apps",      "group": "integrations" }
```

`rc capital` (RevenueCat Capital) isn't shipped yet, so it's marked **experimental** — hidden from `--help` and `rc commands`/schema, still runnable, and shown only under `rc --all`. (This PR also renames that surface tier from the old jargon "punted" to "experimental", matching the `--help` footer.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly help text, home layout, and discovery metadata; experimental commands remain runnable with clearer visibility rules.
> 
> **Overview**
> **Unifies CLI discovery UX** so bare `rc`, `rc --help`, and agent JSON use the same command grouping and clearer surface rules.
> 
> Command **help groups** now come from one place: each top-level command gets `GroupID` in `NewRootCmd` (the old `commandGroupByName` map is removed), with renamed section titles (e.g. **Get started**, **Design paywalls**). The authenticated **home screen** drops ad-hoc labels like "Build"/"Inspect" and the separate paywalls block; it renders the same `commandGroups` titles/order via `groupTitle`, plus a drift test that every command has a valid group.
> 
> The **surface model** is simplified from three tiers to **default** vs **`surface: experimental`**: experimental commands (notably `rc capital`) stay hidden from normal `--help` until `rc --all` / `RC_SURFACE=full`, but remain in `rc commands` / `rc schema` with `"experimental": true` and a new **`group`** field—replacing the old "punted" tier that omitted commands from schema entirely. `--all` is documented as revealing experimental commands only.
> 
> Agent **capabilities** still skip experimental subtrees; README and `docs/command-surface.md` describe the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfc1397afaac21be9944fdcb1578669b7b14cbf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->