### PR TITLE
fix(paywalls): note that restore buttons are hidden in preview screenshots

### DIFF
--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -28,8 +28,7 @@ approved the design. See generate's and edit's help for how to prompt well.
 Iterating is the normal workflow: expect several edit turns until the result
 is acceptable, not a perfect first try. Every completed turn writes a preview
 screenshot; judge it against the direction and keep editing until it matches.
-Screenshots never show Restore Purchases buttons; the session JSON is the
-source of truth for those. Undo a bad turn with rc paywalls rewind.
+Undo a bad turn with rc paywalls rewind.
 
 Custom assets: upload the app's real fonts with rc fonts upload and real
 images (logo, hero) with rc media-assets upload BEFORE designing, then

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -28,7 +28,8 @@ approved the design. See generate's and edit's help for how to prompt well.
 Iterating is the normal workflow: expect several edit turns until the result
 is acceptable, not a perfect first try. Every completed turn writes a preview
 screenshot; judge it against the direction and keep editing until it matches.
-Undo a bad turn with rc paywalls rewind.
+Screenshots never show Restore Purchases buttons; the session JSON is the
+source of truth for those. Undo a bad turn with rc paywalls rewind.
 
 Custom assets: upload the app's real fonts with rc fonts upload and real
 images (logo, hero) with rc media-assets upload BEFORE designing, then

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -132,8 +132,11 @@ answer with a clarifying question instead of a design — reply with another
 edit turn. Each completed turn also writes a preview screenshot next to the
 session file (plus a dark-mode one when the design has dark mode); its path is
 shown in the output — look at it after every turn and keep iterating with edit
-turns until the design is right. The draft stays unpublished; review it and
-run rc paywalls publish.
+turns until the design is right. The preview never renders Restore Purchases
+buttons — the renderer hides them by design. Do not report them missing from
+a screenshot; check the paywall JSON in the session file for a button with
+action type restore_purchases instead. The draft stays unpublished; review it
+and run rc paywalls publish.
 
 Do not generate blind: read the app's theme and brand files and collect app
 screenshots before the first turn. If the app ships custom fonts (.ttf/.otf
@@ -289,7 +292,11 @@ Using it well:
   - Each completed turn writes a preview screenshot next to the session file
     (and a dark-mode one when the design has dark mode); its path is shown in
     the output. Look at it after every turn and judge it against the
-    direction; in the next prompt, describe what is still wrong.
+    direction; in the next prompt, describe what is still wrong. The preview
+    never renders Restore Purchases buttons — the renderer hides them by
+    design; do not report them missing from a screenshot. Check the paywall
+    JSON in the session file for a button with action type restore_purchases
+    instead.
   - Turns take one to several minutes and stream progress; run with an
     extended timeout (--timeout) or in the background rather than polling.
   - Undo the last turn:  rc paywalls rewind --session <file>`,


### PR DESCRIPTION
The paywall preview renderer hides Restore Purchases buttons by design. This adds a note to the generate and edit command help text so agent does not report them as missing when reviewing a screenshot.

This is a mitigation, and a quick fix.

The proper fix would be to render that button in screenshots, i.e. fix it in `purchases-ui-js`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CLI help text; no runtime, API, or security behavior is modified.
> 
> **Overview**
> Documents that paywall **preview screenshots hide Restore Purchases buttons** by design, so agents reviewing generate/edit output don't flag them as missing.
> 
> Adds the same guidance to both `rc paywalls generate` and `rc paywalls edit` help: check the session file JSON for a `restore_purchases` button instead of relying on the screenshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b7bc7ea5ff19e114030c64b03b2a292fab51bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->