### PR TITLE
feat(paywalls): add attach and detach commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ rc charts show mrr
 | **Offerings** | `list` · `show` · `verify` · `preview` · `create` · `update` · `set-current` · `archive` |
 | **Packages** | `list` (across all offerings) · `show` · `products` · `create` · `update` · `delete` · `attach` · `detach` |
 | **Products** | `list` · `show` · `create` · `archive` · `restore` · `delete` · `store sync` |
-| **Paywalls** | `list` · `show` · `create` · `generate` (AI) · `edit` (AI) · `rewind` · `publish` · `unpublish` · `delete` |
+| **Paywalls** | `list` · `show` · `create` · `generate` (AI) · `edit` (AI) · `rewind` · `publish` · `unpublish` · `attach` · `detach` · `delete` |
 | **Rico (AI assistant)** | `chat` (streaming, tool approvals) · `conversations list/show/delete` · `feedback` |
 | **Charts & metrics** | Interactive bar/line charts · daily/weekly/monthly/quarterly/yearly |
 | **Apps** | `list` · `show` · `create` · `update` · `delete` · `apple check` · `apple setup` |

--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -214,6 +214,8 @@ rc paywalls edit <paywall-id>|--session <file> --prompt  # AI-edit any paywall (
 rc paywalls rewind --session <file>                      # undo the last editor action
 rc paywalls publish [id]                                 # publish the current draft; confirmation/--yes
 rc paywalls unpublish [id]                               # remove the published paywall; confirmation/--yes
+rc paywalls attach <paywall-id> <offering-id>            # attach or move a paywall to an offering (one paywall per offering); confirms when published
+rc paywalls detach <paywall-id>                          # make it standalone; unpublish a published paywall first
 rc paywalls delete <id> [--force]                        # attached/published paywalls refuse to delete without --force
 
 # Rico (AI assistant)

--- a/internal/api/paywalls.go
+++ b/internal/api/paywalls.go
@@ -90,8 +90,8 @@ func (s *PaywallsService) CreateFromComponents(ctx context.Context, projectID st
 }
 
 // SetOffering attaches (non-nil) or detaches (nil) the paywall's offering.
-func (s *PaywallsService) SetOffering(ctx context.Context, projectID, id string, offeringID *string) (*Paywall, error) {
-	body := map[string]any{"offering_id": offeringID}
+func (s *PaywallsService) SetOffering(ctx context.Context, projectID, id string, revision int, offeringID *string) (*Paywall, error) {
+	body := map[string]any{"revision": revision, "offering_id": offeringID}
 	var out Paywall
 	err := s.c.do(ctx, http.MethodPatch, pathPaywall(projectID, id), body, &out)
 	return &out, err

--- a/internal/api/paywalls.go
+++ b/internal/api/paywalls.go
@@ -89,6 +89,14 @@ func (s *PaywallsService) CreateFromComponents(ctx context.Context, projectID st
 	return &out, err
 }
 
+// SetOffering attaches (non-nil) or detaches (nil) the paywall's offering.
+func (s *PaywallsService) SetOffering(ctx context.Context, projectID, id string, offeringID *string) (*Paywall, error) {
+	body := map[string]any{"offering_id": offeringID}
+	var out Paywall
+	err := s.c.do(ctx, http.MethodPatch, pathPaywall(projectID, id), body, &out)
+	return &out, err
+}
+
 func (s *PaywallsService) Publish(ctx context.Context, projectID, id string) (*Paywall, error) {
 	var out Paywall
 	path := pathPaywallActionsPublish(projectID, id)

--- a/internal/api/paywalls_test.go
+++ b/internal/api/paywalls_test.go
@@ -43,14 +43,14 @@ func TestPaywallsSetOffering(t *testing.T) {
 		{
 			name:       "attach",
 			offeringID: &ofrng,
-			wantBody:   `{"offering_id":"ofrng_x"}`,
+			wantBody:   `{"offering_id":"ofrng_x","revision":7}`,
 			response:   `{"id":"pw","offering_id":"ofrng_x","created_at":1,"published_at":null,"object":"paywall"}`,
 			wantResult: "ofrng_x",
 		},
 		{
 			name:       "detach",
 			offeringID: nil,
-			wantBody:   `{"offering_id":null}`,
+			wantBody:   `{"offering_id":null,"revision":7}`,
 			response:   `{"id":"pw","offering_id":null,"created_at":1,"published_at":null,"object":"paywall"}`,
 			wantResult: "",
 		},
@@ -71,7 +71,7 @@ func TestPaywallsSetOffering(t *testing.T) {
 			t.Cleanup(srv.Close)
 
 			client := api.NewClient(api.Options{APIKey: "sk_test", BaseURL: srv.URL})
-			paywall, err := client.Paywalls.SetOffering(context.Background(), "proj", "pw", tt.offeringID)
+			paywall, err := client.Paywalls.SetOffering(context.Background(), "proj", "pw", 7, tt.offeringID)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/api/paywalls_test.go
+++ b/internal/api/paywalls_test.go
@@ -2,8 +2,10 @@ package api_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/revenuecat/cli/internal/api"
@@ -26,6 +28,57 @@ func TestPaywallsPublishPreservesPublishedState(t *testing.T) {
 	}
 	if paywall.PublishedAt == nil || *paywall.PublishedAt != 2 {
 		t.Fatalf("published_at = %v, want 2", paywall.PublishedAt)
+	}
+}
+
+func TestPaywallsSetOffering(t *testing.T) {
+	ofrng := "ofrng_x"
+	tests := []struct {
+		name       string
+		offeringID *string
+		wantBody   string
+		response   string
+		wantResult string
+	}{
+		{
+			name:       "attach",
+			offeringID: &ofrng,
+			wantBody:   `{"offering_id":"ofrng_x"}`,
+			response:   `{"id":"pw","offering_id":"ofrng_x","created_at":1,"published_at":null,"object":"paywall"}`,
+			wantResult: "ofrng_x",
+		},
+		{
+			name:       "detach",
+			offeringID: nil,
+			wantBody:   `{"offering_id":null}`,
+			response:   `{"id":"pw","offering_id":null,"created_at":1,"published_at":null,"object":"paywall"}`,
+			wantResult: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPatch || r.URL.Path != "/projects/proj/paywalls/pw" {
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+				body, _ := io.ReadAll(r.Body)
+				if got := strings.TrimSpace(string(body)); got != tt.wantBody {
+					t.Fatalf("body = %s, want %s", got, tt.wantBody)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			t.Cleanup(srv.Close)
+
+			client := api.NewClient(api.Options{APIKey: "sk_test", BaseURL: srv.URL})
+			paywall, err := client.Paywalls.SetOffering(context.Background(), "proj", "pw", tt.offeringID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if paywall.OfferingID != tt.wantResult {
+				t.Fatalf("offering_id = %q, want %q", paywall.OfferingID, tt.wantResult)
+			}
+		})
 	}
 }
 

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -68,6 +68,8 @@ URL, get the user's approval, then rc paywalls publish.`,
 		newPaywallsRewindCmd(),
 		newPaywallsPublishCmd(),
 		newPaywallsUnpublishCmd(),
+		newPaywallsAttachCmd(),
+		newPaywallsDetachCmd(),
 		newPaywallsDeleteCmd(),
 	)
 	return cmd
@@ -208,6 +210,113 @@ Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`
 	}
 }
 
+func newPaywallsAttachCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "attach [paywall-id] [offering-id]",
+		Short: "Attach a Paywall to an Offering",
+		Long: `Attaches a paywall to an offering, or moves it from its current offering.
+
+An offering holds one paywall: attach fails if the target offering already
+has one — detach that one first. Attaching a published paywall makes it live
+for the offering immediately.
+
+Confirmation: prompts under TTY when the paywall is published; pass --yes to
+skip. Required under --no-input.`,
+		Example: `  rc paywalls attach pw_abc ofrng_default
+  rc paywalls attach pw_abc ofrng_default --yes --no-input --json`,
+		Args: cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rt := RuntimeFrom(cmd.Context())
+			projectID, err := requireProject(rt)
+			if err != nil {
+				return err
+			}
+			client, err := rt.API()
+			if err != nil {
+				return err
+			}
+			paywallID, err := requireID(rt, argAt(args, 0), "paywall", func() ([]PickerItem, error) {
+				return paywallPickerItems(cmd.Context(), client, projectID)
+			})
+			if err != nil {
+				return err
+			}
+			offeringID, err := requireID(rt, argAt(args, 1), "offering", func() ([]PickerItem, error) {
+				return offeringPickerItems(cmd.Context(), client, projectID)
+			})
+			if err != nil {
+				return err
+			}
+			paywall, err := client.Paywalls.Get(cmd.Context(), projectID, paywallID)
+			if err != nil {
+				return err
+			}
+			if paywall.PublishedAt != nil {
+				if err := confirmOrAbort(rt, fmt.Sprintf("Paywall %s is published — attaching makes it live for offering %s. Attach now?", paywallID, offeringID)); err != nil {
+					return err
+				}
+			}
+			paywall, err = client.Paywalls.SetOffering(cmd.Context(), projectID, paywallID, &offeringID)
+			if err != nil {
+				var apiErr *api.APIError
+				if errors.As(err, &apiErr) && apiErr.Status == 409 && apiErr.Type == "resource_already_exists" {
+					return WithHint(
+						fmt.Errorf("attaching paywall %s: offering %s already has a paywall (an offering can only have one): %w", paywallID, offeringID, err),
+						"Find the offering's current paywall with rc paywalls list, detach it (rc paywalls detach <paywall-id>), or attach to a different offering. Do NOT delete the existing paywall to clear the way: deletion is irreversible and it may be someone else's in-progress work.",
+					)
+				}
+				return err
+			}
+			rt.Out.Success(fmt.Sprintf("Attached %s to %s", paywall.ID, offeringID))
+			return rt.Out.Render(paywall)
+		},
+	}
+}
+
+func newPaywallsDetachCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "detach [paywall-id]",
+		Short: "Detach a Paywall from its Offering",
+		Long: `Detaches a paywall from its offering, leaving it as a standalone draft and
+freeing the offering for another paywall.
+
+A published paywall cannot be detached — unpublish it first.`,
+		Example: `  rc paywalls detach pw_abc
+  rc paywalls detach pw_abc --no-input --json`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rt := RuntimeFrom(cmd.Context())
+			projectID, err := requireProject(rt)
+			if err != nil {
+				return err
+			}
+			client, err := rt.API()
+			if err != nil {
+				return err
+			}
+			paywallID, err := requireID(rt, argAt(args, 0), "paywall", func() ([]PickerItem, error) {
+				return paywallPickerItems(cmd.Context(), client, projectID)
+			})
+			if err != nil {
+				return err
+			}
+			paywall, err := client.Paywalls.SetOffering(cmd.Context(), projectID, paywallID, nil)
+			if err != nil {
+				var apiErr *api.APIError
+				if errors.As(err, &apiErr) && apiErr.Status == 422 && apiErr.Type == "parameter_error" {
+					return WithHint(
+						fmt.Errorf("detaching offering from paywall %s: %w", paywallID, err),
+						"A published paywall keeps its offering. Unpublish it first (rc paywalls unpublish "+paywallID+"), then re-run rc paywalls detach "+paywallID+".",
+					)
+				}
+				return err
+			}
+			rt.Out.Success(fmt.Sprintf("Detached %s from its offering", paywall.ID))
+			return rt.Out.Render(paywall)
+		},
+	}
+}
+
 func paywallPickerItems(ctx context.Context, client *api.Client, projectID string) ([]PickerItem, error) {
 	page, err := client.Paywalls.List(ctx, projectID)
 	if err != nil {
@@ -324,12 +433,12 @@ Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`
 				case paywall.PublishedAt != nil:
 					return WithHint(
 						fmt.Errorf("paywall %s is published — customers may be seeing it", pickedID),
-						"Deletion is irreversible. Unpublish it first (rc paywalls unpublish "+pickedID+") and detach it from its offering in the dashboard, or re-run with --force after the user explicitly confirms this paywall should be destroyed.",
+						"Deletion is irreversible. Unpublish it first (rc paywalls unpublish "+pickedID+"), then detach it (rc paywalls detach "+pickedID+") if you only need to free the offering, or re-run with --force after the user explicitly confirms this paywall should be destroyed.",
 					)
 				case paywall.OfferingID != "":
 					return WithHint(
 						fmt.Errorf("paywall %s is attached to offering %s and may be someone's in-progress work", pickedID, paywall.OfferingID),
-						"Deletion is irreversible. Re-run with --force only after the user explicitly confirms this paywall should be destroyed. To free the offering for a new design instead, generate a standalone draft (rc paywalls generate without --offering-id) and attach it in the dashboard.",
+						"Deletion is irreversible. Re-run with --force only after the user explicitly confirms this paywall should be destroyed. To free the offering instead, detach this paywall (rc paywalls detach "+pickedID+") — it stays as a standalone draft.",
 					)
 				}
 			}

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -268,6 +268,9 @@ skip. Required under --no-input.`,
 				return err
 			}
 			rt.Out.Success(fmt.Sprintf("Attached %s to %s", paywall.ID, offeringID))
+			if paywall.PublishedAt != nil {
+				rt.Out.Hint("Apps may not pick this up until the next publish — run rc paywalls publish " + paywall.ID + ".")
+			}
 			return rt.Out.Render(paywall)
 		},
 	}

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -217,8 +217,8 @@ func newPaywallsAttachCmd() *cobra.Command {
 		Long: `Attaches a paywall to an offering, or moves it from its current offering.
 
 An offering holds one paywall: attach fails if the target offering already
-has one — detach that one first. Attaching a published paywall makes it live
-for the offering immediately.
+has one — detach that one first. Attaching a published paywall means it can
+be served to customers through that offering.
 
 Confirmation: prompts under TTY when the paywall is published; pass --yes to
 skip. Required under --no-input.`,
@@ -247,16 +247,20 @@ skip. Required under --no-input.`,
 			if err != nil {
 				return err
 			}
-			paywall, err := client.Paywalls.Get(cmd.Context(), projectID, paywallID)
+			paywall, err := client.Paywalls.GetWithComponents(cmd.Context(), projectID, paywallID)
 			if err != nil {
 				return err
 			}
 			if paywall.PublishedAt != nil {
-				if err := confirmOrAbort(rt, fmt.Sprintf("Paywall %s is published — attaching makes it live for offering %s. Attach now?", paywallID, offeringID)); err != nil {
+				prompt := fmt.Sprintf("Paywall %s is published — it will be served to customers through offering %s. Attach now?", paywallID, offeringID)
+				if paywall.OfferingID != "" && paywall.OfferingID != offeringID {
+					prompt = fmt.Sprintf("Paywall %s is published and served to customers through offering %s — moving it will serve it through %s instead. Move now?", paywallID, paywall.OfferingID, offeringID)
+				}
+				if err := confirmOrAbort(rt, prompt); err != nil {
 					return err
 				}
 			}
-			paywall, err = client.Paywalls.SetOffering(cmd.Context(), projectID, paywallID, &offeringID)
+			paywall, err = client.Paywalls.SetOffering(cmd.Context(), projectID, paywallID, paywallRevision(paywall), &offeringID)
 			if err != nil {
 				var apiErr *api.APIError
 				if errors.As(err, &apiErr) && apiErr.Status == 409 && apiErr.Type == "resource_already_exists" {
@@ -303,7 +307,11 @@ A published paywall cannot be detached — unpublish it first.`,
 			if err != nil {
 				return err
 			}
-			paywall, err := client.Paywalls.SetOffering(cmd.Context(), projectID, paywallID, nil)
+			paywall, err := client.Paywalls.GetWithComponents(cmd.Context(), projectID, paywallID)
+			if err != nil {
+				return err
+			}
+			paywall, err = client.Paywalls.SetOffering(cmd.Context(), projectID, paywallID, paywallRevision(paywall), nil)
 			if err != nil {
 				var apiErr *api.APIError
 				if errors.As(err, &apiErr) && apiErr.Status == 422 && apiErr.Type == "parameter_error" {
@@ -318,6 +326,18 @@ A published paywall cannot be detached — unpublish it first.`,
 			return rt.Out.Render(paywall)
 		},
 	}
+}
+
+func paywallRevision(paywall *api.Paywall) int {
+	if paywall.Components != nil {
+		if draft := paywall.Components.Draft; draft != nil && draft.Revision != nil {
+			return *draft.Revision
+		}
+		if published := paywall.Components.Published; published != nil && published.Revision != nil {
+			return *published.Revision
+		}
+	}
+	return 0
 }
 
 func paywallPickerItems(ctx context.Context, client *api.Client, projectID string) ([]PickerItem, error) {
@@ -404,8 +424,9 @@ func newPaywallsDeleteCmd() *cobra.Command {
 Reversibility: irreversible. Recreate the paywall if it is deleted.
 
 A paywall that is attached to an offering or published refuses to delete
-unless --force is passed — --yes alone is not enough. It may be live or
-someone else's in-progress work; get explicit consent from the user first.
+unless --force is passed — --yes alone is not enough. It may be serving
+customers or be someone else's in-progress work; get explicit consent from
+the user first.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
 		Example: `  rc paywalls delete pw_old --yes

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -188,7 +188,7 @@ screenshots via --image, audience via --context.`,
 				if opts.offeringID != "" && errors.As(err, &apiErr) && apiErr.Status == 409 {
 					return WithHint(
 						fmt.Errorf("creating draft paywall: offering %s already has a paywall (an offering can only have one): %w", opts.offeringID, err),
-						"omit --offering-id to generate a standalone draft and attach it in the dashboard later, or generate against another offering. Do NOT delete the existing paywall to clear the way: deletion is irreversible and it may be someone else's in-progress work — inspect it first (rc paywalls show <id>) and get explicit consent from the user before any rc paywalls delete.",
+						"omit --offering-id to generate a standalone draft and attach it later (rc paywalls attach <paywall-id> <offering-id>), or generate against another offering. To replace the offering's current paywall, detach it first (rc paywalls detach <its-paywall-id> — find it with rc paywalls list). Do NOT delete it: deletion is irreversible and it may be someone else's in-progress work — get explicit consent from the user before any rc paywalls delete.",
 					)
 				}
 				return fmt.Errorf("creating draft paywall: %w", err)
@@ -655,7 +655,7 @@ func finishPaywallAI(ctx context.Context, rt *Runtime, opts paywallAIOptions, se
 		rt.Out.Field("View it", paywallBuilderURL(session.ProjectID, session.PaywallID))
 		rt.Out.Field("Keep designing", "rc paywalls edit --session "+opts.sessionPath)
 		if session.Paywall.OfferingID == nil {
-			rt.Out.Field("Attach it", "dashboard → Paywalls → "+session.PaywallID+" → attach to an offering")
+			rt.Out.Field("Attach it", "rc paywalls attach "+session.PaywallID+" <offering-id>")
 		} else {
 			rt.Out.Field("Publish when ready", "rc paywalls publish "+session.PaywallID)
 		}

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -747,15 +747,7 @@ func currentDraftRevision(ctx context.Context, client *api.Client, projectID, pa
 	if err != nil {
 		return 0, err
 	}
-	if paywall.Components != nil {
-		if d := paywall.Components.Draft; d != nil && d.Revision != nil {
-			return *d.Revision, nil
-		}
-		if p := paywall.Components.Published; p != nil && p.Revision != nil {
-			return *p.Revision, nil
-		}
-	}
-	return 0, nil
+	return paywallRevision(paywall), nil
 }
 
 // reportPaywallAIActivity prints activity items not yet shown; snapshots carry

--- a/internal/cli/paywalls_attach_test.go
+++ b/internal/cli/paywalls_attach_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPaywallsAttachAndDetachSendCurrentRevision(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		offeringID any
+	}{
+		{
+			name:       "attach",
+			command:    "attach",
+			args:       []string{"pw_test", "ofrng_test"},
+			offeringID: "ofrng_test",
+		},
+		{
+			name:       "detach",
+			command:    "detach",
+			args:       []string{"pw_test"},
+			offeringID: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var patchBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.Method {
+				case http.MethodGet:
+					if r.URL.Query().Get("expand") != "components" {
+						t.Errorf("expand = %q, want components", r.URL.Query().Get("expand"))
+					}
+					_, _ = io.WriteString(w, `{"id":"pw_test","offering_id":null,"created_at":1,"published_at":null,"components":{"published":null,"draft":{"revision":7,"components_config":{},"components_localizations":{},"default_locale":"en_US"}}}`)
+				case http.MethodPatch:
+					if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
+						t.Fatal(err)
+					}
+					_, _ = io.WriteString(w, `{"id":"pw_test","offering_id":null,"created_at":1,"published_at":null}`)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			t.Setenv("RC_CONFIG_DIR", t.TempDir())
+			t.Setenv("RC_BASE_URL", server.URL)
+			root := NewRootCmd("test")
+			root.SetOut(io.Discard)
+			root.SetErr(&bytes.Buffer{})
+			args := append([]string{"paywalls", tt.command}, tt.args...)
+			args = append(args, "--no-input", "--api-key", "sk_test", "--project-id", "proj")
+			root.SetArgs(args)
+			if err := root.ExecuteContext(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+
+			if patchBody["revision"] != float64(7) {
+				t.Fatalf("revision = %v, want 7", patchBody["revision"])
+			}
+			if patchBody["offering_id"] != tt.offeringID {
+				t.Fatalf("offering_id = %v, want %v", patchBody["offering_id"], tt.offeringID)
+			}
+		})
+	}
+}

--- a/internal/cli/paywalls_attach_test.go
+++ b/internal/cli/paywalls_attach_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -72,5 +73,111 @@ func TestPaywallsAttachAndDetachSendCurrentRevision(t *testing.T) {
 				t.Fatalf("offering_id = %v, want %v", patchBody["offering_id"], tt.offeringID)
 			}
 		})
+	}
+}
+
+func TestPaywallsAttachAndDetachHintOnAPIError(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		patchStatus int
+		patchBody   string
+		wantErr     string
+		wantHint    string
+	}{
+		{
+			name:        "attach 409 offering already has a paywall",
+			args:        []string{"attach", "pw_test", "ofrng_test"},
+			patchStatus: http.StatusConflict,
+			patchBody:   `{"type":"resource_already_exists","message":"There is already a paywall for offering ofrng_test"}`,
+			wantErr:     "offering ofrng_test already has a paywall",
+			wantHint:    "rc paywalls detach",
+		},
+		{
+			name:        "detach 422 published paywall",
+			args:        []string{"detach", "pw_test"},
+			patchStatus: http.StatusUnprocessableEntity,
+			patchBody:   `{"type":"parameter_error","message":"offering_id cannot be removed from a published paywall"}`,
+			wantErr:     "detaching offering from paywall pw_test",
+			wantHint:    "rc paywalls unpublish pw_test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.Method {
+				case http.MethodGet:
+					_, _ = io.WriteString(w, `{"id":"pw_test","offering_id":null,"created_at":1,"published_at":null,"components":{"published":null,"draft":{"revision":7}}}`)
+				case http.MethodPatch:
+					w.WriteHeader(tt.patchStatus)
+					_, _ = io.WriteString(w, tt.patchBody)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			t.Setenv("RC_CONFIG_DIR", t.TempDir())
+			t.Setenv("RC_BASE_URL", server.URL)
+			root := NewRootCmd("test")
+			root.SetOut(io.Discard)
+			root.SetErr(&bytes.Buffer{})
+			root.SetArgs(append([]string{"paywalls"}, append(tt.args, "--no-input", "--api-key", "sk_test", "--project-id", "proj")...))
+			err := root.ExecuteContext(context.Background())
+			if err == nil {
+				t.Fatal("want error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", err, tt.wantErr)
+			}
+			if hint := hintFor(err); !strings.Contains(hint, tt.wantHint) {
+				t.Fatalf("hint = %q, want it to contain %q", hint, tt.wantHint)
+			}
+		})
+	}
+}
+
+func TestPaywallsAttachPublishedRequiresConfirmation(t *testing.T) {
+	var patches int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `{"id":"pw_test","offering_id":null,"created_at":1,"published_at":1700000000000,"components":{"published":null,"draft":{"revision":7}}}`)
+		case http.MethodPatch:
+			patches++
+			_, _ = io.WriteString(w, `{"id":"pw_test","offering_id":"ofrng_test","created_at":1,"published_at":1700000000000}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	t.Setenv("RC_BASE_URL", server.URL)
+
+	attach := func(extra ...string) error {
+		root := NewRootCmd("test")
+		root.SetOut(io.Discard)
+		root.SetErr(&bytes.Buffer{})
+		args := []string{"paywalls", "attach", "pw_test", "ofrng_test", "--no-input", "--api-key", "sk_test", "--project-id", "proj"}
+		root.SetArgs(append(args, extra...))
+		return root.ExecuteContext(context.Background())
+	}
+
+	if err := attach(); err == nil {
+		t.Fatal("attaching a published paywall under --no-input without --yes should fail")
+	}
+	if patches != 0 {
+		t.Fatalf("refusal must not issue PATCH, got %d", patches)
+	}
+
+	if err := attach("--yes"); err != nil {
+		t.Fatalf("--yes should attach published paywall: %v", err)
+	}
+	if patches != 1 {
+		t.Fatalf("PATCH count = %d, want 1", patches)
 	}
 }


### PR DESCRIPTION
Adds `rc paywalls attach <paywall-id> <offering-id>` and `rc paywalls detach <paywall-id>` so users can link or unlink paywalls from offerings without going to the dashboard.

Depends on https://github.com/RevenueCat/khepri/pull/23893

Closes PWAI-351.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect which paywall customers see when offerings are linked or moved; published-paywall confirmations and detach/unpublish rules limit accidental live impact.
> 
> **Overview**
> Adds **`rc paywalls attach`** and **`rc paywalls detach`** so paywalls can be linked to or unlinked from offerings from the CLI instead of the dashboard.
> 
> The API client gains **`SetOffering`** (PATCH with `revision` and `offering_id`). Attach/move uses the current draft revision from expanded components, prompts when the paywall is **published** (or `--yes` / `--no-input`), and surfaces hints on **409** (offering already has a paywall) and related cases. Detach clears `offering_id` and hints to unpublish first on **422** for published paywalls.
> 
> Docs/README list the new commands; AI generate/edit hints and delete guidance now point to attach/detach instead of dashboard-only flows. **`paywallRevision`** is shared for attach/detach and AI draft persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b8d8d5e2f2b68722f346903e9935ea0c557a65d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->