### PR TITLE
fix(cli): apple setup key creation is non-fatal and explains Apple's key limits

### DIFF
--- a/internal/cli/apps_apple.go
+++ b/internal/cli/apps_apple.go
@@ -29,6 +29,7 @@ type appleConfigurationResult struct {
 	InAppPurchaseKeyID       string   `json:"in_app_purchase_key_id,omitempty"`
 	AppStoreConnectAPIKeyID  string   `json:"app_store_connect_api_key_id,omitempty"`
 	VendorNumberConfigured   bool     `json:"vendor_number_configured"`
+	Failed                   []string `json:"failed_keys,omitempty"`
 }
 
 type appleConnectClient interface {
@@ -108,6 +109,60 @@ func createAppStoreAppRecord(ctx context.Context, rt *Runtime, apple appleConnec
 	}
 	rt.Out.Success("Created App Store Connect app " + name + " (" + bundleID + ")")
 	return nil
+}
+
+// A nil key field means it was not requested or Apple refused it; Failed lists the refusals.
+type createdAppleKeys struct {
+	InAppPurchaseKey   *appleconnect.Key
+	AppStoreConnectKey *appleconnect.Key
+	Failed             []string
+}
+
+// One source for both labels so the card and the Failed list can't desync.
+const (
+	inAppKeyLabel = "in-app purchase key"
+	ascKeyLabel   = "App Store Connect API key"
+)
+
+func createAppleKeys(ctx context.Context, rt *Runtime, apple appleConnectClient, session *appleconnect.Session, createInApp, createAPI bool, inAppKeyName, apiKeyName string) createdAppleKeys {
+	var keys createdAppleKeys
+	if createInApp {
+		rt.Out.Info("Creating in-app purchase key in App Store Connect…")
+		key, err := apple.CreateInAppPurchaseKey(ctx, session, inAppKeyName)
+		switch {
+		case err != nil:
+			rt.Out.Warn("Could not create the " + inAppKeyLabel + ": " + err.Error())
+			appleKeyHint(rt, err, appleconnect.InAppPurchaseKey)
+			keys.Failed = append(keys.Failed, inAppKeyLabel)
+		default:
+			rt.Out.Success(fmt.Sprintf("Created in-app purchase key %s (%q) in App Store Connect", key.ID, inAppKeyName))
+			keys.InAppPurchaseKey = key
+		}
+	}
+	if createAPI {
+		rt.Out.Info("Creating App Store Connect API key…")
+		key, err := apple.CreateAppStoreConnectKey(ctx, session, apiKeyName)
+		switch {
+		case err != nil:
+			rt.Out.Warn("Could not create the " + ascKeyLabel + ": " + err.Error())
+			appleKeyHint(rt, err, appleconnect.AppStoreConnectKey)
+			keys.Failed = append(keys.Failed, ascKeyLabel)
+		default:
+			rt.Out.Success(fmt.Sprintf("Created App Store Connect API key %s (%q)", key.ID, apiKeyName))
+			keys.AppStoreConnectKey = key
+		}
+	}
+	return keys
+}
+
+func appleKeyHint(rt *Runtime, err error, kind appleconnect.KeyKind) {
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "maximum number of active keys") || strings.Contains(msg, "revoke"):
+		rt.Out.Hint("You're at Apple's limit of active keys. Revoke an unused one in App Store Connect (Users and Access → Integrations) and re-run — or reuse a key you already set up for another app (Apple keys are account-level).")
+	case kind == appleconnect.InAppPurchaseKey && (strings.Contains(msg, "does not allow") || strings.Contains(msg, "forbidden")):
+		rt.Out.Hint("Apple wouldn't create the In-App Purchase key. It usually already exists (Apple allows one per account) or your Apple Account isn't the Account Holder — reuse the existing key or sign in as the Account Holder.")
+	}
 }
 
 func warnAppRecordFailed(rt *Runtime, bundleID string, err error) {
@@ -425,6 +480,7 @@ func newAppsAppleWorkflowCmd(checkOnly bool, factory appleConnectFactory) *cobra
 				result.Mode = "check"
 			}
 			createdIDs := make([]string, 0, 2)
+			var failedKeys []string
 			if needsApple {
 				apple, err := factory()
 				if err != nil {
@@ -580,26 +636,16 @@ func newAppsAppleWorkflowCmd(checkOnly bool, factory appleConnectFactory) *cobra
 					}
 				}
 
-				if createInAppKey {
-					rt.Out.Info("Creating in-app purchase key in App Store Connect…")
-					key, err := apple.CreateInAppPurchaseKey(cmd.Context(), session, inAppKeyName)
-					if err != nil {
-						return appleConfigurationError(err, createdIDs)
-					}
-					rt.Out.Success(fmt.Sprintf("Created in-app purchase key %s (%q) in App Store Connect", key.ID, inAppKeyName))
+				keys := createAppleKeys(cmd.Context(), rt, apple, session, createInAppKey, createAPIKey, inAppKeyName, apiKeyName)
+				failedKeys = keys.Failed
+				if key := keys.InAppPurchaseKey; key != nil {
 					createdIDs = append(createdIDs, string(key.Kind)+":"+key.ID)
 					result.InAppPurchaseKeyID = key.ID
 					update.AppStore.SubscriptionPrivateKey = &key.PrivateKey
 					update.AppStore.SubscriptionKeyID = &key.ID
 					update.AppStore.SubscriptionKeyIssuer = &key.IssuerID
 				}
-				if createAPIKey {
-					rt.Out.Info("Creating App Store Connect API key…")
-					key, err := apple.CreateAppStoreConnectKey(cmd.Context(), session, apiKeyName)
-					if err != nil {
-						return appleConfigurationError(err, createdIDs)
-					}
-					rt.Out.Success(fmt.Sprintf("Created App Store Connect API key %s (%q)", key.ID, apiKeyName))
+				if key := keys.AppStoreConnectKey; key != nil {
 					createdIDs = append(createdIDs, string(key.Kind)+":"+key.ID)
 					result.AppStoreConnectAPIKeyID = key.ID
 					update.AppStore.AppStoreConnectAPIKey = &key.PrivateKey
@@ -620,12 +666,22 @@ func newAppsAppleWorkflowCmd(checkOnly bool, factory appleConnectFactory) *cobra
 				rt.Out.Info("No RevenueCat changes to upload.")
 			}
 			result.VendorNumberConfigured = vendorNumber != ""
-			rt.Out.Success("Apple credentials configured")
+			result.Failed = failedKeys
+			if len(failedKeys) > 0 {
+				rt.Out.Warn("Partly done: couldn't create the " + strings.Join(failedKeys, " and the ") + ". Everything that succeeded was saved to RevenueCat — resolve the note above and re-run to finish.")
+			} else {
+				rt.Out.Success("Apple credentials configured")
+			}
 			subtitle := ""
 			if result.ProviderName != "" {
 				subtitle = fmt.Sprintf("App Store Connect team %s (%d)", result.ProviderName, result.ProviderID)
 			}
-			keptOrCreated := func(id string) string {
+			keptOrCreated := func(id, label string) string {
+				for _, f := range failedKeys {
+					if f == label {
+						return "not created — see note above"
+					}
+				}
 				if id == "" {
 					return "kept existing"
 				}
@@ -635,19 +691,27 @@ func newAppsAppleWorkflowCmd(checkOnly bool, factory appleConnectFactory) *cobra
 			if vendorNumber != "" {
 				vendorLine = vendorNumber
 			}
-			return rt.Out.RenderCard(output.Card{
+			if err := rt.Out.RenderCard(output.Card{
 				Title:    fmt.Sprintf("%s (%s)", app.Name, appID),
 				Subtitle: subtitle,
 				Sections: []output.CardSection{{
 					Heading: "Configured",
 					Lines: []output.CardLine{
-						{Key: "In-app purchase key", Value: keptOrCreated(result.InAppPurchaseKeyID)},
-						{Key: "App Store Connect API key", Value: keptOrCreated(result.AppStoreConnectAPIKeyID)},
+						{Key: "In-app purchase key", Value: keptOrCreated(result.InAppPurchaseKeyID, inAppKeyLabel)},
+						{Key: "App Store Connect API key", Value: keptOrCreated(result.AppStoreConnectAPIKeyID, ascKeyLabel)},
 						{Key: "Vendor number", Value: vendorLine},
 					},
 				}},
 				Raw: result,
-			})
+			}); err != nil {
+				return err
+			}
+			// Partial progress is saved, but a refused key still means the run
+			// didn't do what was asked — exit non-zero so scripts don't see success.
+			if len(failedKeys) > 0 {
+				return &SilentExitError{Code: 1}
+			}
+			return nil
 		},
 	}
 	cmd.Flags().StringVar(&appleID, "apple-id", "", "Apple Account email (env: RC_APPLE_ID)")

--- a/internal/cli/apps_apple_test.go
+++ b/internal/cli/apps_apple_test.go
@@ -152,6 +152,163 @@ func (f *fakeAppleCheckClient) CreateApp(context.Context, *appleconnect.Session,
 	return errors.New("unexpected App Store Connect app creation")
 }
 
+type fakeAppleSetupClient struct {
+	fakeAppleCheckClient
+	inApp          func() (*appleconnect.Key, error)
+	api            func() (*appleconnect.Key, error)
+	registerErr    error
+	createErr      error
+	registerCalled bool
+	createCalled   bool
+}
+
+func (f *fakeAppleSetupClient) CreateInAppPurchaseKey(context.Context, *appleconnect.Session, string) (*appleconnect.Key, error) {
+	return f.inApp()
+}
+
+func (f *fakeAppleSetupClient) CreateAppStoreConnectKey(context.Context, *appleconnect.Session, string) (*appleconnect.Key, error) {
+	return f.api()
+}
+
+func (f *fakeAppleSetupClient) RegisterBundleID(context.Context, *appleconnect.Session, string, string) error {
+	f.registerCalled = true
+	return f.registerErr
+}
+
+func (f *fakeAppleSetupClient) CreateApp(context.Context, *appleconnect.Session, string, string, string) error {
+	f.createCalled = true
+	return f.createErr
+}
+
+func TestCreateAppleKeys_NonFatalOnOneFailure(t *testing.T) {
+	inAppKey := &appleconnect.Key{Kind: appleconnect.InAppPurchaseKey, ID: "iap1", IssuerID: "iss", PrivateKey: "iap-pem"}
+	apiKey := &appleconnect.Key{Kind: appleconnect.AppStoreConnectKey, ID: "asc1", IssuerID: "iss", PrivateKey: "asc-pem"}
+	maxKeys := errors.New("You've reached the maximum number of active keys allowed. To generate a new key, revoke an existing one.")
+	forbidden := errors.New("403 FORBIDDEN_ERROR: The API key in use does not allow this request")
+
+	tests := []struct {
+		name       string
+		inApp      func() (*appleconnect.Key, error)
+		api        func() (*appleconnect.Key, error)
+		wantInApp  *appleconnect.Key
+		wantAPI    *appleconnect.Key
+		wantFailed []string
+		wantHint   string
+	}{
+		{
+			name:       "in-app fails, ASC succeeds",
+			inApp:      func() (*appleconnect.Key, error) { return nil, forbidden },
+			api:        func() (*appleconnect.Key, error) { return apiKey, nil },
+			wantAPI:    apiKey,
+			wantFailed: []string{"in-app purchase key"},
+			wantHint:   "already exists",
+		},
+		{
+			name:       "ASC fails, in-app succeeds",
+			inApp:      func() (*appleconnect.Key, error) { return inAppKey, nil },
+			api:        func() (*appleconnect.Key, error) { return nil, maxKeys },
+			wantInApp:  inAppKey,
+			wantFailed: []string{"App Store Connect API key"},
+			wantHint:   "limit of active keys",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apple := &fakeAppleSetupClient{inApp: tt.inApp, api: tt.api}
+			var stdout, stderr bytes.Buffer
+			rt := &Runtime{
+				Globals: &Globals{NoInput: true, Version: "test"},
+				Out:     output.NewRenderer(&stdout, &stderr, false, false, false, ""),
+			}
+			keys := createAppleKeys(context.Background(), rt, apple, &appleconnect.Session{}, true, true, "in-app", "api")
+
+			if keys.InAppPurchaseKey != tt.wantInApp {
+				t.Errorf("InAppPurchaseKey = %v, want %v", keys.InAppPurchaseKey, tt.wantInApp)
+			}
+			if keys.AppStoreConnectKey != tt.wantAPI {
+				t.Errorf("AppStoreConnectKey = %v, want %v", keys.AppStoreConnectKey, tt.wantAPI)
+			}
+			if !equalStrings(keys.Failed, tt.wantFailed) {
+				t.Errorf("Failed = %v, want %v", keys.Failed, tt.wantFailed)
+			}
+			if !strings.Contains(stderr.String(), tt.wantHint) {
+				t.Errorf("stderr missing hint %q:\n%s", tt.wantHint, stderr.String())
+			}
+		})
+	}
+}
+
+func TestAppsAppleSetup_PartialFailureExitsNonZeroAndReportsFailedKey(t *testing.T) {
+	inAppKey := &appleconnect.Key{Kind: appleconnect.InAppPurchaseKey, ID: "iap1", IssuerID: "iss", PrivateKey: "iap-pem"}
+	maxKeys := errors.New("You've reached the maximum number of active keys allowed.")
+
+	var patched bool
+	revenueCat := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/projects/proj/apps/app" {
+			if r.Method == http.MethodPost {
+				patched = true
+			}
+			_, _ = io.WriteString(w, `{"id":"app","name":"iOS","type":"app_store","created_at":1,"app_store":{"bundle_id":"com.example.app","subscription_key_configured":false,"app_store_connect_api_key_configured":false}}`)
+			return
+		}
+		http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+	}))
+	t.Cleanup(revenueCat.Close)
+
+	apple := &fakeAppleSetupClient{
+		inApp: func() (*appleconnect.Key, error) { return inAppKey, nil },
+		api:   func() (*appleconnect.Key, error) { return nil, maxKeys },
+	}
+	var stdout, stderr bytes.Buffer
+	rt := &Runtime{
+		Globals: &Globals{JSON: true, NoInput: true, AssumeYes: true, Version: "test"},
+		Config:  &config.Config{APIKey: "sk_test", ProjectID: "proj", BaseURL: revenueCat.URL},
+		Ctx:     context.Background(),
+		Out:     output.NewRenderer(&stdout, &stderr, true, true, false, ""),
+		client:  api.NewClient(api.Options{APIKey: "sk_test", BaseURL: revenueCat.URL}),
+	}
+	cmd := newAppsAppleCmdWithFactory(func() (appleConnectClient, error) { return apple, nil })
+	// Without this, cobra appends usage text to stdout on the non-zero return.
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetContext(WithRuntime(context.Background(), rt))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"setup", "app",
+		"--apple-id", "dev@example.com",
+		"--apple-password", "secret",
+		"--verification-code", "123456",
+	})
+
+	err := cmd.Execute()
+	var exit *SilentExitError
+	if !errors.As(err, &exit) || exit.Code == 0 {
+		t.Fatalf("execute err = %v, want SilentExitError with non-zero code\nstderr: %s", err, stderr.String())
+	}
+	if !patched {
+		t.Error("expected the in-app key that succeeded to be saved to RevenueCat (no PATCH seen)")
+	}
+
+	var out struct {
+		Data struct {
+			InAppPurchaseKeyID string   `json:"in_app_purchase_key_id"`
+			Failed             []string `json:"failed_keys"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	if out.Data.InAppPurchaseKeyID != "iap1" {
+		t.Errorf("in_app_purchase_key_id = %q, want the saved key iap1", out.Data.InAppPurchaseKeyID)
+	}
+	if !equalStrings(out.Data.Failed, []string{ascKeyLabel}) {
+		t.Errorf("failed_keys = %v, want [%q]", out.Data.Failed, ascKeyLabel)
+	}
+}
+
 func TestCreateAppStoreAppRecord_NonFatalOnAppleFailure(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -198,24 +355,6 @@ func TestCreateAppStoreAppRecord_NonFatalOnAppleFailure(t *testing.T) {
 			}
 		})
 	}
-}
-
-type fakeAppleSetupClient struct {
-	fakeAppleCheckClient
-	registerErr    error
-	createErr      error
-	registerCalled bool
-	createCalled   bool
-}
-
-func (f *fakeAppleSetupClient) RegisterBundleID(context.Context, *appleconnect.Session, string, string) error {
-	f.registerCalled = true
-	return f.registerErr
-}
-
-func (f *fakeAppleSetupClient) CreateApp(context.Context, *appleconnect.Session, string, string, string) error {
-	f.createCalled = true
-	return f.createErr
 }
 
 func equalStrings(left, right []string) bool {


### PR DESCRIPTION
When `rc apps apple setup` failed to create an Apple key it aborted the whole run — so a failed in-app purchase key meant you never got the App Store Connect API key (the exact "I just wanted the ASC key" case). Now a failed key warns with an actionable hint, and the run continues to the other key and saves whatever succeeded.

The two Apple failures we actually see get real guidance instead of the raw error:
- **Active-key limit** ("maximum number of active keys… revoke one") → revoke an unused key in App Store Connect, or reuse one from another app (Apple keys are account-level).
- **In-app key forbidden** → it usually already exists (one per account) or you're not the Account Holder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Apple credential upload behavior and CLI exit semantics on partial failure; successful keys are still persisted, but automation must handle non-zero exit when `failed_keys` is set.
> 
> **Overview**
> **`rc apps apple setup` no longer aborts when one Apple key fails.** In-app purchase and App Store Connect API keys are created via `createAppleKeys`, which warns on refusal, prints actionable hints (active-key limit, in-app key forbidden / Account Holder), and still attempts the other key.
> 
> Successful keys and vendor settings are saved to RevenueCat as before. JSON output adds `failed_keys`; the summary card shows **not created — see note above** for refused keys. The command exits non-zero via `SilentExitError` when any requested key failed so scripts don't treat partial setup as success.
> 
> Tests cover one-key failure paths and the partial-failure setup flow (save + non-zero exit + `failed_keys`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35500adc8fde5fad7e017aaa7e6f0b090aacb58c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->