### PR TITLE
fix(cli): drop internal identity-cache line from rc auth status

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -383,7 +383,6 @@ func newAuthStatusCmd() *cobra.Command {
 				rt.Out.Success(fmt.Sprintf("Logged in as %s (profile: %s)", identity, profileName))
 			} else {
 				rt.Out.Success(fmt.Sprintf("Logged in (profile: %s)", profileName))
-				rt.Out.Info("Account identity is not cached for this login")
 			}
 			if projectStatus == "not_found" {
 				rt.Out.Warn(fmt.Sprintf("Configured project %s is no longer accessible; run `rc projects use`", rt.Config.ProjectID))


### PR DESCRIPTION
`rc auth status` printed "Account identity is not cached for this login" after the "Logged in". This is just leaking a debug style type line 🙈 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic CLI output change only; no auth, credential, or API behavior is modified.
> 
> **Overview**
> Stops `rc auth status` from printing the internal **"Account identity is not cached for this login"** info line after a successful login when no account email/name is cached (e.g. API key logins).
> 
> Status still shows `Logged in (profile: …)` in that case; only the extra debug-style message is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b43d3b114e1ed9fd25259342d97ed4e6165a759a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->