### PR TITLE
fix(cli): unknown subcommands error with exit 2 instead of silent help

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -699,3 +699,108 @@ func TestExitCode_UsageErrorsAre2(t *testing.T) {
 		t.Errorf("unknown flag should exit 2, got %d (err: %v)", got, err)
 	}
 }
+
+func TestUnknownSubcommand_ErrorsAcrossGroups(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"non-runnable group", []string{"apps", "frobnicate"}},
+		{"another non-runnable group", []string{"auth", "frobnicate"}},
+		{"runnable guided group", []string{"paywalls", "create"}},
+		{"runnable list group", []string{"packages", "frobnicate"}},
+		{"nested group", []string{"apps", "apple", "frobnicate"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, _, err := runCmd(t, tc.args...)
+			if err == nil {
+				t.Fatalf("want error for unknown subcommand %v, got nil (stdout: %s)", tc.args, out)
+			}
+			if got := cli.ExitCodeFor(err); got != 2 {
+				t.Errorf("unknown subcommand should exit 2, got %d (err: %v)", got, err)
+			}
+			if !strings.HasPrefix(err.Error(), "unknown command") {
+				t.Errorf("want an unknown-command message, got %q", err.Error())
+			}
+		})
+	}
+}
+
+func TestUnknownSubcommand_PreservesBareGroupAndValidSubcommand(t *testing.T) {
+	out, _, err := runCmd(t, "apps")
+	if err != nil {
+		t.Fatalf("bare group should show help, not error: %v", err)
+	}
+	if !strings.Contains(out, "Available Commands:") {
+		t.Errorf("bare group should render help with its subcommands, got:\n%s", out)
+	}
+
+	// A valid subcommand isn't guarded: it may fail on missing auth (exit 4),
+	// but never as unknown-command (exit 2).
+	_, _, err = runCmd(t, "apps", "list", "--no-input")
+	if err != nil && strings.HasPrefix(err.Error(), "unknown command") {
+		t.Errorf("valid subcommand misrouted as unknown: %v", err)
+	}
+}
+
+func TestGroupHelpHidesBareUseLine(t *testing.T) {
+	out, _, err := runCmd(t, "apps", "--help")
+	if err != nil {
+		t.Fatalf("apps --help: %v", err)
+	}
+	if !strings.Contains(out, "rc apps [command]") {
+		t.Fatalf("group usage should offer the subcommand form:\n%s", out)
+	}
+	if strings.Contains(out, "rc apps [flags]") {
+		t.Errorf("help-only group must not render a runnable useline:\n%s", out)
+	}
+}
+
+// The guard makes groups cobra-runnable, but that must not leak into the agent
+// discovery surface: a group stays runnable:false and never lists its own name
+// as a capability.
+func TestUnknownSubcommand_KeepsGroupsOutOfDiscoverySurface(t *testing.T) {
+	out, _, err := runCmd(t, "commands", "--json")
+	if err != nil {
+		t.Fatalf("commands --json: %v", err)
+	}
+	type node struct {
+		Name         string   `json:"name"`
+		Runnable     bool     `json:"runnable"`
+		Capabilities []string `json:"capabilities"`
+		Commands     []node   `json:"commands"`
+	}
+	var got struct {
+		Data node `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, out)
+	}
+	var apps *node
+	for i := range got.Data.Commands {
+		if got.Data.Commands[i].Name == "apps" {
+			apps = &got.Data.Commands[i]
+		}
+	}
+	if apps == nil {
+		t.Fatal("apps group missing from commands tree")
+	}
+	if apps.Runnable {
+		t.Error("pure group apps should report runnable:false in the discovery surface")
+	}
+	if contains(apps.Capabilities, "apps") {
+		t.Errorf("pure group apps must not advertise its own name as a capability, got %v", apps.Capabilities)
+	}
+}
+
+// Near-misses carry cobra's did-you-mean so an agent can self-correct.
+func TestUnknownSubcommand_SuggestsNearMiss(t *testing.T) {
+	_, _, err := runCmd(t, "apps", "lst")
+	if err == nil {
+		t.Fatal("want error for unknown subcommand")
+	}
+	if !strings.Contains(err.Error(), `did you mean "list"?`) {
+		t.Errorf("want a did-you-mean suggestion for 'lst', got %q", err.Error())
+	}
+}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -13,7 +13,7 @@ import (
 var helpColor = true
 
 // rcUsageTemplate styles the usage sections and collapses inherited flags via rcGlobalFlags.
-const rcUsageTemplate = `{{rcHead "Usage:"}}{{if .Runnable}}
+const rcUsageTemplate = `{{rcHead "Usage:"}}{{if rcShowUseLine .}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
@@ -85,6 +85,7 @@ func applyHelpStyling(root *cobra.Command) {
 	cobra.AddTemplateFunc("rcCmd", func(s string) string { return output.HelpCommand(helpColor, s) })
 	cobra.AddTemplateFunc("rcFoot", func(s string) string { return output.HelpDim(helpColor, s) })
 	cobra.AddTemplateFunc("rcGlobalFlags", globalFlagsSummary)
+	cobra.AddTemplateFunc("rcShowUseLine", isDiscoverableRunnable)
 	root.SetUsageTemplate(rcUsageTemplate)
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -184,12 +184,12 @@ Agent-friendly entrypoints:
 	return root
 }
 
-// guardUnknownSubcommands makes every command group reject an unknown
-// subcommand instead of cobra's default — printing group help and exiting 0,
-// which reads as success to scripts and agents. cobra only guards the root:
-// other parents short-circuit to help before arg validation runs, so a
-// non-runnable group also gets a help-only RunE to reach validation. A bare
-// group (no args) still falls through to help or the group's own RunE, and
+// guardUnknownSubcommands walks the whole tree so every group — top-level and
+// nested — rejects an unknown subcommand instead of cobra's default of printing
+// help and exiting 0, which reads as success to scripts and agents. (cobra only
+// does that for the root.) A non-runnable group short-circuits to help before
+// arg validation runs, so it also gets a help-only RunE to reach the check. A
+// bare group (no args) still falls through to help or the group's own RunE, and
 // groups that set their own Args (e.g. rico takes a message) are left alone.
 func guardUnknownSubcommands(cmd *cobra.Command) {
 	for _, sub := range cmd.Commands() {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -165,6 +165,7 @@ Agent-friendly entrypoints:
 		return usageError{suggestFlag(cmd, err)}
 	})
 	applyCommandGroups(root)
+	guardUnknownSubcommands(root)
 	applySurfaceProfile(root)
 	applyHelpStyling(root)
 
@@ -181,6 +182,44 @@ Agent-friendly entrypoints:
 		}
 	})
 	return root
+}
+
+// guardUnknownSubcommands makes every command group reject an unknown
+// subcommand instead of cobra's default — printing group help and exiting 0,
+// which reads as success to scripts and agents. cobra only guards the root:
+// other parents short-circuit to help before arg validation runs, so a
+// non-runnable group also gets a help-only RunE to reach validation. A bare
+// group (no args) still falls through to help or the group's own RunE, and
+// groups that set their own Args (e.g. rico takes a message) are left alone.
+func guardUnknownSubcommands(cmd *cobra.Command) {
+	for _, sub := range cmd.Commands() {
+		guardUnknownSubcommands(sub)
+	}
+	if !cmd.HasSubCommands() {
+		return
+	}
+	if cmd.SuggestionsMinimumDistance <= 0 {
+		cmd.SuggestionsMinimumDistance = 2 // SuggestionsFor reads this directly; cobra only defaults it inside its own help path.
+	}
+	if cmd.Args == nil {
+		cmd.Args = func(c *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return nil
+			}
+			e := &unknownSubcommandError{parent: c.CommandPath(), name: args[0]}
+			if s := c.SuggestionsFor(args[0]); len(s) > 0 {
+				e.suggestion = s[0]
+			}
+			return e
+		}
+	}
+	if !cmd.Runnable() {
+		cmd.RunE = func(c *cobra.Command, _ []string) error { return c.Help() }
+		if cmd.Annotations == nil {
+			cmd.Annotations = map[string]string{}
+		}
+		cmd.Annotations["help_only"] = "true"
+	}
 }
 
 // suggestFlag appends a did-you-mean to unknown-flag errors: agents guess

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -123,6 +123,8 @@ func writeJSONError(w io.Writer, err error) {
 		env.RetryAfterSeconds = apiErr.RetryAfterSeconds
 	} else if errors.Is(err, ErrNotAuthenticated) {
 		env.Type = "unauthorized"
+	} else if uce := (*unknownSubcommandError)(nil); errors.As(err, &uce) {
+		env.Type = "unknown_command_error"
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -152,6 +152,30 @@ func TestWithHint_NilPassesThrough(t *testing.T) {
 	}
 }
 
+func TestWriteJSONError_UnknownSubcommandHasOwnType(t *testing.T) {
+	var buf bytes.Buffer
+	writeJSONError(&buf, &unknownSubcommandError{parent: "rc paywalls", name: "create", suggestion: "generate"})
+	var got struct {
+		Error struct {
+			Type     string `json:"type"`
+			Message  string `json:"message"`
+			ExitCode int    `json:"exit_code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if got.Error.Type != "unknown_command_error" {
+		t.Errorf("want type=unknown_command_error, got %q", got.Error.Type)
+	}
+	if got.Error.ExitCode != 2 {
+		t.Errorf("unknown subcommand should map to exit 2, got %d", got.Error.ExitCode)
+	}
+	if !strings.Contains(got.Error.Message, `did you mean "generate"?`) {
+		t.Errorf("message should carry the suggestion, got %q", got.Error.Message)
+	}
+}
+
 func TestWriteJSONError_NotAuthenticatedHasUnauthorizedType(t *testing.T) {
 	var buf bytes.Buffer
 	writeJSONError(&buf, ErrNotAuthenticated)

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -26,6 +26,23 @@ type usageError struct{ err error }
 func (e usageError) Error() string { return e.err.Error() }
 func (e usageError) Unwrap() error { return e.err }
 
+// unknownSubcommandError is returned when a command group is handed a verb it
+// doesn't have. It carries a distinct type so the JSON envelope can label it
+// unknown_command_error while still mapping to the usage exit code.
+type unknownSubcommandError struct {
+	parent     string
+	name       string
+	suggestion string
+}
+
+func (e *unknownSubcommandError) Error() string {
+	msg := fmt.Sprintf("unknown command %q for %q", e.name, e.parent)
+	if e.suggestion != "" {
+		msg += fmt.Sprintf("; did you mean %q?", e.suggestion)
+	}
+	return msg
+}
+
 // cobra emits these prefixes for command/arg misuse; none pass through
 // FlagErrorFunc, so match them by message.
 func isCobraUsage(err error) bool {
@@ -150,7 +167,8 @@ func ExitCodeFor(err error) int {
 		return 2
 	}
 	var ue usageError
-	if errors.As(err, &ue) || isCobraUsage(err) {
+	var uce *unknownSubcommandError
+	if errors.As(err, &ue) || errors.As(err, &uce) || isCobraUsage(err) {
 		return 2
 	}
 	var apiErr *api.APIError

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -115,7 +115,7 @@ func commandSchema(c *cobra.Command) map[string]any {
 			"name":     sc.Name(),
 			"short":    sc.Short,
 			"aliases":  sc.Aliases,
-			"runnable": sc.Runnable(),
+			"runnable": isDiscoverableRunnable(sc),
 		})
 	}
 
@@ -130,7 +130,7 @@ func commandSchema(c *cobra.Command) map[string]any {
 		"example":      c.Example,
 		"flags":        flags,
 		"subcommands":  subs,
-		"runnable":     c.Runnable(),
+		"runnable":     isDiscoverableRunnable(c),
 		"capabilities": inferCapabilities(c),
 	}
 	addHumanRequirement(schema, c)
@@ -150,10 +150,17 @@ func addHumanRequirement(schema map[string]any, c *cobra.Command) {
 	}
 }
 
+// isDiscoverableRunnable reports whether a command is a real, invocable verb
+// for the agent discovery surface. A pure group made runnable only to reject
+// unknown subcommands (help_only) isn't one — it just prints help.
+func isDiscoverableRunnable(c *cobra.Command) bool {
+	return c.Runnable() && c.Annotations["help_only"] != "true"
+}
+
 // inferCapabilities lists runnable descendants as `group:verb` labels relative to c.
 func inferCapabilities(c *cobra.Command) []string {
 	acc := &capAccumulator{seen: map[string]bool{}}
-	if c.Runnable() {
+	if isDiscoverableRunnable(c) {
 		acc.add(canonicalVerb(c.Name()))
 	}
 	for _, sc := range c.Commands() {
@@ -166,7 +173,7 @@ func inferCapabilities(c *cobra.Command) []string {
 }
 
 func collectCapabilities(c *cobra.Command, path []string, acc *capAccumulator) {
-	if c.Runnable() {
+	if isDiscoverableRunnable(c) {
 		acc.add(capLabel(path))
 	}
 	for _, sc := range c.Commands() {
@@ -260,7 +267,7 @@ func commandTree(c *cobra.Command) map[string]any {
 		"path":         commandPath(c),
 		"short":        c.Short,
 		"aliases":      c.Aliases,
-		"runnable":     c.Runnable(),
+		"runnable":     isDiscoverableRunnable(c),
 		"capabilities": inferCapabilities(c),
 		"commands":     subs,
 	}

--- a/internal/cli/schema_test.go
+++ b/internal/cli/schema_test.go
@@ -106,7 +106,7 @@ func TestInferCapabilities_DriftGuard(t *testing.T) {
 		if len(c.Commands()) > 0 {
 			caps := inferCapabilities(c)
 			for _, sc := range c.Commands() {
-				if puntedFromSchema(sc) || !sc.Runnable() {
+				if puntedFromSchema(sc) || !isDiscoverableRunnable(sc) {
 					continue
 				}
 				want := canonicalVerb(sc.Name())


### PR DESCRIPTION
`rc apps frobnicate` (a typo'd subcommand) used to print the group's help and exit 0 — so in a script or an agent run it looked like success when nothing actually ran. Now it errors: `unknown command "frobnicate" for "rc apps"`, with a did-you-mean and exit 2.

One wrinkle worth knowing: cobra bails a group out to its help screen *before* it checks the args, so to make the check fire I had to give each group a tiny help-only `RunE`. Side effect: that makes a group look "runnable," which would leak into agent discovery — so those are tagged and kept out of `rc commands` / schema. I verified that output is byte-identical to before.

Commands that legitimately take free text — like `rc rico "fix my paywall"` — are left alone, since there's no way to tell a typo from a message there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global CLI routing, exit codes, and agent discovery for all command groups; behavior is heavily tested but affects every nested group in the tree.
> 
> **Overview**
> **Unknown subcommands on groups no longer look like success.** Typos such as `rc apps frobnicate` used to print group help and exit 0; they now fail with an `unknown command` message, optional did-you-mean text, and **exit code 2**.
> 
> A new **`guardUnknownSubcommands`** pass on the cobra tree adds arg checks on groups (unless they already define `Args`, e.g. free-text commands), introduces **`unknownSubcommandError`**, and wires **`ExitCodeFor`** and **`--json`** errors (`type: unknown_command_error`) to that behavior.
> 
> Because cobra only validates args when a group is runnable, non-runnable groups get a **help-only `RunE`** and a **`help_only`** annotation. **`isDiscoverableRunnable`** keeps those groups **`runnable: false`** in `rc commands` / schema and out of capabilities; help rendering uses **`rcShowUseLine`** so group help does not show a misleading `rc apps [flags]` line.
> 
> Bare invocations like `rc apps` still show subcommand help; valid subcommands are not misclassified as unknown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a368d637670c6bcaf9153796f38700126457691a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

