### PR TITLE
fix(cli): --no-input errors instead of silently picking a select's first option

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -175,10 +175,12 @@ with rc apps apple setup.`,
 			if err != nil {
 				return err
 			}
-			if err := tui.Form(rt.Globals.NoInput).
-				Field(huh.NewInput().Title("App name").Value(&name).Validate(tui.Required("name"))).
-				Field(huh.NewSelect[string]().Title("Type").Options(appTypes...).Value(&appType)).
-				Run(); err != nil {
+			form := tui.Form(rt.Globals.NoInput).
+				Field(huh.NewInput().Title("App name").Value(&name).Validate(tui.Required("name")))
+			if appType == "" && rt.CanPrompt() {
+				form.Field(huh.NewSelect[string]().Title("Type").Options(appTypes...).Value(&appType))
+			}
+			if err := form.Run(); err != nil {
 				return err
 			}
 			if !validAppType(appType) {

--- a/internal/cli/apps_test.go
+++ b/internal/cli/apps_test.go
@@ -1,0 +1,65 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/config"
+)
+
+func TestAppsCreate_NoInputWithoutTypeErrorsBeforeCreating(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", configDir)
+
+	var createBodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/projects/proj_x/apps" {
+			b, _ := io.ReadAll(r.Body)
+			createBodies = append(createBodies, string(b))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":"app_new","name":"Acme","type":"play_store"}`)
+			return
+		}
+		http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+	if err := config.Save("", &config.Config{APIKey: "sk_test", ProjectID: "proj_x", BaseURL: server.URL}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := runCmdInConfigDir(t, configDir, "apps", "create", "--name", "Acme", "--no-input")
+	if err == nil {
+		t.Fatal("want error when --type omitted under --no-input")
+	}
+	if !strings.Contains(err.Error(), "--type") {
+		t.Fatalf("error should name --type, got: %v", err)
+	}
+	if len(createBodies) != 0 {
+		t.Fatalf("no create request should be made when --type is missing, got: %v", createBodies)
+	}
+
+	out, _, err := runCmdInConfigDir(t, configDir,
+		"apps", "create", "--name", "Acme", "--type", "play_store", "--package-name", "com.acme.app", "--no-input", "--json")
+	if err != nil {
+		t.Fatalf("create with --type should succeed: %v", err)
+	}
+	if len(createBodies) != 1 {
+		t.Fatalf("want exactly one create request, got %d", len(createBodies))
+	}
+	var sent struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(createBodies[0]), &sent); err != nil {
+		t.Fatalf("create body not JSON: %v", err)
+	}
+	if sent.Type != "play_store" {
+		t.Fatalf("want type play_store from flag, got %q", sent.Type)
+	}
+	if !strings.Contains(out, "app_new") {
+		t.Fatalf("expected created app in output: %s", out)
+	}
+}

--- a/internal/cli/project_setup_cli_test.go
+++ b/internal/cli/project_setup_cli_test.go
@@ -240,6 +240,19 @@ func TestPaywallsUnpublishRequiresConfirmationAndReturnsState(t *testing.T) {
 	}
 }
 
+func TestProjectsUse_NoInputWithoutArgErrorsAndLeavesSelectionUntouched(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request %s %s: use without an argument under --no-input must not touch the API or active project", r.Method, r.URL.Path)
+		http.Error(w, "unexpected request", http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	_, _, err := runProjectSetupCommand(t, server.URL, "projects", "use", "--no-input", "--json")
+	if err == nil || !strings.Contains(err.Error(), "no project specified") {
+		t.Fatalf("error = %v, want a 'no project specified' error", err)
+	}
+}
+
 func runProjectSetupCommand(t *testing.T, baseURL string, args ...string) (string, string, error) {
 	t.Helper()
 	t.Setenv("RC_CONFIG_DIR", t.TempDir())

--- a/internal/cli/projects.go
+++ b/internal/cli/projects.go
@@ -210,6 +210,10 @@ The chosen project is written to the active profile file (default:
 			var chosen string
 			if len(args) == 1 {
 				chosen = args[0]
+			} else if rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
+				// No picker available: erroring beats the silent clear that the
+				// non-interactive select otherwise resolves to.
+				return fmt.Errorf("no project specified: pass a project ID (e.g. `rc projects use proj_abc`); the interactive picker is unavailable under --json/--no-input")
 			} else {
 				page, err := client.Projects.List(cmd.Context())
 				if err != nil {

--- a/internal/cli/projects.go
+++ b/internal/cli/projects.go
@@ -210,7 +210,7 @@ The chosen project is written to the active profile file (default:
 			var chosen string
 			if len(args) == 1 {
 				chosen = args[0]
-			} else if rt.Globals.JSON || rt.Globals.NoInput || !tui.IsInteractive() {
+			} else if !rt.CanPrompt() {
 				// No picker available: erroring beats the silent clear that the
 				// non-interactive select otherwise resolves to.
 				return fmt.Errorf("no project specified: pass a project ID (e.g. `rc projects use proj_abc`); the interactive picker is unavailable under --json/--no-input")


### PR DESCRIPTION
A hand-rolled `huh` select writes its first option into the bound variable at construction (`.Value(&x)`), so under `--no-input` a missing choice silently resolved to option 0 instead of erroring. Two commands hit this:

- `rc projects use` with no argument — the first option is "Ask me every time," so it silently *cleared* the active project and reported success.
- `rc apps create` with no `--type` — the first type is `app_store`, so it silently created an App Store app.

Both now build the picker only when interactive, so under `--no-input` a missing value errors before touching anything. Audited the other select-bearing commands (products, auth, customers, apple setup, setup, rico) — they already guard before building the select, so no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only behavior fix for non-interactive mode with regression tests; no API or auth changes.
> 
> **Overview**
> Under **`--no-input`** / **`--json`**, missing required choices no longer fall through to `huh` selects that default to the first option.
> 
> **`rc projects use`** without a project ID now returns an error instead of opening the picker (which could silently choose “Ask me every time” and clear the active project). **`rc apps create`** only adds the type select when prompting is allowed; without **`--type`**, it errors before any create API call.
> 
> Tests cover both paths (no API traffic on failure; successful create with explicit **`--type`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 670f8c6b4969d7de4244ad6c0beae81c16e744ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

