### PR TITLE
fix(cli): make rc customers the canonical name (customer stays as alias)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ Quick reference:
 - **stdout = data, stderr = chatter.** `--json` is opt-in, never auto.
 - **Don't auto-generate from OpenAPI.** This is a hand-crafted CLI; that's
   the whole pitch.
-- **Don't name commands after HTTP shape.** `rc customer grant`, not
+- **Don't name commands after HTTP shape.** `rc customers grant`, not
   `rc post-promotional-entitlement`.
 - **Errors**: typed `*api.APIError` from the API layer; CLI maps to exit codes
   via `internal/cli/runtime.go:ExitCodeFor`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ internal/api/   ← typed REST client, 1:1 with API endpoints. NO CLI concepts.
 internal/cli/   ← user-intent commands. Composes api/ calls into UX.
 ```
 
-**The CLI shape is not the API shape.** `rc customer show` calls three
+**The CLI shape is not the API shape.** `rc customers show` calls three
 endpoints to build one composite view; the `api/` package never knows that
 command exists.
 
@@ -44,7 +44,7 @@ REST shape in command names.
 
 If you find yourself naming a command after the HTTP verb + path
 (`rc post-customer-entitlement`), stop. The right name is the user's intent
-(`rc customer grant`).
+(`rc customers grant`).
 
 ## Dual-mode contract (humans + agents)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ make check            # verify everything passes clean
 ```bash
 go run ./cmd/rc --help
 go run ./cmd/rc commands --json | jq    # full surface
-go run ./cmd/rc schema customer grant   # per-command schema
+go run ./cmd/rc schema customers grant   # per-command schema
 ```
 
 Build a local binary:
@@ -38,7 +38,7 @@ export RC_PROJECT_ID="proj_..."
 export RC_CONFIG_DIR="$(mktemp -d)"
 
 go run ./cmd/rc projects list
-go run ./cmd/rc customer show <id>
+go run ./cmd/rc customers show <id>
 ```
 
 When done: `unset RC_API_KEY` and revoke the key in the dashboard.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The official command line interface for [RevenueCat](https://www.revenuecat.com)
 
 ```
 rc auth login
-rc customer show cus_abc
+rc customers show cus_abc
 rc charts show mrr
 ```
 
@@ -54,7 +54,7 @@ rc projects use
 rc capital setup
 
 # Look up a customer
-rc customer show cus_abc
+rc customers show cus_abc
 
 # See your MRR in an interactive chart
 rc charts show mrr
@@ -79,7 +79,7 @@ rc charts show mrr
 
 ```bash
 rc --help          # see everything
-rc customer --help # see subcommands for any noun
+rc customers --help # see subcommands for any noun
 ```
 
 ### Verify a Test Store setup
@@ -90,7 +90,7 @@ SDK, and create a real headless Test Store transaction without raw API calls:
 ```bash
 rc offerings verify ofrng_default --json --no-input
 rc offerings preview app_test --app-user-id demo-user --json --no-input
-rc customer simulate-purchase \
+rc customers simulate-purchase \
   --app-id app_test --product premium_monthly --app-user-id demo-user \
   --yes --json --no-input
 ```
@@ -227,8 +227,8 @@ manual start, run `rc projects create --name "My App" --use`.
 Every command supports `--json` for stable, machine-readable output:
 
 ```bash
-rc customer list --json | jq '.data.items[].id'
-rc customer show cus_abc --json
+rc customers list --json | jq '.data.items[].id'
+rc customers show cus_abc --json
 RC_API_KEY=sk_... rc entitlements list --json --no-input
 ```
 

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -11,7 +11,7 @@ the code when adding/renaming a command.
    the same user concept, they collapse under one noun. The CLI tree reflects
    how humans think, not how the API is laid out.
 2. **`/actions/foo` endpoints become verbs**, not subcommands of an `actions`
-   group. `POST /customers/{id}/actions/grant_entitlement` → `rc customer grant`.
+   group. `POST /customers/{id}/actions/grant_entitlement` → `rc customers grant`.
 3. **Archive/unarchive collapses** to `archive` + `restore` (or one verb +
    flag) — don't expose REST's symmetry as user-facing symmetry when one verb
    is the common case.
@@ -21,7 +21,7 @@ the code when adding/renaming a command.
    story.
 6. **Implicit project context.** `--project-id` is global, defaults to the
    profile's project, so most commands take just a resource ID.
-7. **Composite views are explicit.** `rc customer show` already gets active
+7. **Composite views are explicit.** `rc customers show` already gets active
    entitlements for free (embedded in API response); add subscriptions +
    purchases for the full SE-debug view.
 8. **Don't invent verbs the API can't fulfill.** Verified against fixtures.
@@ -134,27 +134,27 @@ rc apps apple check [app-id]                             # validate Apple login,
 rc apps apple setup [app-id]                             # interactive: create ASC app record if missing, per-key consent for IAP/ASC keys, auto-fetch vendor number
 
 # Customers — busiest noun
-rc customer show [id]                                    # already embeds active_entitlements; we'll add subs + purchases
-rc customer get [id]                                     # raw single endpoint
-rc customer list
-rc customer create
-rc customer delete <id>
-rc customer aliases <id>
-rc customer attributes <id>                              # GET; --set k=v for POST
-rc customer grant <id> <entitlement> [--duration ...]
-rc customer revoke <id> <entitlement>
-rc customer transfer <from> --to <id>
-rc customer override-offering <id> --offering <id>
-rc customer clear-override <id>
-rc customer restore-google <id> --token <t>
-rc customer simulate-purchase                            # Test Store only; --app-id/--product/--app-user-id + confirmation/--yes
-rc customer subscriptions <id>
-rc customer purchases <id>
-rc customer entitlements <id>                            # active
-rc customer invoices <id>
-rc customer wallet <id>                                  # virtual_currencies per-customer
-rc customer wallet-grant <id> <currency> --amount N      # /virtual_currencies/update_balance
-rc customer wallet-tx <id> <currency> --amount N         # /virtual_currencies/transactions
+rc customers show [id]                                    # already embeds active_entitlements; we'll add subs + purchases
+rc customers get [id]                                     # raw single endpoint
+rc customers list
+rc customers create
+rc customers delete <id>
+rc customers aliases <id>
+rc customers attributes <id>                              # GET; --set k=v for POST
+rc customers grant <id> <entitlement> [--duration ...]
+rc customers revoke <id> <entitlement>
+rc customers transfer <from> --to <id>
+rc customers override-offering <id> --offering <id>
+rc customers clear-override <id>
+rc customers restore-google <id> --token <t>
+rc customers simulate-purchase                            # Test Store only; --app-id/--product/--app-user-id + confirmation/--yes
+rc customers subscriptions <id>
+rc customers purchases <id>
+rc customers entitlements <id>                            # active
+rc customers invoices <id>
+rc customers wallet <id>                                  # virtual_currencies per-customer
+rc customers wallet-grant <id> <currency> --amount N      # /virtual_currencies/update_balance
+rc customers wallet-tx <id> <currency> --amount N         # /virtual_currencies/transactions
 
 # Entitlements (project catalog)
 rc entitlements list

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -23,14 +23,14 @@ Look up a customer end-to-end (customer record + active entitlements + subs +
 purchases, merged into one envelope):
 
 ```bash
-rc customer show cus_abc
-rc customer show cus_abc --json | jq '.data.subscriptions.items'
+rc customers show cus_abc
+rc customers show cus_abc --json | jq '.data.subscriptions.items'
 ```
 
 Grant a one-month promotional entitlement:
 
 ```bash
-rc customer grant --customer-id cus_abc --entitlement-id pro --duration monthly --yes
+rc customers grant --customer-id cus_abc --entitlement-id pro --duration monthly --yes
 ```
 
 Refund a Web Billing subscription (this is `--yes` by intent — confirmation
@@ -49,7 +49,7 @@ rc subscriptions extend sub_abc --by P1M
 Merge two customer records into one:
 
 ```bash
-rc customer transfer cus_old --to cus_new --yes
+rc customers transfer cus_old --to cus_new --yes
 ```
 
 ## Catalog management
@@ -134,7 +134,7 @@ rc --profile prod metrics --json
 Or per-invocation env (no on-disk profile needed for CI):
 
 ```bash
-RC_PROFILE=staging rc customer list --json
+RC_PROFILE=staging rc customers list --json
 RC_API_KEY=sk_... RC_PROJECT_ID=proj_x rc audit --limit 10 --json
 ```
 
@@ -149,7 +149,7 @@ rc commands --json
 Get a single command's input/output schema:
 
 ```bash
-rc schema customer grant
+rc schema customers grant
 rc schema entitlements attach        # shows positional arg shape
 ```
 
@@ -178,10 +178,10 @@ Exit code reference: `0` success, `1` generic, `2` usage, `4` unauthorized,
 **Pipe IDs into a loop**:
 
 ```bash
-rc customer list --json --limit 100 |
+rc customers list --json --limit 100 |
   jq -r '.data.items[].id' |
   while read id; do
-    rc customer show "$id" --json > "customers/$id.json"
+    rc customers show "$id" --json > "customers/$id.json"
   done
 ```
 
@@ -190,7 +190,7 @@ prompts only when stdin/stdout are terminals; pass `--no-color` to force off
 or `--no-input` to disable prompts):
 
 ```bash
-rc customer list                    # pretty table on TTY
-rc customer list | cat              # still pretty (we don't auto-switch on pipe)
-rc customer list --json | cat       # explicit machine-readable
+rc customers list                    # pretty table on TTY
+rc customers list | cat              # still pretty (we don't auto-switch on pipe)
+rc customers list --json | cat       # explicit machine-readable
 ```

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -21,7 +21,7 @@ user feedback.
 
 The four items that move "feels unfinished" → "feels real" for the launch audience.
 
-### 1.1 Pretty `rc customer show` (M, 4–6h)
+### 1.1 Pretty `rc customers show` (M, 4–6h)
 
 Replace the JSON dump with a card view in TTY mode. `--json` path unchanged.
 
@@ -41,7 +41,7 @@ spec is composable so other future detail views can reuse it.
 in `internal/output/output.go` via `github.com/itchyny/gojq`.
 
 **Acceptance (met):**
-- ✓ `rc customer list --json --format '.data.items[].id'` works.
+- ✓ `rc customers list --json --format '.data.items[].id'` works.
 - ✓ Plain JSON path expressions (jq syntax).
 - ✓ Errors in the expression go to stderr with a clear message; exit 2.
 - ✓ `--format` is only meaningful with `--json` (warns otherwise).
@@ -82,7 +82,7 @@ Make the most common API failures self-resolving.
 ---
 
 **Phase 1 done when:** a new internal user can install, login (with URL
-guidance), run `rc customer show` and read it without squinting, switch
+guidance), run `rc customers show` and read it without squinting, switch
 between staging and prod profiles, and get a hint when their key is revoked.
 
 ## Phase 2 — Quality of life (after real feedback)

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -229,7 +229,7 @@ anything on disk.`,
   rc auth login --api-key sk_...
 
   # CI: don't store on disk
-  RC_API_KEY=sk_... rc customer list`,
+  RC_API_KEY=sk_... rc customers list`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -350,7 +350,7 @@ func TestCommandsJSON_AgentDiscovery(t *testing.T) {
 	}
 	// Spot-check a few critical subcommands exist for agents to find.
 	tree := string(out)
-	for _, want := range []string{`"auth"`, `"customer"`, `"entitlements"`, `"schema"`, `"projects"`} {
+	for _, want := range []string{`"auth"`, `"customers"`, `"entitlements"`, `"schema"`, `"projects"`} {
 		if !strings.Contains(tree, want) {
 			t.Errorf("expected %s in command tree", want)
 		}
@@ -560,6 +560,7 @@ func TestSchema_IncludesPositionalArgs(t *testing.T) {
 }
 
 func TestSchema_IncludesAliases(t *testing.T) {
+	// Query via the singular alias to prove it resolves to the canonical plural.
 	out, errb, err := runCmd(t, "schema", "customer", "--json")
 	if err != nil {
 		t.Fatalf("execute: %v\nstderr: %s\nstdout: %s", err, errb, out)
@@ -576,11 +577,11 @@ func TestSchema_IncludesAliases(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &got); err != nil {
 		t.Fatalf("not JSON: %v\nstdout: %s", err, out)
 	}
-	if got.Data.Name != "customer" {
+	if got.Data.Name != "customers" {
 		t.Fatalf("wrong command resolved: name=%q stdout=%s", got.Data.Name, out)
 	}
-	if !contains(got.Data.Aliases, "customers") {
-		t.Errorf("want 'customers' in aliases, got %v", got.Data.Aliases)
+	if !contains(got.Data.Aliases, "customer") {
+		t.Errorf("want 'customer' in aliases, got %v", got.Data.Aliases)
 	}
 	subNames := make([]string, len(got.Data.Subcommands))
 	for i, s := range got.Data.Subcommands {

--- a/internal/cli/customers.go
+++ b/internal/cli/customers.go
@@ -52,22 +52,22 @@ func grantExpiry(duration string, now time.Time) (int64, error) {
 }
 
 // Customer commands illustrate the design principle: the CLI shape is NOT a
-// 1:1 mirror of the REST API. `rc customer show` composes the customer record
+// 1:1 mirror of the REST API. `rc customers show` composes the customer record
 // (which already embeds active_entitlements) with subscriptions and purchases
 // to build one user-intent view.
 
 func newCustomersCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "customer",
-		Aliases: []string{"customers"},
+		Use:     "customers",
+		Aliases: []string{"customer"},
 		Short:   "Inspect and manage Customers",
 		Long: `Inspect and manage Customers in the active project. A Customer Profile
 gathers a Customer's subscriptions, Non-Subscription Purchases, active
 Entitlements, and Customer Attributes. Multiple App User IDs that resolve to
 one Customer are aliases.`,
-		Example: `  rc customer list
-  rc customer show cus_abc
-  rc customer grant cus_abc entl_pro --duration monthly`,
+		Example: `  rc customers list
+  rc customers show cus_abc
+  rc customers grant cus_abc entl_pro --duration monthly`,
 	}
 	cmd.AddCommand(
 		newCustomerListCmd(),
@@ -97,8 +97,8 @@ endpoint used by the SDK. The selected app must have a test_ public SDK key.
 The Product may be given by RevenueCat Product ID or store identifier.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc customer simulate-purchase --app-id app_test --product premium_monthly --app-user-id demo-user
-  rc customer simulate-purchase --app-id app_test --product prod_abc --app-user-id demo-user --yes --json --no-input`,
+		Example: `  rc customers simulate-purchase --app-id app_test --product premium_monthly --app-user-id demo-user
+  rc customers simulate-purchase --app-id app_test --product prod_abc --app-user-id demo-user --yes --json --no-input`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -225,8 +225,8 @@ func newCustomerAliasesCmd() *cobra.Command {
 		Long: `Lists the App User IDs that resolve to one Customer. Aliases accumulate
 when the same person is identified under different App User IDs (anonymous
 then logged-in, across devices, after a transfer).`,
-		Example: `  rc customer aliases cus_abc
-  rc customer aliases cus_abc --json | jq '.data.items[].id'`,
+		Example: `  rc customers aliases cus_abc
+  rc customers aliases cus_abc --json | jq '.data.items[].id'`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -253,8 +253,8 @@ func newCustomerAttributesCmd() *cobra.Command {
 		Short: "List a Customer's attributes",
 		Long: `Lists the Customer Attributes (metadata) stored on a Customer, including
 reserved keys like $email and any custom keys you set.`,
-		Example: `  rc customer attributes cus_abc
-  rc customer attributes cus_abc --json | jq '.data'`,
+		Example: `  rc customers attributes cus_abc
+  rc customers attributes cus_abc --json | jq '.data'`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -283,8 +283,8 @@ func newCustomerSetAttributeCmd() *cobra.Command {
 		Long: `Sets Customer Attributes (metadata) on a Customer. Pass --set key=value
 once per attribute. Existing attributes with the same key are overwritten;
 others are preserved.`,
-		Example: `  rc customer set-attribute cus_abc --set email=user@example.com
-  rc customer set-attribute cus_abc --set $segment=premium --set $churnRisk=low`,
+		Example: `  rc customers set-attribute cus_abc --set email=user@example.com
+  rc customers set-attribute cus_abc --set $segment=premium --set $churnRisk=low`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -340,8 +340,8 @@ Reversibility: destructive on the source Customer's purchase history — the
 transfer is not automatically reversed.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc customer transfer cus_old --to cus_new
-  rc customer transfer cus_old --to cus_new --yes --json`,
+		Example: `  rc customers transfer cus_old --to cus_new
+  rc customers transfer cus_old --to cus_new --yes --json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -377,9 +377,9 @@ func newCustomerOverrideOfferingCmd() *cobra.Command {
 		Short: "Assign an Offering override to a Customer",
 		Long: `Forces a specific Offering to be shown to one Customer regardless of
 which Offering is currently the project default. Common for A/B tests or
-support overrides. Use 'rc customer clear-override' to remove.`,
-		Example: `  rc customer override-offering cus_abc --offering ofrng_promo_2026
-  rc customer clear-override cus_abc`,
+support overrides. Use 'rc customers clear-override' to remove.`,
+		Example: `  rc customers override-offering cus_abc --offering ofrng_promo_2026
+  rc customers clear-override cus_abc`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -388,7 +388,7 @@ support overrides. Use 'rc customer clear-override' to remove.`,
 				return err
 			}
 			if offering == "" {
-				return fmt.Errorf("--offering is required (use `rc customer clear-override` to remove)")
+				return fmt.Errorf("--offering is required (use `rc customers clear-override` to remove)")
 			}
 			client, err := rt.API()
 			if err != nil {
@@ -409,13 +409,13 @@ func newCustomerClearOverrideCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "clear-override <customer-id>",
 		Short: "Clear a Customer's Offering override",
-		Long: `Removes any Offering override set via ` + "`rc customer override-offering`" + `.
+		Long: `Removes any Offering override set via ` + "`rc customers override-offering`" + `.
 The Customer will see whichever Offering is the project default.
 
-Reversibility: re-apply with ` + "`rc customer override-offering`" + `.
+Reversibility: re-apply with ` + "`rc customers override-offering`" + `.
 
 Confirmation: no prompt.`,
-		Example: `  rc customer clear-override cus_abc`,
+		Example: `  rc customers clear-override cus_abc`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -449,7 +449,7 @@ Reversibility: the resulting subscription can be cancelled normally, but
 the original token consumption with Google cannot be undone.
 
 Confirmation: no prompt — idempotent (re-running with the same token is safe).`,
-		Example: `  rc customer restore-google cus_abc --token GPA.xxxx-xxxx-xxxx-xxxxx`,
+		Example: `  rc customers restore-google cus_abc --token GPA.xxxx-xxxx-xxxx-xxxxx`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -481,8 +481,8 @@ func newCustomerWalletCmd() *cobra.Command {
 		Short: "Show a Customer's Virtual Currency balances",
 		Long: `Shows the Customer's wallet: per-currency virtual currency balances for
 the project.`,
-		Example: `  rc customer wallet cus_abc
-  rc customer wallet cus_abc --json | jq '.data.items[]'`,
+		Example: `  rc customers wallet cus_abc
+  rc customers wallet cus_abc --json | jq '.data.items[]'`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -586,9 +586,9 @@ func newCustomerListCmd() *cobra.Command {
 		Short: "List Customers in the active project",
 		Long: `Lists Customers, paginated. In TTY mode launches an interactive browser;
 pass --json for machine-readable output or --no-input to disable the browser.`,
-		Example: `  rc customer list
-  rc customer list --json --limit 100 | jq '.data.items[].id'
-  rc customer list --cursor cus_xyz --limit 50`,
+		Example: `  rc customers list
+  rc customers list --json --limit 100 | jq '.data.items[].id'
+  rc customers list --cursor cus_xyz --limit 50`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			rt := RuntimeFrom(cmd.Context())
 			projectID, err := requireProject(rt)
@@ -655,8 +655,8 @@ func newCustomerShowCmd() *cobra.Command {
 subscriptions, and Non-Subscription Purchases into one envelope — the CLI's
 take on the Customer Profile. In TTY mode launches an interactive detail view
 with drill-down. Use --json for the raw merged document.`,
-		Example: `  rc customer show cus_abc
-  rc customer show cus_abc --json | jq '.data.customer.active_entitlements'`,
+		Example: `  rc customers show cus_abc
+  rc customers show cus_abc --json | jq '.data.customer.active_entitlements'`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -720,9 +720,9 @@ to pick from the project's Entitlements interactively.
 Duration must be one of: daily, three_day, weekly, monthly, two_month,
 three_month, six_month, yearly, lifetime. Omit --duration under a TTY to
 pick from the list interactively.`,
-		Example: `  rc customer grant cus_abc                          # TTY: picks entitlement + duration
-  rc customer grant cus_abc pro --duration monthly   # fully explicit
-  rc customer grant cus_abc pro --duration monthly --yes --json`,
+		Example: `  rc customers grant cus_abc                          # TTY: picks entitlement + duration
+  rc customers grant cus_abc pro --duration monthly   # fully explicit
+  rc customers grant cus_abc pro --duration monthly --yes --json`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -786,17 +786,17 @@ func newCustomerRevokeCmd() *cobra.Command {
 		Use:   "revoke <customer-id> [entitlement-id]",
 		Short: "Revoke a promotional Entitlement from a Customer",
 		Long: `Revokes a previously-granted promotional Entitlement. Only affects
-promotional grants made through ` + "`rc customer grant`" + ` — store
+promotional grants made through ` + "`rc customers grant`" + ` — store
 purchases are not affected.
 
 customer-id is required. entitlement-id is optional under a TTY — omit it
 to pick from the project's Entitlements interactively.
 
-Reversibility: re-grant with ` + "`rc customer grant`" + ` if needed.
+Reversibility: re-grant with ` + "`rc customers grant`" + ` if needed.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc customer revoke cus_abc              # TTY: picks entitlement
-  rc customer revoke cus_abc pro --yes   # fully explicit`,
+		Example: `  rc customers revoke cus_abc              # TTY: picks entitlement
+  rc customers revoke cus_abc pro --yes   # fully explicit`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
@@ -840,7 +840,7 @@ Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`
 	return cmd
 }
 
-// customerCard composes the pretty TTY view of `rc customer show`. JSON
+// customerCard composes the pretty TTY view of `rc customers show`. JSON
 // callers never touch this — they get `raw` straight through Render().
 func customerCard(c *api.Customer, subs *api.Page[api.Subscription], purs *api.Page[api.Purchase], raw any) output.Card {
 	card := output.Card{

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -59,7 +59,7 @@ var commandGroupByName = map[string]string{
 	"profiles": "start", "browse": "start", "open": "start", "setup": "start",
 	"paywalls": "design", "fonts": "design", "media-assets": "design",
 	"offerings": "catalog", "products": "catalog", "packages": "catalog", "entitlements": "catalog",
-	"customer": "revenue", "subscriptions": "revenue", "purchases": "revenue",
+	"customers": "revenue", "subscriptions": "revenue", "purchases": "revenue",
 	"invoices": "revenue", "charts": "revenue", "metrics": "revenue",
 	"apps": "integrations", "capital": "integrations", "webhooks": "integrations",
 	"rico": "ai", "skills": "ai",

--- a/internal/cli/home.go
+++ b/internal/cli/home.go
@@ -21,7 +21,7 @@ var homeMap = []homeGroup{
 		{"rc entitlements list", "entitlements & their products"},
 	}},
 	{"Inspect", [][2]string{
-		{"rc customer show <id>", "a full customer view"},
+		{"rc customers show <id>", "a full customer view"},
 		{"rc charts show mrr", "MRR, actives, conversion"},
 		{"rc metrics", "project overview at a glance"},
 	}},

--- a/internal/cli/invoices.go
+++ b/internal/cli/invoices.go
@@ -50,7 +50,7 @@ func newInvoicesShowCmd() *cobra.Command {
 	}
 }
 
-// `rc invoices for <customer-id>` is more user-friendly than `rc customer invoices`
+// `rc invoices for <customer-id>` is more user-friendly than `rc customers invoices`
 // because invoices are an independent noun; users go looking for an invoice
 // first and only narrow by customer if needed.
 func newInvoicesForCustomerCmd() *cobra.Command {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -58,15 +58,15 @@ Agent-friendly entrypoints:
   rc <cmd> --yes         skip confirmations`,
 		Example: `  # Human use
   rc auth login
-  rc customer show cus_abc
+  rc customers show cus_abc
 
   # Scripted use
-  rc customer list --json | jq '.data.items[].id'
+  rc customers list --json | jq '.data.items[].id'
   RC_API_KEY=sk_... rc entitlements list --json
 
   # Agent discovery
   rc commands --json
-  rc schema customer grant`,
+  rc schema customers grant`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Version:       version,

--- a/internal/cli/root_gettingstarted_test.go
+++ b/internal/cli/root_gettingstarted_test.go
@@ -73,7 +73,7 @@ func TestBareRC_LoggedInWithProject_ShowsCommandMap(t *testing.T) {
 		"app.revenuecat.com/projects/abc", // dashboard deep-link (prefix stripped)
 		"Build", "Inspect", "Automate & set up",
 		"✨ Paywalls — design with AI", "rc paywalls generate", "rc paywalls edit",
-		"rc customer show <id>",
+		"rc customers show <id>",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("logged-in/project home missing %q:\n%s", want, out)

--- a/internal/cli/surface_test.go
+++ b/internal/cli/surface_test.go
@@ -19,7 +19,7 @@ func TestCommandSurface_SchemaIncludesAgentCommands(t *testing.T) {
 	for _, c := range tree["commands"].([]map[string]any) {
 		names[c["name"].(string)] = true
 	}
-	for _, want := range []string{"customer", "offerings", "entitlements", "packages", "setup"} {
+	for _, want := range []string{"customers", "offerings", "entitlements", "packages", "setup"} {
 		if !names[want] {
 			t.Errorf("command %q missing from schema surface", want)
 		}
@@ -46,8 +46,8 @@ func TestCurateSurface(t *testing.T) {
 	if hidden("paywalls") {
 		t.Error("'paywalls' should be visible in --help")
 	}
-	if hidden("customer") {
-		t.Error("'customer' should be visible in --help (full surface)")
+	if hidden("customers") {
+		t.Error("'customers' should be visible in --help (full surface)")
 	}
 	if hidden("setup") {
 		t.Error("'setup' should be visible in --help")

--- a/internal/output/card.go
+++ b/internal/output/card.go
@@ -7,7 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Card is a structured detail view used by commands like `rc customer show`.
+// Card is a structured detail view used by commands like `rc customers show`.
 // It's an alternative to RenderTable for "one entity, many facets" output.
 // JSON mode bypasses Card entirely and emits Raw via Render().
 //


### PR DESCRIPTION
`rc customer` was the odd one out — every other group is plural (`apps`, `products`, `offerings`, `subscriptions`…). Flipped the canonical name to `customers` and kept `customer` as an alias, so nothing that already types `rc customer` breaks. Schema/`rc commands` now advertises the plural.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic command rename with a singular alias preserved, so existing `rc customer …` invocations keep working. No API or auth behavior changes.
> 
> **Overview**
> Makes **`customers`** the canonical top-level command name so it matches other plural resource groups (`apps`, `products`, `offerings`, …). **`customer` remains a working alias**, so existing scripts and muscle memory are unaffected.
> 
> Schema / `rc commands` now advertise the plural as the primary name. Docs, help examples, home screen copy, and tests were swept to the plural form for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c22f8dbf2f89ff8235c21250c880e1b4b528054b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
