### PR TITLE
feat(auth): name the active credential's source in auth status

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -388,7 +388,7 @@ Shows which credential is in control (the OAuth login, an RC_API_KEY env var, th
 				conflict = map[string]any{
 					"active_source":   string(credSource),
 					"ignored_sources": ignored,
-					"message":         credentialConflictMessage(credSource, present),
+					"message":         credentialConflictMessage(rt.Config, credSource, present),
 				}
 			}
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -311,6 +311,7 @@ To remove the profile entirely, use: rc profiles delete <name>`,
 			rt.Config.TokenType = ""
 			rt.Config.AccountEmail = ""
 			rt.Config.AccountName = ""
+			rt.Config.AuthSource = ""
 			rt.Config.ProjectID = ""
 
 			if err := config.Save(rt.Globals.Profile, rt.Config); err != nil {
@@ -413,7 +414,10 @@ Shows which credential is in control (the OAuth login, an RC_API_KEY env var, th
 				rt.Out.Success(fmt.Sprintf("Logged in (profile: %s)", profileName))
 			}
 			if authenticated {
-				rt.Out.Field("Credential", credSource.Describe())
+				rt.Out.Field("Credential", rt.Config.CredentialDescription())
+				if credSource == config.SourceOAuth {
+					writeTokenStatus(rt)
+				}
 			}
 			if conflict != nil {
 				rt.warnCredentialConflict(credSource)
@@ -436,15 +440,26 @@ Shows which credential is in control (the OAuth login, an RC_API_KEY env var, th
 				return nil
 			}
 			out := map[string]any{
-				"profile":           profileName,
-				"authenticated":     authenticated,
-				"account_email":     rt.Config.AccountEmail,
-				"account_name":      rt.Config.AccountName,
-				"method":            method,
-				"credential_source": string(credSource),
-				"project_id":        rt.Config.ProjectID,
-				"project_status":    projectStatus,
-				"base_url":          rt.Config.BaseURL,
+				"profile":                profileName,
+				"authenticated":          authenticated,
+				"account_email":          rt.Config.AccountEmail,
+				"account_name":           rt.Config.AccountName,
+				"method":                 method,
+				"credential_source":      string(credSource),
+				"credential_description": rt.Config.CredentialDescription(),
+				"project_id":             rt.Config.ProjectID,
+				"project_status":         projectStatus,
+				"base_url":               rt.Config.BaseURL,
+			}
+			if authenticated && rt.Config.AuthSource != "" {
+				out["auth_origin"] = rt.Config.AuthSource
+			}
+			if credSource == config.SourceOAuth {
+				out["token_status"] = rt.Config.TokenStatus()
+				out["token_can_refresh"] = rt.Config.CanAutoRefresh()
+				if !rt.Config.TokenExpiresAt.IsZero() {
+					out["token_expires_at"] = rt.Config.TokenExpiresAt.Format(time.RFC3339)
+				}
 			}
 			if conflict != nil {
 				out["credential_conflict"] = conflict
@@ -462,6 +477,29 @@ Shows which credential is in control (the OAuth login, an RC_API_KEY env var, th
 	}
 	cmd.Flags().BoolVar(&showScopes, "scopes", false, "show the active credential's scopes (when determinable)")
 	return cmd
+}
+
+func writeTokenStatus(rt *Runtime) {
+	when := rt.Config.TokenExpiresAt.Local().Format("2006-01-02 15:04")
+	canRefresh := rt.Config.CanAutoRefresh()
+	switch rt.Config.TokenStatus() {
+	case config.TokenValid:
+		rt.Out.Field("Token", "valid until "+when)
+	case config.TokenNearExpiry:
+		if canRefresh {
+			rt.Out.Field("Token", "expires "+when+" (refreshes automatically)")
+		} else {
+			rt.Out.Warn("Token expires " + when + " and can't auto-refresh; run `rc login`")
+		}
+	case config.TokenExpired:
+		if canRefresh {
+			rt.Out.Field("Token", "expired "+when+" (refreshes on next use)")
+		} else {
+			rt.Out.Warn("Token expired " + when + "; run `rc login` to re-authenticate")
+		}
+	default:
+		rt.Out.Field("Token", "expiry unknown")
+	}
 }
 
 // credentialScopes best-effort reports the scopes of the active credential.
@@ -526,7 +564,12 @@ func loginWithAPIKeyInteractive(ctx context.Context, rt *Runtime) error {
 }
 
 func loginWithAPIKey(ctx context.Context, rt *Runtime, key string) error {
+	return loginWithAPIKeyOrigin(ctx, rt, key, config.AuthOriginAPIKey)
+}
+
+func loginWithAPIKeyOrigin(ctx context.Context, rt *Runtime, key, origin string) error {
 	rt.Config.SetAPIKey(key)
+	rt.Config.AuthSource = origin
 	rt.Config.TokenType = ""
 	rt.Config.AccessToken = ""
 	rt.Config.RefreshToken = ""
@@ -642,6 +685,7 @@ func loginWithOAuth(ctx context.Context, rt *Runtime) error {
 	rt.Config.RefreshToken = tr.RefreshToken
 	rt.Config.TokenExpiresAt = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
 	rt.Config.APIKey = ""
+	rt.Config.AuthSource = config.AuthOriginOAuthLogin
 	clearProjectBinding(rt)
 
 	rt.client = nil
@@ -713,6 +757,7 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 	rt.Config.APIKey = ""
 	rt.Config.AccountEmail = email
 	rt.Config.AccountName = name
+	rt.Config.AuthSource = config.AuthOriginOAuthLogin
 	clearProjectBinding(rt)
 	rt.client = nil
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -451,7 +451,10 @@ Shows which credential is in control (the OAuth login, an RC_API_KEY env var, th
 				"project_status":         projectStatus,
 				"base_url":               rt.Config.BaseURL,
 			}
-			if authenticated && rt.Config.AuthSource != "" {
+			// Only report auth_origin when the stored credential is the active
+			// one; under a flag/env override it's the wrong credential's origin.
+			if authenticated && rt.Config.AuthSource != "" &&
+				(credSource == config.SourceOAuth || credSource == config.SourceProfile) {
 				out["auth_origin"] = rt.Config.AuthSource
 			}
 			if credSource == config.SourceOAuth {

--- a/internal/cli/auth_mcp_import.go
+++ b/internal/cli/auth_mcp_import.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/revenuecat/cli/internal/config"
 )
 
 // Importing an existing RevenueCat MCP credential lets a dev who already has
@@ -138,11 +140,12 @@ func (c mcpCredential) label() string {
 // call, and we translate it into a browser-login nudge.
 func loginWithMCPCredential(ctx context.Context, rt *Runtime, cred mcpCredential) error {
 	if cred.durable {
-		return loginWithAPIKey(ctx, rt, cred.Token)
+		return loginWithAPIKeyOrigin(ctx, rt, cred.Token, config.AuthOriginMCPImport)
 	}
 	rt.Config.APIKey = ""
 	rt.Config.TokenType = "oauth"
 	rt.Config.AccessToken = cred.Token
+	rt.Config.AuthSource = config.AuthOriginMCPImport
 	// No refresh token and no expiry on purpose: this is a borrowed access
 	// token. Empty RefreshToken makes Config.NeedsRefresh() return false, so
 	// rc never tries (and never could) to refresh it — which also means it

--- a/internal/cli/auth_status_test.go
+++ b/internal/cli/auth_status_test.go
@@ -1,0 +1,166 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/revenuecat/cli/internal/cli"
+	"github.com/revenuecat/cli/internal/config"
+)
+
+func seedProfile(t *testing.T, dir string, cfg *config.Config) {
+	t.Helper()
+	t.Setenv("RC_CONFIG_DIR", dir)
+	t.Setenv("RC_PROFILE", "")
+	if err := config.Save("", cfg); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+}
+
+// statusData runs `auth status --json` in dir; no project is configured, so
+// status makes no network call.
+func statusData(t *testing.T, dir string, extraArgs ...string) map[string]any {
+	t.Helper()
+	t.Setenv("RC_CONFIG_DIR", dir)
+	t.Setenv("RC_PROFILE", "")
+	t.Setenv("RC_PROJECT_ID", "")
+	t.Setenv("RC_BASE_URL", "")
+
+	args := append([]string{"auth", "status", "--json", "--no-input"}, extraArgs...)
+	var out, errb bytes.Buffer
+	root := cli.NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	root.SetArgs(args)
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("auth status failed: %v\nstderr: %s", err, errb.String())
+	}
+	var env struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("status not JSON: %v\n%s", err, out.String())
+	}
+	return env.Data
+}
+
+func wantField(t *testing.T, data map[string]any, key string, want any) {
+	t.Helper()
+	if got := data[key]; got != want {
+		t.Errorf("%s = %v (%T); want %v", key, got, data[key], want)
+	}
+}
+
+func TestAuthStatus_NamesOAuthLogin(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_API_KEY", "")
+	seedProfile(t, dir, &config.Config{
+		TokenType:      "oauth",
+		AccessToken:    "atk_live",
+		RefreshToken:   "rt_x",
+		TokenExpiresAt: time.Now().Add(time.Hour),
+		AuthSource:     config.AuthOriginOAuthLogin,
+		AccountEmail:   "dev@example.com",
+	})
+
+	data := statusData(t, dir)
+	wantField(t, data, "credential_source", "oauth")
+	wantField(t, data, "credential_description", "the OAuth login in this profile")
+	wantField(t, data, "auth_origin", "oauth_login")
+	wantField(t, data, "token_status", "valid")
+	wantField(t, data, "token_can_refresh", true)
+}
+
+func TestAuthStatus_NamesAPIKeyFlag(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_API_KEY", "")
+	seedProfile(t, dir, &config.Config{APIKey: "sk_stored", AuthSource: config.AuthOriginAPIKey})
+
+	data := statusData(t, dir, "--api-key", "sk_flag")
+	wantField(t, data, "credential_source", "flag")
+	wantField(t, data, "credential_description", "the --api-key flag")
+}
+
+func TestAuthStatus_NamesEnvVar(t *testing.T) {
+	dir := t.TempDir()
+	seedProfile(t, dir, &config.Config{})
+	t.Setenv("RC_API_KEY", "sk_env")
+
+	data := statusData(t, dir)
+	wantField(t, data, "credential_source", "env")
+	wantField(t, data, "credential_description", "the RC_API_KEY environment variable")
+}
+
+func TestAuthStatus_NamesProfileKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_API_KEY", "")
+	seedProfile(t, dir, &config.Config{APIKey: "sk_stored", AuthSource: config.AuthOriginAPIKey})
+
+	data := statusData(t, dir)
+	wantField(t, data, "credential_source", "profile")
+	wantField(t, data, "credential_description", "the API key stored in this profile")
+	wantField(t, data, "auth_origin", "api_key")
+}
+
+func TestAuthStatus_NamesMCPImportedAccessToken(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_API_KEY", "")
+	// Mirrors what loginWithMCPCredential stores for a borrowed atk_ token.
+	seedProfile(t, dir, &config.Config{
+		TokenType:   "oauth",
+		AccessToken: "atk_borrowed",
+		AuthSource:  config.AuthOriginMCPImport,
+	})
+
+	data := statusData(t, dir)
+	wantField(t, data, "credential_source", "oauth")
+	wantField(t, data, "credential_description", "an MCP-imported access token (borrowed; no auto-refresh)")
+	wantField(t, data, "auth_origin", "mcp_import")
+	wantField(t, data, "token_status", "no_expiry")
+	wantField(t, data, "token_can_refresh", false)
+}
+
+func TestAuthStatus_NamesMCPImportedAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_API_KEY", "")
+	seedProfile(t, dir, &config.Config{APIKey: "sk_from_mcp", AuthSource: config.AuthOriginMCPImport})
+
+	data := statusData(t, dir)
+	wantField(t, data, "credential_source", "profile")
+	wantField(t, data, "credential_description", "an MCP-imported API key")
+	wantField(t, data, "auth_origin", "mcp_import")
+}
+
+// An RC_API_KEY set alongside an OAuth login must not silently take over.
+func TestAuthStatus_ConflictNamesActiveAndIgnored(t *testing.T) {
+	dir := t.TempDir()
+	seedProfile(t, dir, &config.Config{
+		TokenType:      "oauth",
+		AccessToken:    "atk_live",
+		RefreshToken:   "rt_x",
+		TokenExpiresAt: time.Now().Add(time.Hour),
+		AuthSource:     config.AuthOriginOAuthLogin,
+	})
+	t.Setenv("RC_API_KEY", "sk_env")
+
+	data := statusData(t, dir)
+	wantField(t, data, "credential_source", "oauth")
+	conflict, ok := data["credential_conflict"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected credential_conflict, got %v", data["credential_conflict"])
+	}
+	wantField(t, conflict, "active_source", "oauth")
+	ignored, _ := conflict["ignored_sources"].([]any)
+	found := false
+	for _, s := range ignored {
+		if s == "env" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ignored_sources should name the env key, got %v", ignored)
+	}
+}

--- a/internal/cli/auth_status_test.go
+++ b/internal/cli/auth_status_test.go
@@ -84,6 +84,17 @@ func TestAuthStatus_NamesAPIKeyFlag(t *testing.T) {
 	wantField(t, data, "credential_description", "the --api-key flag")
 }
 
+func TestAuthStatus_OmitsAuthOriginWhenOverridden(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RC_API_KEY", "")
+	seedProfile(t, dir, &config.Config{APIKey: "sk_from_mcp", AuthSource: config.AuthOriginMCPImport})
+
+	// A live --api-key wins, so the stored mcp_import provenance is not in use.
+	data := statusData(t, dir, "--api-key", "sk_flag")
+	wantField(t, data, "credential_source", "flag")
+	wantField(t, data, "auth_origin", nil)
+}
+
 func TestAuthStatus_NamesEnvVar(t *testing.T) {
 	dir := t.TempDir()
 	seedProfile(t, dir, &config.Config{})

--- a/internal/cli/auth_status_test.go
+++ b/internal/cli/auth_status_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -143,6 +144,29 @@ func TestAuthStatus_NamesMCPImportedAPIKey(t *testing.T) {
 	wantField(t, data, "credential_source", "profile")
 	wantField(t, data, "credential_description", "an MCP-imported API key")
 	wantField(t, data, "auth_origin", "mcp_import")
+}
+
+// The conflict message must name the active credential with the same
+// provenance-aware phrasing as the Credential line, not a bare source name.
+func TestAuthStatus_ConflictNamesMCPImportedActive(t *testing.T) {
+	dir := t.TempDir()
+	seedProfile(t, dir, &config.Config{
+		TokenType:   "oauth",
+		AccessToken: "atk_borrowed",
+		AuthSource:  config.AuthOriginMCPImport,
+	})
+	t.Setenv("RC_API_KEY", "sk_env")
+
+	data := statusData(t, dir)
+	wantField(t, data, "credential_source", "oauth")
+	conflict, ok := data["credential_conflict"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected credential_conflict, got %v", data["credential_conflict"])
+	}
+	msg, _ := conflict["message"].(string)
+	if !strings.Contains(msg, "an MCP-imported access token") {
+		t.Errorf("conflict message should name the MCP-imported token, got %q", msg)
+	}
 }
 
 // An RC_API_KEY set alongside an OAuth login must not silently take over.

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -128,17 +128,17 @@ func (r *Runtime) warnCredentialConflict(active config.CredentialSource) {
 		return
 	}
 	r.warnedCredConflict = true
-	r.Out.AlwaysWarn(credentialConflictMessage(active, present))
+	r.Out.AlwaysWarn(credentialConflictMessage(r.Config, active, present))
 }
 
-func credentialConflictMessage(active config.CredentialSource, present []config.CredentialSource) string {
+func credentialConflictMessage(cfg *config.Config, active config.CredentialSource, present []config.CredentialSource) string {
 	var ignored []string
 	for _, s := range present {
 		if s != active {
-			ignored = append(ignored, s.Describe())
+			ignored = append(ignored, cfg.DescribeSource(s))
 		}
 	}
-	msg := "Multiple credentials found — using " + active.Describe()
+	msg := "Multiple credentials found — using " + cfg.DescribeSource(active)
 	if len(ignored) > 0 {
 		msg += "; ignoring " + strings.Join(ignored, " and ")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,12 @@ type Config struct {
 	AccountEmail   string    `json:"account_email,omitempty"`
 	AccountName    string    `json:"account_name,omitempty"`
 
+	// AuthSource records how the stored credential was obtained, so status can
+	// name a borrowed MCP-imported token instead of passing it off as a normal
+	// OAuth login or stored key. Flag/env credentials aren't stored, so they're
+	// resolved live and never written here. Empty on legacy profiles.
+	AuthSource string `json:"auth_source,omitempty"` // AuthOrigin* constants
+
 	ProjectID string `json:"project_id,omitempty"`
 	BaseURL   string `json:"base_url,omitempty"`
 
@@ -57,6 +63,12 @@ const (
 	SourceEnv     CredentialSource = "env"
 	SourceProfile CredentialSource = "profile"
 	SourceNone    CredentialSource = "none"
+)
+
+const (
+	AuthOriginOAuthLogin = "oauth_login" // also set on signup
+	AuthOriginAPIKey     = "api_key"
+	AuthOriginMCPImport  = "mcp_import"
 )
 
 // Describe returns a human-readable phrase naming the source.
@@ -104,6 +116,50 @@ func (c *Config) Credential() (token string, source CredentialSource) {
 		return k, SourceProfile
 	}
 	return "", SourceNone
+}
+
+// CredentialDescription refines Describe with stored provenance so an
+// MCP-imported credential isn't named as an ordinary OAuth login or stored key.
+func (c *Config) CredentialDescription() string {
+	_, source := c.Credential()
+	if c.AuthSource == AuthOriginMCPImport {
+		switch source {
+		case SourceOAuth:
+			return "an MCP-imported access token (borrowed; no auto-refresh)"
+		case SourceProfile:
+			return "an MCP-imported API key"
+		}
+	}
+	return source.Describe()
+}
+
+const (
+	TokenValid      = "valid"
+	TokenNearExpiry = "near_expiry"
+	TokenExpired    = "expired"
+	TokenNoExpiry   = "no_expiry" // borrowed tokens carry no expiry we can read
+)
+
+// TokenStatus is only meaningful when IsOAuth(); the near-expiry window matches
+// NeedsRefresh's 5 minutes.
+func (c *Config) TokenStatus() string {
+	if c.TokenExpiresAt.IsZero() {
+		return TokenNoExpiry
+	}
+	now := time.Now()
+	switch {
+	case now.After(c.TokenExpiresAt):
+		return TokenExpired
+	case c.TokenExpiresAt.Sub(now) <= 5*time.Minute:
+		return TokenNearExpiry
+	default:
+		return TokenValid
+	}
+}
+
+// CanAutoRefresh is false for borrowed MCP tokens, which carry no refresh token.
+func (c *Config) CanAutoRefresh() bool {
+	return c.IsOAuth() && c.RefreshToken != ""
 }
 
 // storedAPIKey is the API key on disk, ignoring any RC_API_KEY override.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,6 +122,12 @@ func (c *Config) Credential() (token string, source CredentialSource) {
 // MCP-imported credential isn't named as an ordinary OAuth login or stored key.
 func (c *Config) CredentialDescription() string {
 	_, source := c.Credential()
+	return c.DescribeSource(source)
+}
+
+// DescribeSource names a credential source, refining the stored credential's
+// phrasing with its provenance (only flag/env overrides never carry one).
+func (c *Config) DescribeSource(source CredentialSource) string {
 	if c.AuthSource == AuthOriginMCPImport {
 		switch source {
 		case SourceOAuth:


### PR DESCRIPTION
`rc auth status` now says where the active credential came from — OAuth login, `--api-key`, `RC_API_KEY`, a stored profile key, or an MCP-imported token — and for OAuth whether the token is valid, near expiry, or expired, and whether rc can refresh it.

Before, a borrowed MCP token looked identical to a normal login. Provenance is recorded on the profile at login/import; flag and env credentials are resolved live. The same detail is in `--json`.

### What it looks like

OAuth login:

```
✓ Logged in as dev@example.com (profile: default)
  Credential                  the OAuth login in this profile
  Token                       valid until 2026-08-25 07:00
```

A borrowed MCP-imported token — now called out as borrowed instead of passing as a normal login:

```
✓ Logged in as dev@example.com (profile: default)
  Credential                  an MCP-imported access token (borrowed; no auto-refresh)
  Token                       expiry unknown
```

An API key (stored in the profile, or via `--api-key` / `RC_API_KEY`) — no token line, since API keys don't expire or refresh:

```
✓ Logged in as dev@example.com (profile: default)
  Credential                  the API key stored in this profile
```

When a flag or env credential overrides a stored one, status names the winner and what it ignored:

```
✓ Logged in as dev@example.com (profile: default)
  Credential                  the --api-key flag
! Multiple credentials found — using the --api-key flag; ignoring the API key stored in this profile.
```

Same detail in `--json` (new fields; `token_*` appear only for OAuth):

```json
{
  "credential_source": "oauth",
  "credential_description": "the OAuth login in this profile",
  "auth_origin": "oauth_login",
  "token_status": "valid",
  "token_can_refresh": true,
  "token_expires_at": "2026-08-25T12:00:00Z"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stored auth metadata and status JSON, but does not change credential selection or token refresh behavior. Legacy profiles with empty `auth_source` keep the previous generic labels.
> 
> **Overview**
> `rc auth status` now distinguishes *how* the active credential was obtained and, for OAuth, whether the token is valid, near expiry, or expired — and whether it can auto-refresh.
> 
> Profiles persist a new `auth_source` (`oauth_login`, `api_key`, `mcp_import`) on login/import/logout. MCP-imported tokens are described as borrowed (no auto-refresh) instead of looking like a normal OAuth login. Flag/env overrides stay live-only; `auth_origin` is omitted when they win.
> 
> Human output adds a Credential line and a Token line; `--json` adds `credential_description`, `auth_origin`, and `token_*` fields. Conflict warnings use the same provenance-aware phrasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c5e39d12b8ce8579cb2f65919a3c8c37809bfa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->