### PR TITLE
fix(setup): classify the project directory and find a single app one level down

### DIFF
--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -572,6 +572,13 @@ func detectSetupStage(cmd *cobra.Command, rt *Runtime, platform string) setupSta
 			return setupStage{"Play Store app exists — catalog not synced", "sync-store-catalog"}
 		}
 	}
+	// Reachable only when the platform is undetermined (empty): a clear iOS,
+	// cross, or Android platform is handled above. With offerings but no store
+	// app connected, onboarding is not finished — keep it going and let the
+	// agent pick the store rather than reporting an audit-only "all synced".
+	if appStore == nil && playStore == nil {
+		return setupStage{"Test Store ready — store app not connected", "test-store-ready"}
+	}
 	return setupStage{"store apps connected and catalogs synced", "check-project"}
 }
 
@@ -758,8 +765,13 @@ func detectAppProject(dir string) (label, platform string, status projectStatus,
 	if home, err := os.UserHomeDir(); err == nil && dir == home {
 		return "this is your home directory, not an app", "", projectNone, nil
 	}
-	if l, p, s, ok := classifyDir(dir); ok {
-		return l, p, s, nil
+	rootLabel, rootPlatform, rootStatus, hasMarkers := classifyDir(dir)
+	// A clear or ambiguous mobile root is the target. A non-mobile root (a web
+	// or tooling package.json) can still sit above a nested mobile app, so fall
+	// through to the subdir scan and only settle on non-mobile if nothing
+	// clearer turns up one level down.
+	if hasMarkers && rootStatus != projectNonMobile {
+		return rootLabel, rootPlatform, rootStatus, nil
 	}
 
 	var subs []struct{ label, platform, rel string }
@@ -779,6 +791,9 @@ func detectAppProject(dir string) (label, platform string, status projectStatus,
 	case 1:
 		return subs[0].label + " (in ./" + subs[0].rel + ")", subs[0].platform, projectClear, []string{subs[0].rel}
 	case 0:
+		if hasMarkers {
+			return rootLabel, rootPlatform, rootStatus, nil
+		}
 		return "no app project detected", "", projectNone, nil
 	default:
 		labels := make([]string, len(subs))

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -134,7 +134,7 @@ func runSetup(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	projectLabel, platform, projStatus, appDir := detectAppProject(dir)
+	projectLabel, platform, projStatus, appDirs := detectAppProject(dir)
 	agents := detectAgents()
 
 	rt.Out.Title("RevenueCat setup  ·  " + filepath.Base(dir))
@@ -196,7 +196,7 @@ func runSetup(cmd *cobra.Command) error {
 		rt.Out.Answer("Agent", "none — copy the prompt")
 		rt.Out.Blank()
 		rt.Out.Info("Run rc skills install, then paste this into any agent:")
-		rt.Out.Info(setupAgentPrompt(rt, stage, applePending, projStatus, appDir))
+		rt.Out.Info(setupAgentPrompt(rt, stage, applePending, projStatus, appDirs))
 		rt.Out.Hint("more starter prompts:  rc skills prompts")
 		return nil
 	}
@@ -239,7 +239,7 @@ func runSetup(cmd *cobra.Command) error {
 	// Apple needs a browser + 2FA; setup always defers it to the agent hand-back.
 	appleDeferred := applePending
 
-	prompt := setupAgentPrompt(rt, stage, appleDeferred, projStatus, appDir)
+	prompt := setupAgentPrompt(rt, stage, appleDeferred, projStatus, appDirs)
 
 	rt.Out.Plan([]string{
 		"Install the RevenueCat AI Toolkit skills for " + choice.Name,
@@ -390,20 +390,34 @@ func activeProjectLabel(cmd *cobra.Command, rt *Runtime) string {
 
 // setupAgentPrompt is the starter prompt handed to the agent, with the
 // Apple-deferred instruction appended when relevant.
-func setupAgentPrompt(rt *Runtime, stage setupStage, appleDeferred bool, status projectStatus, appDir string) string {
-	prompt := starterPromptByID(stage.PromptID) + setupToolingNote(rt) + setupProjectNote(status, appDir)
+// joinSubdirs renders relative app subdirectories as "./a, ./b" for agent notes.
+func joinSubdirs(dirs []string) string {
+	out := make([]string, len(dirs))
+	for i, d := range dirs {
+		out[i] = "./" + d
+	}
+	return strings.Join(out, ", ")
+}
+
+func setupAgentPrompt(rt *Runtime, stage setupStage, appleDeferred bool, status projectStatus, appDirs []string) string {
+	prompt := starterPromptByID(stage.PromptID) + setupToolingNote(rt) + setupProjectNote(status, appDirs)
 	if appleDeferred {
 		prompt += "\n\nApple: I have deliberately deferred connecting my Apple account. Do NOT pause, wait, or poll for Apple credentials at any point — complete every stage that does not require Apple (Test Store catalog, paywall, SDK integration, build verification) and finish your run by listing the Apple steps as remaining work with the exact commands I should run later."
 	}
 	return prompt
 }
 
-func setupProjectNote(status projectStatus, appDir string) string {
-	if appDir != "" {
-		return "\n\nProject detection: the app is in ./" + appDir + ", not the current directory — cd into it (or target that path) before making changes."
-	}
+func setupProjectNote(status projectStatus, appDirs []string) string {
 	switch status {
+	case projectClear:
+		if len(appDirs) == 1 {
+			return "\n\nProject detection: the app is in ./" + appDirs[0] + ", not the current directory — cd into it (or target that path) before making changes."
+		}
+		return ""
 	case projectAmbiguous:
+		if len(appDirs) > 0 {
+			return "\n\nProject detection: several app projects live in subdirectories (" + joinSubdirs(appDirs) + "); the current directory has none. Identify the specific app and platform that needs RevenueCat before making changes — do not infer one."
+		}
 		return "\n\nProject detection: this directory has several project markers, so it may be a monorepo or nested checkout. Identify the specific app and platform that needs RevenueCat before making changes — do not infer one from the directory."
 	case projectNonMobile:
 		return "\n\nProject detection: this directory does not look like a mobile app (it resembles a web or backend project). Confirm with the user what should get RevenueCat and which platform, rather than assuming iOS."
@@ -421,13 +435,13 @@ func runSetupAgentPrompt(cmd *cobra.Command, rt *Runtime) error {
 	if err != nil {
 		return err
 	}
-	_, platform, projStatus, appDir := detectAppProject(dir)
+	_, platform, projStatus, appDirs := detectAppProject(dir)
 	stage := detectSetupStage(cmd, rt, platform)
 	authed := rt.Config != nil && rt.Config.BearerToken() != ""
 	applePending := (platform == "ios" || platform == "cross") &&
 		(stage.PromptID == "test-store-ready" || stage.PromptID == "connect-apple")
 
-	prompt := setupAgentPrompt(rt, stage, applePending, projStatus, appDir) + setupAuthHandbackNote(authed)
+	prompt := setupAgentPrompt(rt, stage, applePending, projStatus, appDirs) + setupAuthHandbackNote(authed)
 
 	if rt.Globals.JSON {
 		return rt.Out.Render(map[string]any{
@@ -736,15 +750,16 @@ func classifyDir(dir string) (label, platform string, status projectStatus, hasM
 // detectAppProject classifies the working directory, returning an empty platform
 // for every non-clear case so applePending never fires and the flow defers to
 // the agent. When the directory has no markers of its own, it looks one level
-// down for a single app in a subdirectory (a common layout: the app lives in
-// ./ios, ./app, or ./apps/mobile). appDir is that relative subdirectory, empty
-// when the app is the working directory itself.
-func detectAppProject(dir string) (label, platform string, status projectStatus, appDir string) {
+// down for apps in subdirectories (a common layout: the app lives in ./ios,
+// ./app, or ./apps/mobile). appDirs holds those relative subdirectories — one
+// for a single clear app, several for an ambiguous set — and is empty when the
+// app (or the ambiguity) is the working directory itself.
+func detectAppProject(dir string) (label, platform string, status projectStatus, appDirs []string) {
 	if home, err := os.UserHomeDir(); err == nil && dir == home {
-		return "this is your home directory, not an app", "", projectNone, ""
+		return "this is your home directory, not an app", "", projectNone, nil
 	}
 	if l, p, s, ok := classifyDir(dir); ok {
-		return l, p, s, ""
+		return l, p, s, nil
 	}
 
 	var subs []struct{ label, platform, rel string }
@@ -762,15 +777,17 @@ func detectAppProject(dir string) (label, platform string, status projectStatus,
 
 	switch len(subs) {
 	case 1:
-		return subs[0].label + " (in ./" + subs[0].rel + ")", subs[0].platform, projectClear, subs[0].rel
+		return subs[0].label + " (in ./" + subs[0].rel + ")", subs[0].platform, projectClear, []string{subs[0].rel}
 	case 0:
-		return "no app project detected", "", projectNone, ""
+		return "no app project detected", "", projectNone, nil
 	default:
 		labels := make([]string, len(subs))
+		rels := make([]string, len(subs))
 		for i, s := range subs {
 			labels[i] = s.label + " (./" + s.rel + ")"
+			rels[i] = s.rel
 		}
-		return "multiple app projects in subdirectories (" + strings.Join(labels, ", ") + ")", "", projectAmbiguous, ""
+		return "multiple app projects in subdirectories (" + strings.Join(labels, ", ") + ")", "", projectAmbiguous, rels
 	}
 }
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -707,22 +707,31 @@ func detectAppProject(dir string) (label, platform string, status projectStatus)
 		return "no app project detected", "", projectNone
 	}
 
+	// A non-mobile marker (a package.json for tooling like Fastlane or Prettier)
+	// sits in many mobile repos, so it doesn't make the target ambiguous — only
+	// distinct mobile platforms do.
+	var mobile []projectMarker
 	buckets := map[string]bool{}
 	for _, m := range markers {
+		if m.platform == "unknown" {
+			continue
+		}
+		mobile = append(mobile, m)
 		buckets[m.platform] = true
 	}
-	if len(buckets) > 1 {
-		labels := make([]string, len(markers))
-		for i, m := range markers {
+
+	switch {
+	case len(buckets) > 1:
+		labels := make([]string, len(mobile))
+		for i, m := range mobile {
 			labels[i] = m.label
 		}
 		return "multiple projects detected (" + strings.Join(labels, ", ") + ")", "", projectAmbiguous
-	}
-
-	if markers[0].platform == "unknown" {
+	case len(buckets) == 1:
+		return mobile[0].label, mobile[0].platform, projectClear
+	default:
 		return markers[0].label + " (not a mobile app)", "", projectNonMobile
 	}
-	return markers[0].label, markers[0].platform, projectClear
 }
 
 // setupSessionName names the launched agent's session after the app directory.

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -682,11 +682,19 @@ func detectProjectMarkers(dir string) []projectMarker {
 		markers = append(markers, projectMarker{label, platformFromLabel(label)})
 	}
 
-	if matches, _ := filepath.Glob(filepath.Join(dir, "*.xcodeproj")); len(matches) > 0 {
-		add("Xcode project (" + filepath.Base(matches[0]) + ")")
+	// Capacitor and similar wrappers keep the Xcode project one level down in
+	// ./App, so an ios/ directory holds no marker of its own without this.
+	for _, g := range []string{filepath.Join(dir, "*.xcodeproj"), filepath.Join(dir, "App", "*.xcodeproj")} {
+		if matches, _ := filepath.Glob(g); len(matches) > 0 {
+			add("Xcode project (" + filepath.Base(matches[0]) + ")")
+			break
+		}
 	}
-	if matches, _ := filepath.Glob(filepath.Join(dir, "*.xcworkspace")); len(matches) > 0 {
-		add("Xcode workspace (" + filepath.Base(matches[0]) + ")")
+	for _, g := range []string{filepath.Join(dir, "*.xcworkspace"), filepath.Join(dir, "App", "*.xcworkspace")} {
+		if matches, _ := filepath.Glob(g); len(matches) > 0 {
+			add("Xcode workspace (" + filepath.Base(matches[0]) + ")")
+			break
+		}
 	}
 	if _, err := os.Stat(filepath.Join(dir, "pubspec.yaml")); err == nil {
 		add("Flutter app")
@@ -710,13 +718,40 @@ func detectProjectMarkers(dir string) []projectMarker {
 	if _, err := os.Stat(filepath.Join(dir, "Package.swift")); err == nil {
 		add("Swift package")
 	}
+	// A bare Gradle module (e.g. a JVM backend) is not an Android app. Require
+	// the Android Gradle plugin or an Android manifest before claiming the
+	// platform, so a Gradle service next to a web project isn't picked as mobile.
+	gradlePresent, androidPlugin := false, false
 	for _, gradle := range []string{"settings.gradle", "settings.gradle.kts", "build.gradle", "build.gradle.kts"} {
-		if _, err := os.Stat(filepath.Join(dir, gradle)); err == nil {
-			add("Android project")
+		data, err := os.ReadFile(filepath.Join(dir, gradle))
+		if err != nil {
+			continue
+		}
+		gradlePresent = true
+		if strings.Contains(string(data), "com.android") {
+			androidPlugin = true
 			break
 		}
 	}
+	if gradlePresent && (androidPlugin || hasAndroidManifest(dir)) {
+		add("Android project")
+	}
 	return markers
+}
+
+// hasAndroidManifest looks for an Android manifest at the manifest's conventional
+// locations relative to an app or module root.
+func hasAndroidManifest(dir string) bool {
+	for _, rel := range []string{
+		"AndroidManifest.xml",
+		filepath.Join("src", "main", "AndroidManifest.xml"),
+		filepath.Join("app", "src", "main", "AndroidManifest.xml"),
+	} {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // classifyDir inspects one directory's markers. hasMarkers is false when it has

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -534,9 +534,9 @@ func detectSetupStage(cmd *cobra.Command, rt *Runtime, platform string) setupSta
 	}
 
 	// Apple applies when an App Store app exists, or none does but the
-	// directory looks like an iOS/cross-platform app. Android-only projects
-	// skip straight to the Play path.
-	appleRelevant := appStore != nil || (playStore == nil && platform != "android")
+	// directory is clearly iOS/cross-platform. An empty platform (nested,
+	// non-mobile, or undetermined) defers to the agent rather than assuming Apple.
+	appleRelevant := appStore != nil || (playStore == nil && (platform == "ios" || platform == "cross"))
 	if appleRelevant {
 		if appStore == nil || appStore.AppStore == nil ||
 			!appStore.AppStore.SubscriptionKeyConfigured || !appStore.AppStore.AppStoreConnectAPIKeyConfigured {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -134,8 +134,7 @@ func runSetup(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	projectLabel, projectDetected := detectAppProject(dir)
-	platform := platformFromLabel(projectLabel)
+	projectLabel, platform, projStatus := detectAppProject(dir)
 	agents := detectAgents()
 
 	rt.Out.Title("RevenueCat setup  ·  " + filepath.Base(dir))
@@ -167,7 +166,12 @@ func runSetup(cmd *cobra.Command) error {
 	stage := detectSetupStage(cmd, rt, platform)
 	rt.Out.Field("Stage", stage.Label)
 
-	if !projectDetected {
+	switch projStatus {
+	case projectAmbiguous:
+		rt.Out.Info("Several project markers here — the agent will figure out which app and platform to set up.")
+	case projectNonMobile:
+		rt.Out.Info("This doesn't look like a mobile app — the agent will confirm what needs RevenueCat and pick the platform.")
+	case projectNone:
 		cont, err := tui.ConfirmDefault(false, "No app project detected in this directory. Set up here anyway?", false)
 		if err != nil {
 			return err
@@ -192,7 +196,7 @@ func runSetup(cmd *cobra.Command) error {
 		rt.Out.Answer("Agent", "none — copy the prompt")
 		rt.Out.Blank()
 		rt.Out.Info("Run rc skills install, then paste this into any agent:")
-		rt.Out.Info(setupAgentPrompt(rt, stage, applePending))
+		rt.Out.Info(setupAgentPrompt(rt, stage, applePending, projStatus))
 		rt.Out.Hint("more starter prompts:  rc skills prompts")
 		return nil
 	}
@@ -235,7 +239,7 @@ func runSetup(cmd *cobra.Command) error {
 	// Apple needs a browser + 2FA; setup always defers it to the agent hand-back.
 	appleDeferred := applePending
 
-	prompt := setupAgentPrompt(rt, stage, appleDeferred)
+	prompt := setupAgentPrompt(rt, stage, appleDeferred, projStatus)
 
 	rt.Out.Plan([]string{
 		"Install the RevenueCat AI Toolkit skills for " + choice.Name,
@@ -386,12 +390,25 @@ func activeProjectLabel(cmd *cobra.Command, rt *Runtime) string {
 
 // setupAgentPrompt is the starter prompt handed to the agent, with the
 // Apple-deferred instruction appended when relevant.
-func setupAgentPrompt(rt *Runtime, stage setupStage, appleDeferred bool) string {
-	prompt := starterPromptByID(stage.PromptID) + setupToolingNote(rt)
+func setupAgentPrompt(rt *Runtime, stage setupStage, appleDeferred bool, status projectStatus) string {
+	prompt := starterPromptByID(stage.PromptID) + setupToolingNote(rt) + setupProjectNote(status)
 	if appleDeferred {
 		prompt += "\n\nApple: I have deliberately deferred connecting my Apple account. Do NOT pause, wait, or poll for Apple credentials at any point — complete every stage that does not require Apple (Test Store catalog, paywall, SDK integration, build verification) and finish your run by listing the Apple steps as remaining work with the exact commands I should run later."
 	}
 	return prompt
+}
+
+func setupProjectNote(status projectStatus) string {
+	switch status {
+	case projectAmbiguous:
+		return "\n\nProject detection: this directory has several project markers, so it may be a monorepo or nested checkout. Identify the specific app and platform that needs RevenueCat before making changes — do not infer one from the directory."
+	case projectNonMobile:
+		return "\n\nProject detection: this directory does not look like a mobile app (it resembles a web or backend project). Confirm with the user what should get RevenueCat and which platform, rather than assuming iOS."
+	case projectNone:
+		return "\n\nProject detection: no recognizable app project was found here. Confirm the target app and platform with the user before proceeding."
+	default:
+		return ""
+	}
 }
 
 // runSetupAgentPrompt emits the stage-aware setup prompt for a non-interactive
@@ -401,14 +418,13 @@ func runSetupAgentPrompt(cmd *cobra.Command, rt *Runtime) error {
 	if err != nil {
 		return err
 	}
-	projectLabel, _ := detectAppProject(dir)
-	platform := platformFromLabel(projectLabel)
+	_, platform, projStatus := detectAppProject(dir)
 	stage := detectSetupStage(cmd, rt, platform)
 	authed := rt.Config != nil && rt.Config.BearerToken() != ""
 	applePending := (platform == "ios" || platform == "cross") &&
 		(stage.PromptID == "test-store-ready" || stage.PromptID == "connect-apple")
 
-	prompt := setupAgentPrompt(rt, stage, applePending) + setupAuthHandbackNote(authed)
+	prompt := setupAgentPrompt(rt, stage, applePending, projStatus) + setupAuthHandbackNote(authed)
 
 	if rt.Globals.JSON {
 		return rt.Out.Render(map[string]any{
@@ -622,46 +638,91 @@ func detectAgents() []agentClient {
 	return found
 }
 
-// detectAppProject decides whether dir looks like an app project root and
-// names what it found. The label rides the Directory field so a wrong-cwd
-// mistake is visible before anything runs.
-func detectAppProject(dir string) (label string, ok bool) {
-	if home, err := os.UserHomeDir(); err == nil && dir == home {
-		return "this is your home directory, not an app", false
+type projectStatus int
+
+const (
+	projectClear projectStatus = iota
+	projectAmbiguous
+	projectNonMobile
+	projectNone
+)
+
+type projectMarker struct {
+	label    string
+	platform string
+}
+
+func detectProjectMarkers(dir string) []projectMarker {
+	var markers []projectMarker
+	add := func(label string) {
+		markers = append(markers, projectMarker{label, platformFromLabel(label)})
 	}
+
 	if matches, _ := filepath.Glob(filepath.Join(dir, "*.xcodeproj")); len(matches) > 0 {
-		return "Xcode project (" + filepath.Base(matches[0]) + ")", true
+		add("Xcode project (" + filepath.Base(matches[0]) + ")")
 	}
 	if matches, _ := filepath.Glob(filepath.Join(dir, "*.xcworkspace")); len(matches) > 0 {
-		return "Xcode workspace (" + filepath.Base(matches[0]) + ")", true
+		add("Xcode workspace (" + filepath.Base(matches[0]) + ")")
 	}
 	if _, err := os.Stat(filepath.Join(dir, "pubspec.yaml")); err == nil {
-		return "Flutter app", true
+		add("Flutter app")
 	}
 	if data, err := os.ReadFile(filepath.Join(dir, "package.json")); err == nil {
 		switch {
 		case strings.Contains(string(data), `"react-native"`):
-			return "React Native app", true
+			add("React Native app")
 		case strings.Contains(string(data), `"expo"`):
-			return "Expo app", true
+			add("Expo app")
 		default:
-			return "JavaScript project", true
+			add("JavaScript project")
 		}
 	}
 	for _, tuist := range []string{"Project.swift", "Workspace.swift"} {
 		if _, err := os.Stat(filepath.Join(dir, tuist)); err == nil {
-			return "Tuist project (iOS)", true
+			add("Tuist project (iOS)")
+			break
 		}
 	}
 	if _, err := os.Stat(filepath.Join(dir, "Package.swift")); err == nil {
-		return "Swift package", true
+		add("Swift package")
 	}
 	for _, gradle := range []string{"settings.gradle", "settings.gradle.kts", "build.gradle", "build.gradle.kts"} {
 		if _, err := os.Stat(filepath.Join(dir, gradle)); err == nil {
-			return "Android project", true
+			add("Android project")
+			break
 		}
 	}
-	return "no app project detected", false
+	return markers
+}
+
+// detectAppProject returns an empty platform for every non-clear case so
+// applePending never fires (and the flow defers the platform to the agent)
+// on a nested, non-mobile, or empty directory.
+func detectAppProject(dir string) (label, platform string, status projectStatus) {
+	if home, err := os.UserHomeDir(); err == nil && dir == home {
+		return "this is your home directory, not an app", "", projectNone
+	}
+	markers := detectProjectMarkers(dir)
+	if len(markers) == 0 {
+		return "no app project detected", "", projectNone
+	}
+
+	buckets := map[string]bool{}
+	for _, m := range markers {
+		buckets[m.platform] = true
+	}
+	if len(buckets) > 1 {
+		labels := make([]string, len(markers))
+		for i, m := range markers {
+			labels[i] = m.label
+		}
+		return "multiple projects detected (" + strings.Join(labels, ", ") + ")", "", projectAmbiguous
+	}
+
+	if markers[0].platform == "unknown" {
+		return markers[0].label + " (not a mobile app)", "", projectNonMobile
+	}
+	return markers[0].label, markers[0].platform, projectClear
 }
 
 // setupSessionName names the launched agent's session after the app directory.

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -683,14 +683,22 @@ func detectProjectMarkers(dir string) []projectMarker {
 	}
 
 	// Capacitor and similar wrappers keep the Xcode project one level down in
-	// ./App, so an ios/ directory holds no marker of its own without this.
-	for _, g := range []string{filepath.Join(dir, "*.xcodeproj"), filepath.Join(dir, "App", "*.xcodeproj")} {
+	// ios/App, so an ios/ directory holds no marker of its own without this. Only
+	// glob the nested App/ for an ios/ directory: a bare ./App beside a web or
+	// tooling root isn't a Capacitor project and must not read as a root iOS app.
+	xcodeprojGlobs := []string{filepath.Join(dir, "*.xcodeproj")}
+	xcworkspaceGlobs := []string{filepath.Join(dir, "*.xcworkspace")}
+	if filepath.Base(dir) == "ios" {
+		xcodeprojGlobs = append(xcodeprojGlobs, filepath.Join(dir, "App", "*.xcodeproj"))
+		xcworkspaceGlobs = append(xcworkspaceGlobs, filepath.Join(dir, "App", "*.xcworkspace"))
+	}
+	for _, g := range xcodeprojGlobs {
 		if matches, _ := filepath.Glob(g); len(matches) > 0 {
 			add("Xcode project (" + filepath.Base(matches[0]) + ")")
 			break
 		}
 	}
-	for _, g := range []string{filepath.Join(dir, "*.xcworkspace"), filepath.Join(dir, "App", "*.xcworkspace")} {
+	for _, g := range xcworkspaceGlobs {
 		if matches, _ := filepath.Glob(g); len(matches) > 0 {
 			add("Xcode workspace (" + filepath.Base(matches[0]) + ")")
 			break

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -134,7 +134,7 @@ func runSetup(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	projectLabel, platform, projStatus := detectAppProject(dir)
+	projectLabel, platform, projStatus, appDir := detectAppProject(dir)
 	agents := detectAgents()
 
 	rt.Out.Title("RevenueCat setup  ·  " + filepath.Base(dir))
@@ -196,7 +196,7 @@ func runSetup(cmd *cobra.Command) error {
 		rt.Out.Answer("Agent", "none — copy the prompt")
 		rt.Out.Blank()
 		rt.Out.Info("Run rc skills install, then paste this into any agent:")
-		rt.Out.Info(setupAgentPrompt(rt, stage, applePending, projStatus))
+		rt.Out.Info(setupAgentPrompt(rt, stage, applePending, projStatus, appDir))
 		rt.Out.Hint("more starter prompts:  rc skills prompts")
 		return nil
 	}
@@ -239,7 +239,7 @@ func runSetup(cmd *cobra.Command) error {
 	// Apple needs a browser + 2FA; setup always defers it to the agent hand-back.
 	appleDeferred := applePending
 
-	prompt := setupAgentPrompt(rt, stage, appleDeferred, projStatus)
+	prompt := setupAgentPrompt(rt, stage, appleDeferred, projStatus, appDir)
 
 	rt.Out.Plan([]string{
 		"Install the RevenueCat AI Toolkit skills for " + choice.Name,
@@ -390,15 +390,18 @@ func activeProjectLabel(cmd *cobra.Command, rt *Runtime) string {
 
 // setupAgentPrompt is the starter prompt handed to the agent, with the
 // Apple-deferred instruction appended when relevant.
-func setupAgentPrompt(rt *Runtime, stage setupStage, appleDeferred bool, status projectStatus) string {
-	prompt := starterPromptByID(stage.PromptID) + setupToolingNote(rt) + setupProjectNote(status)
+func setupAgentPrompt(rt *Runtime, stage setupStage, appleDeferred bool, status projectStatus, appDir string) string {
+	prompt := starterPromptByID(stage.PromptID) + setupToolingNote(rt) + setupProjectNote(status, appDir)
 	if appleDeferred {
 		prompt += "\n\nApple: I have deliberately deferred connecting my Apple account. Do NOT pause, wait, or poll for Apple credentials at any point — complete every stage that does not require Apple (Test Store catalog, paywall, SDK integration, build verification) and finish your run by listing the Apple steps as remaining work with the exact commands I should run later."
 	}
 	return prompt
 }
 
-func setupProjectNote(status projectStatus) string {
+func setupProjectNote(status projectStatus, appDir string) string {
+	if appDir != "" {
+		return "\n\nProject detection: the app is in ./" + appDir + ", not the current directory — cd into it (or target that path) before making changes."
+	}
 	switch status {
 	case projectAmbiguous:
 		return "\n\nProject detection: this directory has several project markers, so it may be a monorepo or nested checkout. Identify the specific app and platform that needs RevenueCat before making changes — do not infer one from the directory."
@@ -418,13 +421,13 @@ func runSetupAgentPrompt(cmd *cobra.Command, rt *Runtime) error {
 	if err != nil {
 		return err
 	}
-	_, platform, projStatus := detectAppProject(dir)
+	_, platform, projStatus, appDir := detectAppProject(dir)
 	stage := detectSetupStage(cmd, rt, platform)
 	authed := rt.Config != nil && rt.Config.BearerToken() != ""
 	applePending := (platform == "ios" || platform == "cross") &&
 		(stage.PromptID == "test-store-ready" || stage.PromptID == "connect-apple")
 
-	prompt := setupAgentPrompt(rt, stage, applePending, projStatus) + setupAuthHandbackNote(authed)
+	prompt := setupAgentPrompt(rt, stage, applePending, projStatus, appDir) + setupAuthHandbackNote(authed)
 
 	if rt.Globals.JSON {
 		return rt.Out.Render(map[string]any{
@@ -695,16 +698,12 @@ func detectProjectMarkers(dir string) []projectMarker {
 	return markers
 }
 
-// detectAppProject returns an empty platform for every non-clear case so
-// applePending never fires (and the flow defers the platform to the agent)
-// on a nested, non-mobile, or empty directory.
-func detectAppProject(dir string) (label, platform string, status projectStatus) {
-	if home, err := os.UserHomeDir(); err == nil && dir == home {
-		return "this is your home directory, not an app", "", projectNone
-	}
+// classifyDir inspects one directory's markers. hasMarkers is false when it has
+// none, so the caller can decide whether to look elsewhere (e.g. one level down).
+func classifyDir(dir string) (label, platform string, status projectStatus, hasMarkers bool) {
 	markers := detectProjectMarkers(dir)
 	if len(markers) == 0 {
-		return "no app project detected", "", projectNone
+		return "", "", projectNone, false
 	}
 
 	// A non-mobile marker (a package.json for tooling like Fastlane or Prettier)
@@ -726,12 +725,66 @@ func detectAppProject(dir string) (label, platform string, status projectStatus)
 		for i, m := range mobile {
 			labels[i] = m.label
 		}
-		return "multiple projects detected (" + strings.Join(labels, ", ") + ")", "", projectAmbiguous
+		return "multiple projects detected (" + strings.Join(labels, ", ") + ")", "", projectAmbiguous, true
 	case len(buckets) == 1:
-		return mobile[0].label, mobile[0].platform, projectClear
+		return mobile[0].label, mobile[0].platform, projectClear, true
 	default:
-		return markers[0].label + " (not a mobile app)", "", projectNonMobile
+		return markers[0].label + " (not a mobile app)", "", projectNonMobile, true
 	}
+}
+
+// detectAppProject classifies the working directory, returning an empty platform
+// for every non-clear case so applePending never fires and the flow defers to
+// the agent. When the directory has no markers of its own, it looks one level
+// down for a single app in a subdirectory (a common layout: the app lives in
+// ./ios, ./app, or ./apps/mobile). appDir is that relative subdirectory, empty
+// when the app is the working directory itself.
+func detectAppProject(dir string) (label, platform string, status projectStatus, appDir string) {
+	if home, err := os.UserHomeDir(); err == nil && dir == home {
+		return "this is your home directory, not an app", "", projectNone, ""
+	}
+	if l, p, s, ok := classifyDir(dir); ok {
+		return l, p, s, ""
+	}
+
+	var subs []struct{ label, platform, rel string }
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if !e.IsDir() || skipSubdir(e.Name()) {
+			continue
+		}
+		// Only a single clear mobile app in a subdir counts; a web/tooling subdir
+		// or a subdir that is itself ambiguous doesn't compete.
+		if l, p, s, ok := classifyDir(filepath.Join(dir, e.Name())); ok && s == projectClear {
+			subs = append(subs, struct{ label, platform, rel string }{l, p, e.Name()})
+		}
+	}
+
+	switch len(subs) {
+	case 1:
+		return subs[0].label + " (in ./" + subs[0].rel + ")", subs[0].platform, projectClear, subs[0].rel
+	case 0:
+		return "no app project detected", "", projectNone, ""
+	default:
+		labels := make([]string, len(subs))
+		for i, s := range subs {
+			labels[i] = s.label + " (./" + s.rel + ")"
+		}
+		return "multiple app projects in subdirectories (" + strings.Join(labels, ", ") + ")", "", projectAmbiguous, ""
+	}
+}
+
+// skipSubdir skips directories that never hold an app root but are expensive or
+// misleading to scan: VCS metadata, dependencies, and build output.
+func skipSubdir(name string) bool {
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+	switch name {
+	case "node_modules", "Pods", "Carthage", "build", "Build", "DerivedData", "vendor", "dist", "out", "target":
+		return true
+	}
+	return false
 }
 
 // setupSessionName names the launched agent's session after the app directory.

--- a/internal/cli/setup_detect_test.go
+++ b/internal/cli/setup_detect_test.go
@@ -3,22 +3,32 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestDetectAppProject(t *testing.T) {
 	cases := []struct {
-		name  string
-		files []string
-		want  string
-		ok    bool
+		name         string
+		files        []string
+		wantLabel    string
+		wantPlatform string
+		wantStatus   projectStatus
 	}{
-		{"xcode", []string{"MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj)", true},
-		{"flutter", []string{"pubspec.yaml"}, "Flutter app", true},
-		{"react-native", []string{"package.json:{\"dependencies\":{\"react-native\":\"0.74\"}}"}, "React Native app", true},
-		{"android", []string{"settings.gradle"}, "Android project", true},
-		{"tuist", []string{"Project.swift"}, "Tuist project (iOS)", true},
-		{"empty", nil, "no app project detected", false},
+		{"xcode", []string{"MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear},
+		{"flutter", []string{"pubspec.yaml"}, "Flutter app", "cross", projectClear},
+		{"react-native", []string{"package.json:{\"dependencies\":{\"react-native\":\"0.74\"}}"}, "React Native app", "cross", projectClear},
+		{"android", []string{"settings.gradle"}, "Android project", "android", projectClear},
+		{"tuist", []string{"Project.swift"}, "Tuist project (iOS)", "ios", projectClear},
+		// A CocoaPods iOS project surfaces twice but is still one clear app.
+		{"xcode-with-workspace", []string{"MyApp.xcodeproj/project.pbxproj", "MyApp.xcworkspace/contents.xcworkspacedata"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear},
+
+		{"js-backend", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}"}, "JavaScript project (not a mobile app)", "", projectNonMobile},
+
+		{"nested-js-and-android", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "settings.gradle"}, "multiple projects detected (JavaScript project, Android project)", "", projectAmbiguous},
+		{"nested-ios-and-android", []string{"MyApp.xcodeproj/project.pbxproj", "settings.gradle"}, "multiple projects detected (Xcode project (MyApp.xcodeproj), Android project)", "", projectAmbiguous},
+
+		{"empty", nil, "no app project detected", "", projectNone},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -36,9 +46,10 @@ func TestDetectAppProject(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			label, ok := detectAppProject(dir)
-			if label != tc.want || ok != tc.ok {
-				t.Fatalf("detectAppProject = %q,%v want %q,%v", label, ok, tc.want, tc.ok)
+			label, platform, status := detectAppProject(dir)
+			if label != tc.wantLabel || platform != tc.wantPlatform || status != tc.wantStatus {
+				t.Fatalf("detectAppProject = %q,%q,%d want %q,%q,%d",
+					label, platform, status, tc.wantLabel, tc.wantPlatform, tc.wantStatus)
 			}
 		})
 	}
@@ -66,6 +77,21 @@ func TestPlatformFromLabel(t *testing.T) {
 	for label, want := range cases {
 		if got := platformFromLabel(label); got != want {
 			t.Errorf("platformFromLabel(%q) = %q, want %q", label, got, want)
+		}
+	}
+}
+
+func TestSetupProjectNote(t *testing.T) {
+	if note := setupProjectNote(projectClear); note != "" {
+		t.Errorf("clear project should add no note, got %q", note)
+	}
+	for _, status := range []projectStatus{projectAmbiguous, projectNonMobile, projectNone} {
+		note := setupProjectNote(status)
+		if note == "" {
+			t.Errorf("status %d should hand the platform decision to the agent, got empty note", status)
+		}
+		if !strings.Contains(note, "Project detection:") {
+			t.Errorf("status %d note missing detection prefix: %q", status, note)
 		}
 	}
 }

--- a/internal/cli/setup_detect_test.go
+++ b/internal/cli/setup_detect_test.go
@@ -51,6 +51,13 @@ func TestDetectAppProject(t *testing.T) {
 		// Capacitor-style layout: Xcode project nested in ios/App, Gradle app in android/.
 		{"capacitor-nested-both", []string{"package.json:{\"dependencies\":{\"@capacitor/core\":\"5\"}}", "android/build.gradle:plugins { id \"com.android.application\" }", "ios/App/MyApp.xcodeproj/project.pbxproj"}, "multiple app projects in subdirectories (Android project (./android), Xcode project (MyApp.xcodeproj) (./ios))", "", projectAmbiguous, []string{"android", "ios"}},
 		{"capacitor-nested-ios-only", []string{"package.json:{\"dependencies\":{\"@capacitor/core\":\"5\"}}", "ios/App/MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj) (in ./ios)", "ios", projectClear, []string{"ios"}},
+		// A bare ./App/*.xcodeproj at a web/tooling root is not Capacitor-shaped: the
+		// root must not read as a root-level iOS app (clear iOS, empty appDirs).
+		// It falls through to the subdir scan, which points the agent at ./App.
+		{"web-root-with-bare-app-xcodeproj", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "App/MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj) (in ./App)", "ios", projectClear, []string{"App"}},
+		// A bare ./App must not short-circuit the root into a clear iOS app: with an
+		// Android app beside it the scan still sees both and defers to the agent.
+		{"bare-app-beside-mobile-subdir", []string{"App/MyApp.xcodeproj/project.pbxproj", "android/build.gradle:plugins { id \"com.android.application\" }"}, "multiple app projects in subdirectories (Xcode project (MyApp.xcodeproj) (./App), Android project (./android))", "", projectAmbiguous, []string{"App", "android"}},
 		// A JVM/Gradle backend next to a web project is not a mobile app.
 		{"web-root-with-gradle-backend", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "backend/build.gradle:plugins { id \"org.jetbrains.kotlin.jvm\" }"}, "JavaScript project (not a mobile app)", "", projectNonMobile, nil},
 

--- a/internal/cli/setup_detect_test.go
+++ b/internal/cli/setup_detect_test.go
@@ -23,30 +23,30 @@ func TestDetectAppProject(t *testing.T) {
 		wantLabel    string
 		wantPlatform string
 		wantStatus   projectStatus
-		wantAppDir   string
+		wantAppDirs  []string
 	}{
-		{"xcode", []string{"MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, ""},
-		{"flutter", []string{"pubspec.yaml"}, "Flutter app", "cross", projectClear, ""},
-		{"react-native", []string{"package.json:{\"dependencies\":{\"react-native\":\"0.74\"}}"}, "React Native app", "cross", projectClear, ""},
-		{"android", []string{"settings.gradle"}, "Android project", "android", projectClear, ""},
-		{"tuist", []string{"Project.swift"}, "Tuist project (iOS)", "ios", projectClear, ""},
+		{"xcode", []string{"MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, nil},
+		{"flutter", []string{"pubspec.yaml"}, "Flutter app", "cross", projectClear, nil},
+		{"react-native", []string{"package.json:{\"dependencies\":{\"react-native\":\"0.74\"}}"}, "React Native app", "cross", projectClear, nil},
+		{"android", []string{"settings.gradle"}, "Android project", "android", projectClear, nil},
+		{"tuist", []string{"Project.swift"}, "Tuist project (iOS)", "ios", projectClear, nil},
 		// A CocoaPods iOS project surfaces twice but is still one clear app.
-		{"xcode-with-workspace", []string{"MyApp.xcodeproj/project.pbxproj", "MyApp.xcworkspace/contents.xcworkspacedata"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, ""},
+		{"xcode-with-workspace", []string{"MyApp.xcodeproj/project.pbxproj", "MyApp.xcworkspace/contents.xcworkspacedata"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, nil},
 
-		{"js-backend", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}"}, "JavaScript project (not a mobile app)", "", projectNonMobile, ""},
+		{"js-backend", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}"}, "JavaScript project (not a mobile app)", "", projectNonMobile, nil},
 
 		// A mobile app carrying a tooling package.json is still one clear app.
-		{"ios-with-tooling-package-json", []string{"MyApp.xcodeproj/project.pbxproj", "package.json:{\"dependencies\":{\"prettier\":\"3\"}}"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, ""},
-		{"android-with-tooling-package-json", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "settings.gradle"}, "Android project", "android", projectClear, ""},
+		{"ios-with-tooling-package-json", []string{"MyApp.xcodeproj/project.pbxproj", "package.json:{\"dependencies\":{\"prettier\":\"3\"}}"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, nil},
+		{"android-with-tooling-package-json", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "settings.gradle"}, "Android project", "android", projectClear, nil},
 
-		{"nested-ios-and-android", []string{"MyApp.xcodeproj/project.pbxproj", "settings.gradle"}, "multiple projects detected (Xcode project (MyApp.xcodeproj), Android project)", "", projectAmbiguous, ""},
+		{"nested-ios-and-android", []string{"MyApp.xcodeproj/project.pbxproj", "settings.gradle"}, "multiple projects detected (Xcode project (MyApp.xcodeproj), Android project)", "", projectAmbiguous, nil},
 
 		// No markers at the root, but a single app one level down is picked up.
-		{"single-app-in-subdir", []string{"ios/MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj) (in ./ios)", "ios", projectClear, "ios"},
-		{"two-apps-in-subdirs", []string{"android-app/settings.gradle", "ios-app/MyApp.xcodeproj/project.pbxproj"}, "multiple app projects in subdirectories (Android project (./android-app), Xcode project (MyApp.xcodeproj) (./ios-app))", "", projectAmbiguous, ""},
-		{"subdir-scan-skips-dependencies", []string{"node_modules/pubspec.yaml"}, "no app project detected", "", projectNone, ""},
+		{"single-app-in-subdir", []string{"ios/MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj) (in ./ios)", "ios", projectClear, []string{"ios"}},
+		{"two-apps-in-subdirs", []string{"android-app/settings.gradle", "ios-app/MyApp.xcodeproj/project.pbxproj"}, "multiple app projects in subdirectories (Android project (./android-app), Xcode project (MyApp.xcodeproj) (./ios-app))", "", projectAmbiguous, []string{"android-app", "ios-app"}},
+		{"subdir-scan-skips-dependencies", []string{"node_modules/pubspec.yaml"}, "no app project detected", "", projectNone, nil},
 
-		{"empty", nil, "no app project detected", "", projectNone, ""},
+		{"empty", nil, "no app project detected", "", projectNone, nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -64,10 +64,10 @@ func TestDetectAppProject(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			label, platform, status, appDir := detectAppProject(dir)
-			if label != tc.wantLabel || platform != tc.wantPlatform || status != tc.wantStatus || appDir != tc.wantAppDir {
-				t.Fatalf("detectAppProject = %q,%q,%d,%q want %q,%q,%d,%q",
-					label, platform, status, appDir, tc.wantLabel, tc.wantPlatform, tc.wantStatus, tc.wantAppDir)
+			label, platform, status, appDirs := detectAppProject(dir)
+			if label != tc.wantLabel || platform != tc.wantPlatform || status != tc.wantStatus || !equalStrings(appDirs, tc.wantAppDirs) {
+				t.Fatalf("detectAppProject = %q,%q,%d,%v want %q,%q,%d,%v",
+					label, platform, status, appDirs, tc.wantLabel, tc.wantPlatform, tc.wantStatus, tc.wantAppDirs)
 			}
 		})
 	}
@@ -135,11 +135,11 @@ func TestPlatformFromLabel(t *testing.T) {
 }
 
 func TestSetupProjectNote(t *testing.T) {
-	if note := setupProjectNote(projectClear, ""); note != "" {
+	if note := setupProjectNote(projectClear, nil); note != "" {
 		t.Errorf("clear project should add no note, got %q", note)
 	}
 	for _, status := range []projectStatus{projectAmbiguous, projectNonMobile, projectNone} {
-		note := setupProjectNote(status, "")
+		note := setupProjectNote(status, nil)
 		if note == "" {
 			t.Errorf("status %d should hand the platform decision to the agent, got empty note", status)
 		}
@@ -148,9 +148,13 @@ func TestSetupProjectNote(t *testing.T) {
 		}
 	}
 	// A clear app in a subdirectory tells the agent where it is.
-	note := setupProjectNote(projectClear, "ios")
-	if !strings.Contains(note, "./ios") {
+	if note := setupProjectNote(projectClear, []string{"ios"}); !strings.Contains(note, "./ios") {
 		t.Errorf("subdir note should point at ./ios, got %q", note)
+	}
+	// Ambiguous apps in subdirectories forward every path, not "this directory".
+	note := setupProjectNote(projectAmbiguous, []string{"android-app", "ios-app"})
+	if !strings.Contains(note, "./android-app") || !strings.Contains(note, "./ios-app") {
+		t.Errorf("ambiguous-subdir note should list the subdirs, got %q", note)
 	}
 }
 

--- a/internal/cli/setup_detect_test.go
+++ b/internal/cli/setup_detect_test.go
@@ -1,10 +1,19 @@
 package cli
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+	"github.com/revenuecat/cli/internal/config"
+	"github.com/revenuecat/cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func TestDetectAppProject(t *testing.T) {
@@ -55,6 +64,41 @@ func TestDetectAppProject(t *testing.T) {
 					label, platform, status, tc.wantLabel, tc.wantPlatform, tc.wantStatus)
 			}
 		})
+	}
+}
+
+func TestDetectSetupStage_EmptyPlatformDoesNotForceApple(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/apps"):
+			_, _ = io.WriteString(w, `{"items":[]}`)
+		case strings.HasSuffix(r.URL.Path, "/offerings"):
+			_, _ = io.WriteString(w, `{"items":[{"id":"ofrng_x"}]}`)
+		case strings.HasSuffix(r.URL.Path, "/products"):
+			_, _ = io.WriteString(w, `{"items":[]}`)
+		default:
+			http.Error(w, "unexpected "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	rt := &Runtime{
+		Globals: &Globals{NoInput: true, Version: "test"},
+		Config:  &config.Config{APIKey: "sk_test", ProjectID: "proj", BaseURL: srv.URL},
+		Out:     output.NewRenderer(io.Discard, io.Discard, false, false, false, ""),
+		client:  api.NewClient(api.Options{APIKey: "sk_test", BaseURL: srv.URL}),
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	// A Test Store exists but no store apps do. An empty platform must defer to
+	// the agent, not route to Apple; a clear iOS platform still connects Apple.
+	if stage := detectSetupStage(cmd, rt, ""); stage.PromptID == "connect-apple" {
+		t.Fatalf("empty platform routed to Apple: %+v", stage)
+	}
+	if stage := detectSetupStage(cmd, rt, "ios"); stage.PromptID != "connect-apple" {
+		t.Fatalf("iOS platform should connect Apple, got %+v", stage)
 	}
 }
 

--- a/internal/cli/setup_detect_test.go
+++ b/internal/cli/setup_detect_test.go
@@ -46,6 +46,11 @@ func TestDetectAppProject(t *testing.T) {
 		{"two-apps-in-subdirs", []string{"android-app/settings.gradle", "ios-app/MyApp.xcodeproj/project.pbxproj"}, "multiple app projects in subdirectories (Android project (./android-app), Xcode project (MyApp.xcodeproj) (./ios-app))", "", projectAmbiguous, []string{"android-app", "ios-app"}},
 		{"subdir-scan-skips-dependencies", []string{"node_modules/pubspec.yaml"}, "no app project detected", "", projectNone, nil},
 
+		// A non-mobile root (web/tooling package.json) must not hide a nested app.
+		{"web-root-with-nested-ios", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "ios/MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj) (in ./ios)", "ios", projectClear, []string{"ios"}},
+		// A non-mobile root with no mobile app below still classifies as non-mobile.
+		{"web-root-no-nested-app", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "docs/README.md"}, "JavaScript project (not a mobile app)", "", projectNonMobile, nil},
+
 		{"empty", nil, "no app project detected", "", projectNone, nil},
 	}
 	for _, tc := range cases {
@@ -100,8 +105,13 @@ func TestDetectSetupStage_EmptyPlatformDoesNotForceApple(t *testing.T) {
 
 	// A Test Store exists but no store apps do. An empty platform must defer to
 	// the agent, not route to Apple; a clear iOS platform still connects Apple.
+	// An empty platform with offerings but no store apps must keep onboarding
+	// going, not fall through to the audit-only "all synced" stage.
 	if stage := detectSetupStage(cmd, rt, ""); stage.PromptID == "connect-apple" {
 		t.Fatalf("empty platform routed to Apple: %+v", stage)
+	}
+	if stage := detectSetupStage(cmd, rt, ""); stage.PromptID == "check-project" {
+		t.Fatalf("empty platform with no store apps must not report all synced: %+v", stage)
 	}
 	if stage := detectSetupStage(cmd, rt, "ios"); stage.PromptID != "connect-apple" {
 		t.Fatalf("iOS platform should connect Apple, got %+v", stage)

--- a/internal/cli/setup_detect_test.go
+++ b/internal/cli/setup_detect_test.go
@@ -28,7 +28,9 @@ func TestDetectAppProject(t *testing.T) {
 		{"xcode", []string{"MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, nil},
 		{"flutter", []string{"pubspec.yaml"}, "Flutter app", "cross", projectClear, nil},
 		{"react-native", []string{"package.json:{\"dependencies\":{\"react-native\":\"0.74\"}}"}, "React Native app", "cross", projectClear, nil},
-		{"android", []string{"settings.gradle"}, "Android project", "android", projectClear, nil},
+		{"android", []string{"build.gradle:plugins { id \"com.android.application\" }"}, "Android project", "android", projectClear, nil},
+		// A Gradle app declared only by its manifest (no plugin id in build.gradle) is still Android.
+		{"android-via-manifest", []string{"build.gradle:plugins {}", "app/src/main/AndroidManifest.xml"}, "Android project", "android", projectClear, nil},
 		{"tuist", []string{"Project.swift"}, "Tuist project (iOS)", "ios", projectClear, nil},
 		// A CocoaPods iOS project surfaces twice but is still one clear app.
 		{"xcode-with-workspace", []string{"MyApp.xcodeproj/project.pbxproj", "MyApp.xcworkspace/contents.xcworkspacedata"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, nil},
@@ -37,14 +39,20 @@ func TestDetectAppProject(t *testing.T) {
 
 		// A mobile app carrying a tooling package.json is still one clear app.
 		{"ios-with-tooling-package-json", []string{"MyApp.xcodeproj/project.pbxproj", "package.json:{\"dependencies\":{\"prettier\":\"3\"}}"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, nil},
-		{"android-with-tooling-package-json", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "settings.gradle"}, "Android project", "android", projectClear, nil},
+		{"android-with-tooling-package-json", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "build.gradle:plugins { id \"com.android.application\" }"}, "Android project", "android", projectClear, nil},
 
-		{"nested-ios-and-android", []string{"MyApp.xcodeproj/project.pbxproj", "settings.gradle"}, "multiple projects detected (Xcode project (MyApp.xcodeproj), Android project)", "", projectAmbiguous, nil},
+		{"nested-ios-and-android", []string{"MyApp.xcodeproj/project.pbxproj", "build.gradle:plugins { id \"com.android.application\" }"}, "multiple projects detected (Xcode project (MyApp.xcodeproj), Android project)", "", projectAmbiguous, nil},
 
 		// No markers at the root, but a single app one level down is picked up.
 		{"single-app-in-subdir", []string{"ios/MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj) (in ./ios)", "ios", projectClear, []string{"ios"}},
-		{"two-apps-in-subdirs", []string{"android-app/settings.gradle", "ios-app/MyApp.xcodeproj/project.pbxproj"}, "multiple app projects in subdirectories (Android project (./android-app), Xcode project (MyApp.xcodeproj) (./ios-app))", "", projectAmbiguous, []string{"android-app", "ios-app"}},
+		{"two-apps-in-subdirs", []string{"android-app/build.gradle:plugins { id \"com.android.application\" }", "ios-app/MyApp.xcodeproj/project.pbxproj"}, "multiple app projects in subdirectories (Android project (./android-app), Xcode project (MyApp.xcodeproj) (./ios-app))", "", projectAmbiguous, []string{"android-app", "ios-app"}},
 		{"subdir-scan-skips-dependencies", []string{"node_modules/pubspec.yaml"}, "no app project detected", "", projectNone, nil},
+
+		// Capacitor-style layout: Xcode project nested in ios/App, Gradle app in android/.
+		{"capacitor-nested-both", []string{"package.json:{\"dependencies\":{\"@capacitor/core\":\"5\"}}", "android/build.gradle:plugins { id \"com.android.application\" }", "ios/App/MyApp.xcodeproj/project.pbxproj"}, "multiple app projects in subdirectories (Android project (./android), Xcode project (MyApp.xcodeproj) (./ios))", "", projectAmbiguous, []string{"android", "ios"}},
+		{"capacitor-nested-ios-only", []string{"package.json:{\"dependencies\":{\"@capacitor/core\":\"5\"}}", "ios/App/MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj) (in ./ios)", "ios", projectClear, []string{"ios"}},
+		// A JVM/Gradle backend next to a web project is not a mobile app.
+		{"web-root-with-gradle-backend", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "backend/build.gradle:plugins { id \"org.jetbrains.kotlin.jvm\" }"}, "JavaScript project (not a mobile app)", "", projectNonMobile, nil},
 
 		// A non-mobile root (web/tooling package.json) must not hide a nested app.
 		{"web-root-with-nested-ios", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "ios/MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj) (in ./ios)", "ios", projectClear, []string{"ios"}},

--- a/internal/cli/setup_detect_test.go
+++ b/internal/cli/setup_detect_test.go
@@ -25,7 +25,10 @@ func TestDetectAppProject(t *testing.T) {
 
 		{"js-backend", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}"}, "JavaScript project (not a mobile app)", "", projectNonMobile},
 
-		{"nested-js-and-android", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "settings.gradle"}, "multiple projects detected (JavaScript project, Android project)", "", projectAmbiguous},
+		// A mobile app carrying a tooling package.json is still one clear app.
+		{"ios-with-tooling-package-json", []string{"MyApp.xcodeproj/project.pbxproj", "package.json:{\"dependencies\":{\"prettier\":\"3\"}}"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear},
+		{"android-with-tooling-package-json", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "settings.gradle"}, "Android project", "android", projectClear},
+
 		{"nested-ios-and-android", []string{"MyApp.xcodeproj/project.pbxproj", "settings.gradle"}, "multiple projects detected (Xcode project (MyApp.xcodeproj), Android project)", "", projectAmbiguous},
 
 		{"empty", nil, "no app project detected", "", projectNone},

--- a/internal/cli/setup_detect_test.go
+++ b/internal/cli/setup_detect_test.go
@@ -23,24 +23,30 @@ func TestDetectAppProject(t *testing.T) {
 		wantLabel    string
 		wantPlatform string
 		wantStatus   projectStatus
+		wantAppDir   string
 	}{
-		{"xcode", []string{"MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear},
-		{"flutter", []string{"pubspec.yaml"}, "Flutter app", "cross", projectClear},
-		{"react-native", []string{"package.json:{\"dependencies\":{\"react-native\":\"0.74\"}}"}, "React Native app", "cross", projectClear},
-		{"android", []string{"settings.gradle"}, "Android project", "android", projectClear},
-		{"tuist", []string{"Project.swift"}, "Tuist project (iOS)", "ios", projectClear},
+		{"xcode", []string{"MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, ""},
+		{"flutter", []string{"pubspec.yaml"}, "Flutter app", "cross", projectClear, ""},
+		{"react-native", []string{"package.json:{\"dependencies\":{\"react-native\":\"0.74\"}}"}, "React Native app", "cross", projectClear, ""},
+		{"android", []string{"settings.gradle"}, "Android project", "android", projectClear, ""},
+		{"tuist", []string{"Project.swift"}, "Tuist project (iOS)", "ios", projectClear, ""},
 		// A CocoaPods iOS project surfaces twice but is still one clear app.
-		{"xcode-with-workspace", []string{"MyApp.xcodeproj/project.pbxproj", "MyApp.xcworkspace/contents.xcworkspacedata"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear},
+		{"xcode-with-workspace", []string{"MyApp.xcodeproj/project.pbxproj", "MyApp.xcworkspace/contents.xcworkspacedata"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, ""},
 
-		{"js-backend", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}"}, "JavaScript project (not a mobile app)", "", projectNonMobile},
+		{"js-backend", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}"}, "JavaScript project (not a mobile app)", "", projectNonMobile, ""},
 
 		// A mobile app carrying a tooling package.json is still one clear app.
-		{"ios-with-tooling-package-json", []string{"MyApp.xcodeproj/project.pbxproj", "package.json:{\"dependencies\":{\"prettier\":\"3\"}}"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear},
-		{"android-with-tooling-package-json", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "settings.gradle"}, "Android project", "android", projectClear},
+		{"ios-with-tooling-package-json", []string{"MyApp.xcodeproj/project.pbxproj", "package.json:{\"dependencies\":{\"prettier\":\"3\"}}"}, "Xcode project (MyApp.xcodeproj)", "ios", projectClear, ""},
+		{"android-with-tooling-package-json", []string{"package.json:{\"dependencies\":{\"express\":\"4\"}}", "settings.gradle"}, "Android project", "android", projectClear, ""},
 
-		{"nested-ios-and-android", []string{"MyApp.xcodeproj/project.pbxproj", "settings.gradle"}, "multiple projects detected (Xcode project (MyApp.xcodeproj), Android project)", "", projectAmbiguous},
+		{"nested-ios-and-android", []string{"MyApp.xcodeproj/project.pbxproj", "settings.gradle"}, "multiple projects detected (Xcode project (MyApp.xcodeproj), Android project)", "", projectAmbiguous, ""},
 
-		{"empty", nil, "no app project detected", "", projectNone},
+		// No markers at the root, but a single app one level down is picked up.
+		{"single-app-in-subdir", []string{"ios/MyApp.xcodeproj/project.pbxproj"}, "Xcode project (MyApp.xcodeproj) (in ./ios)", "ios", projectClear, "ios"},
+		{"two-apps-in-subdirs", []string{"android-app/settings.gradle", "ios-app/MyApp.xcodeproj/project.pbxproj"}, "multiple app projects in subdirectories (Android project (./android-app), Xcode project (MyApp.xcodeproj) (./ios-app))", "", projectAmbiguous, ""},
+		{"subdir-scan-skips-dependencies", []string{"node_modules/pubspec.yaml"}, "no app project detected", "", projectNone, ""},
+
+		{"empty", nil, "no app project detected", "", projectNone, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -58,10 +64,10 @@ func TestDetectAppProject(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			label, platform, status := detectAppProject(dir)
-			if label != tc.wantLabel || platform != tc.wantPlatform || status != tc.wantStatus {
-				t.Fatalf("detectAppProject = %q,%q,%d want %q,%q,%d",
-					label, platform, status, tc.wantLabel, tc.wantPlatform, tc.wantStatus)
+			label, platform, status, appDir := detectAppProject(dir)
+			if label != tc.wantLabel || platform != tc.wantPlatform || status != tc.wantStatus || appDir != tc.wantAppDir {
+				t.Fatalf("detectAppProject = %q,%q,%d,%q want %q,%q,%d,%q",
+					label, platform, status, appDir, tc.wantLabel, tc.wantPlatform, tc.wantStatus, tc.wantAppDir)
 			}
 		})
 	}
@@ -129,17 +135,22 @@ func TestPlatformFromLabel(t *testing.T) {
 }
 
 func TestSetupProjectNote(t *testing.T) {
-	if note := setupProjectNote(projectClear); note != "" {
+	if note := setupProjectNote(projectClear, ""); note != "" {
 		t.Errorf("clear project should add no note, got %q", note)
 	}
 	for _, status := range []projectStatus{projectAmbiguous, projectNonMobile, projectNone} {
-		note := setupProjectNote(status)
+		note := setupProjectNote(status, "")
 		if note == "" {
 			t.Errorf("status %d should hand the platform decision to the agent, got empty note", status)
 		}
 		if !strings.Contains(note, "Project detection:") {
 			t.Errorf("status %d note missing detection prefix: %q", status, note)
 		}
+	}
+	// A clear app in a subdirectory tells the agent where it is.
+	note := setupProjectNote(projectClear, "ios")
+	if !strings.Contains(note, "./ios") {
+		t.Errorf("subdir note should point at ./ios, got %q", note)
 	}
 }
 


### PR DESCRIPTION
`rc setup` used to grab the first project marker it found in the current directory. So a directory with several markers picked one arbitrarily and asserted a platform, and a plain web/backend `package.json` was reported as a project *with* a platform hint — handing the agent a wrong guess (an Apple step for a backend, or one arbitrary app in a mixed directory).

### Now

Detection looks at everything in the directory and classifies it:
- **one mobile app** → keeps its platform and the guided happy path
- **several distinct mobile platforms** (e.g. an Xcode project *and* a Gradle project together) → no platform; hands the choice to the agent
- **non-mobile** (web/backend) → no platform; the agent confirms what needs RevenueCat

A stray tooling `package.json` (Fastlane-JS, Prettier, a docs site) no longer counts as a second project — only real mobile platforms make it ambiguous.

### App in a subdirectory

Lots of repos keep the app one level down (`./ios`, `./app`, `./apps/mobile`). When the working directory has no markers of its own, detection now looks one level down:
- **exactly one** mobile app in a subdir → picked, with the path shown (`… (in ./ios)`) and passed to the agent so it works in the right place
- **several** app subdirs → ambiguous, deferred to the agent
- dependency/build dirs (`node_modules`, `Pods`, `build`, …) are skipped

Detection stays local and cheap — the current dir plus one level down, never a full recursive walk.

The safety property throughout: every non-single-app case returns an empty platform, so `applePending` can't fire and a web or multi-project directory is never pushed into Apple 2FA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding path selection and Apple-deferral based on local filesystem heuristics. Wrong classification can skip Apple 2FA or send the agent to the wrong app, but it does not touch auth or API credentials.
> 
> **Overview**
> `rc setup` no longer treats the first project marker as the app. Detection now classifies the working directory as **one clear mobile app**, **ambiguous** (multiple mobile platforms), **non-mobile**, or **none**, and only a clear case gets a platform.
> 
> When the cwd has no mobile markers, it looks **one level down** (skipping `node_modules`, `Pods`, build dirs). A single nested app is selected and the path is passed to the agent; several apps stay ambiguous. Android is claimed only with the Android Gradle plugin or a manifest, and Capacitor’s `ios/App` layout is recognized without treating a bare `./App` as a root iOS project.
> 
> Ambiguous, non-mobile, and empty platforms no longer assume Apple. Setup stage detection defers store choice instead of routing to `connect-apple` or reporting catalogs as fully synced. Agent prompts include a short project-detection note so the agent confirms the target instead of guessing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561007eb01c6552db6cb393e4a128a8bec2bf812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->