### PR TITLE
fix(setup): reframe account signup as user-consented in the handback note

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -72,7 +72,7 @@ You must accept the RevenueCat Terms of Service and Privacy Policy:
 		Example: `  # Interactive signup
   rc auth signup
 
-  # Agent helping a user sign up on macOS, after the user has agreed to the Terms
+  # Agent helping a user sign up (--save-password saves to the macOS Keychain), after they agreed to the Terms
   rc auth signup --email dev@example.com --name "Example Developer" \
     --generate-password --save-password --accept-terms --no-input --json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -72,7 +72,7 @@ You must accept the RevenueCat Terms of Service and Privacy Policy:
 		Example: `  # Interactive signup
   rc auth signup
 
-  # Agent on macOS, after the user explicitly authorizes Terms acceptance
+  # Agent helping a user sign up on macOS, after the user has agreed to the Terms
   rc auth signup --email dev@example.com --name "Example Developer" \
     --generate-password --save-password --accept-terms --no-input --json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -433,7 +433,7 @@ func setupAuthHandbackNote(authed bool) string {
 	if runtime.GOOS == "darwin" {
 		savePassword = " --save-password"
 	}
-	return "\n\nAuth: you are not logged in. If the user has no RevenueCat account, create one without a browser: `rc auth signup --email <user's email> --name \"<user's name>\" --generate-password" + savePassword + " --accept-terms --no-input --json` — but only after the user explicitly agrees to the RevenueCat Terms of Service and Privacy Policy. If the user already has an account, STOP and ask them to run `rc auth login` (a browser sign-in you cannot perform), then continue."
+	return "\n\nAuth: you are not logged in. If the user has no RevenueCat account and wants to sign up, you can help them do it from the terminal once they've agreed to the RevenueCat Terms of Service and Privacy Policy: `rc auth signup --email <user's email> --name \"<user's name>\" --generate-password" + savePassword + " --accept-terms --no-input --json`. The user is the one signing up and accepting the terms; the `--accept-terms` flag records the consent they gave you, so run it only after they say yes. If the user already has an account, STOP and ask them to run `rc auth login` (a browser sign-in you cannot perform), then continue."
 }
 
 // setupStage is where this project stands in the onboarding journey; it


### PR DESCRIPTION
The setup handback note read as if the agent would create a RevenueCat account by itself, so coding agents refused to run it. Reworded so it's clear the user is the one signing up and accepting the Terms — the agent just runs the command after they consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CLI help/example and setup handback prompt text change; no auth, signup, or setup behavior.
> 
> **Overview**
> **Docs-only** updates so coding agents treat headless signup as something they can run **after** the user consents, not as the agent creating an account on its own.
> 
> In **`setupAuthHandbackNote`** (appended to the non-interactive `rc setup` prompt when logged out), the auth paragraph now says the user is signing up and accepting the Terms; the agent may help run `rc auth signup` once the user has agreed, and **`--accept-terms`** should only be used after they say yes. The existing-account path (`rc auth login`) is unchanged.
> 
> The **`rc auth signup`** command **Example** line is aligned: it describes an agent helping a user sign up (with optional macOS **`--save-password`**), after Terms agreement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9510310529b6e4a57bf7fdfbd3336e2e279b9697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->