### PR TITLE
feat(config): per-directory project binding via .revenuecat.json

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -833,11 +833,11 @@ func clearProjectBinding(rt *Runtime) {
 	if rt.Globals.ProjectID != "" {
 		return
 	}
-	if rt.Config.ProjectID != "" {
-		rt.Out.Info("Cleared saved project " + rt.Config.ProjectID + ".")
+	if stored := rt.Config.StoredProjectID(); stored != "" {
+		rt.Out.Info("Cleared saved project " + stored + ".")
 		rt.Out.Hint("Pick one for this account:  rc projects use")
 	}
-	rt.Config.ProjectID = ""
+	rt.Config.UseProjectID("")
 }
 
 func finishLogin(ctx context.Context, rt *Runtime, _ *api.Client) error {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -831,6 +831,9 @@ func signupAuthenticationError(err error) error {
 // --project-id / RC_PROJECT_ID passed alongside the login is kept.
 func clearProjectBinding(rt *Runtime) {
 	if rt.Globals.ProjectID != "" {
+		// Login is the one path that adopts an explicit --project-id as the new
+		// default; promote it from a transient override to a persisted choice.
+		rt.Config.UseProjectID(rt.Globals.ProjectID)
 		return
 	}
 	if stored := rt.Config.StoredProjectID(); stored != "" {

--- a/internal/cli/customers.go
+++ b/internal/cli/customers.go
@@ -571,7 +571,7 @@ func pickProjectInteractive(ctx context.Context, rt *Runtime) (string, error) {
 		return pick, nil
 	}
 
-	rt.Config.ProjectID = projectID
+	rt.Config.UseProjectID(projectID)
 	if err := config.Save(rt.Globals.Profile, rt.Config); err != nil {
 		rt.Out.Info(fmt.Sprintf("note: couldn't save profile: %v", err))
 	}

--- a/internal/cli/profiles.go
+++ b/internal/cli/profiles.go
@@ -54,7 +54,7 @@ func newProfilesListCmd() *cobra.Command {
 				if n == active {
 					marker = "*"
 				}
-				cfg, _ := config.Load(n)
+				cfg, _ := config.LoadStored(n)
 				project := ""
 				if cfg != nil {
 					project = cfg.ProjectID

--- a/internal/cli/projects.go
+++ b/internal/cli/projects.go
@@ -161,7 +161,7 @@ current profile.`,
 				return err
 			}
 			if use {
-				rt.Config.ProjectID = p.ID
+				rt.Config.UseProjectID(p.ID)
 				if err := config.Save(rt.Globals.Profile, rt.Config); err != nil {
 					return err
 				}
@@ -261,7 +261,7 @@ The chosen project is written to the active profile file (default:
 				return err
 			}
 
-			rt.Config.ProjectID = p.ID
+			rt.Config.UseProjectID(p.ID)
 			if err := config.Save(rt.Globals.Profile, rt.Config); err != nil {
 				return err
 			}

--- a/internal/cli/projects.go
+++ b/internal/cli/projects.go
@@ -169,6 +169,7 @@ current profile.`,
 			rt.Out.Success(fmt.Sprintf("Created project %s", p.ID))
 			if use {
 				rt.Out.Success(fmt.Sprintf("Active project: %s (%s)", p.Name, p.ID))
+				warnDirBindingShadow(rt, p.ID)
 			}
 			return rt.Out.Render(map[string]any{
 				"project": p,
@@ -247,6 +248,7 @@ The chosen project is written to the active profile file (default:
 							return err
 						}
 						rt.Out.Success("No default project set — you'll be prompted on each command.")
+						warnDirBindingShadow(rt, "")
 						return rt.Out.Render(map[string]any{
 							"profile":    config.ProfileName(rt.Globals.Profile),
 							"project_id": "",
@@ -267,6 +269,7 @@ The chosen project is written to the active profile file (default:
 			}
 
 			rt.Out.Success(fmt.Sprintf("Active project: %s (%s)", p.Name, p.ID))
+			warnDirBindingShadow(rt, p.ID)
 			return rt.Out.Render(map[string]any{
 				"profile":    config.ProfileName(rt.Globals.Profile),
 				"project_id": p.ID,
@@ -274,6 +277,22 @@ The chosen project is written to the active profile file (default:
 			})
 		},
 	}
+}
+
+// warnDirBindingShadow warns when a committed .revenuecat.json binding in the
+// current tree resolves to a different project than the profile default just
+// set or cleared. The precedence (binding > profile default) is intentional;
+// the hazard is that it's silent, so name the binding's project and file and
+// state that commands here use it until the file changes. selected is the id
+// just persisted, or "" when the default was cleared (any binding then shadows
+// it and keeps suppressing the prompt).
+func warnDirBindingShadow(rt *Runtime, selected string) {
+	path, bound, ok := config.DirBinding()
+	if !ok || bound == selected {
+		return
+	}
+	rt.Out.Warn(fmt.Sprintf("A directory binding overrides this: %s pins project %s.", path, bound))
+	rt.Out.Hint(fmt.Sprintf("Commands run in this directory will use %s, not the profile default, until you change or remove %s.", bound, path))
 }
 
 func formatMillis(m int64) string {

--- a/internal/cli/projects.go
+++ b/internal/cli/projects.go
@@ -167,17 +167,22 @@ current profile.`,
 				}
 			}
 			rt.Out.Success(fmt.Sprintf("Created project %s", p.ID))
+			var shadow *dirBindingShadow
 			if use {
 				rt.Out.Success(fmt.Sprintf("Active project: %s (%s)", p.Name, p.ID))
-				warnDirBindingShadow(rt, p.ID)
+				shadow = warnDirBindingShadow(rt, p.ID)
 			}
-			return rt.Out.Render(map[string]any{
+			result := map[string]any{
 				"project": p,
 				"profile": map[string]any{
 					"name":       config.ProfileName(rt.Globals.Profile),
 					"project_id": rt.Config.ProjectID,
 				},
-			})
+			}
+			if shadow != nil {
+				result["dir_binding_shadow"] = shadow
+			}
+			return rt.Out.Render(result)
 		},
 	}
 	cmd.Flags().StringVar(&name, "name", "", "project name (required)")
@@ -248,11 +253,14 @@ The chosen project is written to the active profile file (default:
 							return err
 						}
 						rt.Out.Success("No default project set — you'll be prompted on each command.")
-						warnDirBindingShadow(rt, "")
-						return rt.Out.Render(map[string]any{
+						result := map[string]any{
 							"profile":    config.ProfileName(rt.Globals.Profile),
 							"project_id": "",
-						})
+						}
+						if shadow := warnDirBindingShadow(rt, ""); shadow != nil {
+							result["dir_binding_shadow"] = shadow
+						}
+						return rt.Out.Render(result)
 					}
 				}
 			}
@@ -269,30 +277,44 @@ The chosen project is written to the active profile file (default:
 			}
 
 			rt.Out.Success(fmt.Sprintf("Active project: %s (%s)", p.Name, p.ID))
-			warnDirBindingShadow(rt, p.ID)
-			return rt.Out.Render(map[string]any{
+			result := map[string]any{
 				"profile":    config.ProfileName(rt.Globals.Profile),
 				"project_id": p.ID,
 				"name":       p.Name,
-			})
+			}
+			if shadow := warnDirBindingShadow(rt, p.ID); shadow != nil {
+				result["dir_binding_shadow"] = shadow
+			}
+			return rt.Out.Render(result)
 		},
 	}
 }
 
-// warnDirBindingShadow warns when a committed .revenuecat.json binding in the
-// current tree resolves to a different project than the profile default just
-// set or cleared. The precedence (binding > profile default) is intentional;
-// the hazard is that it's silent, so name the binding's project and file and
-// state that commands here use it until the file changes. selected is the id
-// just persisted, or "" when the default was cleared (any binding then shadows
-// it and keeps suppressing the prompt).
-func warnDirBindingShadow(rt *Runtime, selected string) {
+// dirBindingShadow describes a committed .revenuecat.json binding that
+// outranks the profile default. It is surfaced in --json results so agents
+// (which run in --json, where Warn/Hint are no-ops) still see the shadowing.
+type dirBindingShadow struct {
+	ProjectID string `json:"project_id"`
+	File      string `json:"file"`
+}
+
+// warnDirBindingShadow reports a committed .revenuecat.json binding in the
+// current tree that resolves to a different project than the profile default
+// just set or cleared. The precedence (binding > profile default) is
+// intentional; the hazard is that it's silent, so name the binding's project
+// and file and state that commands here use it until the file changes. In
+// human mode it emits a Warn+Hint; in every mode it returns the shadow (nil
+// when nothing shadows) so callers can include it in --json output. selected
+// is the id just persisted, or "" when the default was cleared (any binding
+// then shadows it and keeps suppressing the prompt).
+func warnDirBindingShadow(rt *Runtime, selected string) *dirBindingShadow {
 	path, bound, ok := config.DirBinding()
 	if !ok || bound == selected {
-		return
+		return nil
 	}
 	rt.Out.Warn(fmt.Sprintf("A directory binding overrides this: %s pins project %s.", path, bound))
 	rt.Out.Hint(fmt.Sprintf("Commands run in this directory will use %s, not the profile default, until you change or remove %s.", bound, path))
+	return &dirBindingShadow{ProjectID: bound, File: path}
 }
 
 func formatMillis(m int64) string {

--- a/internal/cli/projects_test.go
+++ b/internal/cli/projects_test.go
@@ -46,43 +46,82 @@ func TestWarnDirBindingShadow(t *testing.T) {
 		t.Chdir(dir)
 	}
 
-	run := func(t *testing.T, selected string) string {
+	run := func(t *testing.T, selected string) (string, *dirBindingShadow) {
 		t.Helper()
 		var errb bytes.Buffer
 		rt := &Runtime{
 			Globals: &Globals{},
 			Out:     output.NewRenderer(&bytes.Buffer{}, &errb, false, true, false, ""),
 		}
-		warnDirBindingShadow(rt, selected)
-		return errb.String()
+		shadow := warnDirBindingShadow(rt, selected)
+		return errb.String(), shadow
 	}
 
 	t.Run("warns when binding shadows a different selected project", func(t *testing.T) {
 		writeBinding(t, "proj_bound")
-		out := run(t, "proj_chosen")
+		out, shadow := run(t, "proj_chosen")
 		if !strings.Contains(out, "proj_bound") || !strings.Contains(out, config.ProjectFileName) {
 			t.Errorf("expected warning naming the binding project and file, got %q", out)
+		}
+		if shadow == nil {
+			t.Fatal("expected a shadow to be returned for --json output")
+		}
+		if shadow.ProjectID != "proj_bound" {
+			t.Errorf("shadow.ProjectID = %q, want proj_bound", shadow.ProjectID)
+		}
+		if !strings.Contains(shadow.File, config.ProjectFileName) {
+			t.Errorf("shadow.File = %q, want it to name %s", shadow.File, config.ProjectFileName)
 		}
 	})
 
 	t.Run("silent when binding matches the selected project", func(t *testing.T) {
 		writeBinding(t, "proj_bound")
-		if out := run(t, "proj_bound"); out != "" {
+		out, shadow := run(t, "proj_bound")
+		if out != "" {
 			t.Errorf("expected no warning when binding matches, got %q", out)
+		}
+		if shadow != nil {
+			t.Errorf("expected no shadow when binding matches, got %+v", shadow)
 		}
 	})
 
 	t.Run("warns when the default was cleared and a binding still applies", func(t *testing.T) {
 		writeBinding(t, "proj_bound")
-		if out := run(t, ""); !strings.Contains(out, "proj_bound") {
+		out, shadow := run(t, "")
+		if !strings.Contains(out, "proj_bound") {
 			t.Errorf("expected warning after clearing the default, got %q", out)
+		}
+		if shadow == nil || shadow.ProjectID != "proj_bound" {
+			t.Errorf("expected shadow naming proj_bound after clearing, got %+v", shadow)
 		}
 	})
 
 	t.Run("silent when there is no binding", func(t *testing.T) {
 		t.Chdir(t.TempDir())
-		if out := run(t, "proj_chosen"); out != "" {
+		out, shadow := run(t, "proj_chosen")
+		if out != "" {
 			t.Errorf("expected no warning without a binding, got %q", out)
+		}
+		if shadow != nil {
+			t.Errorf("expected no shadow without a binding, got %+v", shadow)
+		}
+	})
+
+	// Under --json the human Warn/Hint are no-ops, but the shadow must still be
+	// returned so the rendered result can carry it — the mode agents run in.
+	t.Run("json mode still returns the shadow", func(t *testing.T) {
+		writeBinding(t, "proj_bound")
+		var errb bytes.Buffer
+		rt := &Runtime{
+			Globals: &Globals{},
+			Out:     output.NewRenderer(&bytes.Buffer{}, &errb, true, true, false, ""),
+		}
+		shadow := warnDirBindingShadow(rt, "proj_chosen")
+		if errb.Len() != 0 {
+			t.Errorf("json mode must not write human warnings to stderr, got %q", errb.String())
+		}
+		if shadow == nil || shadow.ProjectID != "proj_bound" {
+			t.Errorf("expected shadow in json mode, got %+v", shadow)
 		}
 	})
 }

--- a/internal/cli/projects_test.go
+++ b/internal/cli/projects_test.go
@@ -1,6 +1,15 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/config"
+	"github.com/revenuecat/cli/internal/output"
+)
 
 func TestDashboardProjectID(t *testing.T) {
 	tests := []struct {
@@ -24,4 +33,56 @@ func TestDashboardProjectID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWarnDirBindingShadow(t *testing.T) {
+	writeBinding := func(t *testing.T, id string) {
+		t.Helper()
+		dir := t.TempDir()
+		body := []byte(`{"project_id": "` + id + `"}`)
+		if err := os.WriteFile(filepath.Join(dir, config.ProjectFileName), body, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(dir)
+	}
+
+	run := func(t *testing.T, selected string) string {
+		t.Helper()
+		var errb bytes.Buffer
+		rt := &Runtime{
+			Globals: &Globals{},
+			Out:     output.NewRenderer(&bytes.Buffer{}, &errb, false, true, false, ""),
+		}
+		warnDirBindingShadow(rt, selected)
+		return errb.String()
+	}
+
+	t.Run("warns when binding shadows a different selected project", func(t *testing.T) {
+		writeBinding(t, "proj_bound")
+		out := run(t, "proj_chosen")
+		if !strings.Contains(out, "proj_bound") || !strings.Contains(out, config.ProjectFileName) {
+			t.Errorf("expected warning naming the binding project and file, got %q", out)
+		}
+	})
+
+	t.Run("silent when binding matches the selected project", func(t *testing.T) {
+		writeBinding(t, "proj_bound")
+		if out := run(t, "proj_bound"); out != "" {
+			t.Errorf("expected no warning when binding matches, got %q", out)
+		}
+	})
+
+	t.Run("warns when the default was cleared and a binding still applies", func(t *testing.T) {
+		writeBinding(t, "proj_bound")
+		if out := run(t, ""); !strings.Contains(out, "proj_bound") {
+			t.Errorf("expected warning after clearing the default, got %q", out)
+		}
+	})
+
+	t.Run("silent when there is no binding", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		if out := run(t, "proj_chosen"); out != "" {
+			t.Errorf("expected no warning without a binding, got %q", out)
+		}
+	})
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -99,7 +99,7 @@ Agent-friendly entrypoints:
 	_ = pf.MarkHidden("verbose")
 	pf.StringVar(&g.Profile, "profile", "", "configuration profile to use (default: active profile)")
 	pf.StringVar(&g.APIKey, "api-key", "", "RevenueCat API key (overrides profile; or set RC_API_KEY)")
-	pf.StringVar(&g.ProjectID, "project-id", "", "RevenueCat project ID (overrides profile; or set RC_PROJECT_ID)")
+	pf.StringVar(&g.ProjectID, "project-id", "", "RevenueCat project ID (highest precedence, then RC_PROJECT_ID, then .revenuecat.json in the directory tree, then the profile default)")
 	pf.StringVar(&g.Format, "format", "", "jq expression applied to --json output (e.g. '.data.items[].id')")
 	pf.BoolVar(&g.NoColor, "no-color", false, "disable ANSI color (also honors NO_COLOR)")
 	pf.BoolVarP(&g.AssumeYes, "yes", "y", false, "assume yes for confirmation prompts")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -77,7 +77,10 @@ Agent-friendly entrypoints:
 			}
 			cfg.SetFlagAPIKey(g.APIKey)
 			if g.ProjectID != "" {
-				cfg.ProjectID = g.ProjectID
+				cfg.UseProjectID(g.ProjectID)
+			}
+			if err := cfg.ProjectBindingError(g.ProjectID != ""); err != nil {
+				return err
 			}
 			rt := &Runtime{
 				Globals: g,

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -76,9 +76,10 @@ Agent-friendly entrypoints:
 				return err
 			}
 			cfg.SetFlagAPIKey(g.APIKey)
-			if g.ProjectID != "" {
-				cfg.UseProjectID(g.ProjectID)
-			}
+			// --project-id is a transient per-invocation override for general
+			// commands; only login adopts it as the stored default (see
+			// clearProjectBinding).
+			cfg.OverrideProjectID(g.ProjectID)
 			if err := cfg.ProjectBindingError(g.ProjectID != ""); err != nil {
 				return err
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,11 @@ type Config struct {
 
 	// flagAPIKey holds an --api-key value for this invocation; never serialized.
 	flagAPIKey string
+
+	// Provenance of a --project-id flag applied for this invocation only. Like
+	// the env/dir overrides it is reverted in Save, so a one-shot flag is never
+	// baked into the profile default by an incidental save (e.g. a token refresh).
+	flagProjectID envOverride
 }
 
 // CredentialSource names where the active credential came from.
@@ -508,6 +513,20 @@ func (c *Config) UseProjectID(id string) {
 	c.ProjectID = id
 	c.envProjectID.set = false
 	c.dirProjectID.set = false
+	c.flagProjectID.set = false
+}
+
+// OverrideProjectID applies a --project-id flag for this invocation only. Unlike
+// UseProjectID it keeps the value out of the profile: it records provenance so
+// Save reverts it, so an ordinary command that happens to persist config (an
+// OAuth token refresh, say) never bakes a one-shot flag into the stored default.
+// Login adopts an explicit --project-id as the new default with UseProjectID.
+func (c *Config) OverrideProjectID(id string) {
+	if id == "" {
+		return
+	}
+	c.flagProjectID = envOverride{env: id, disk: c.ProjectID, set: true}
+	c.ProjectID = id
 }
 
 // StoredProjectID returns the profile's on-disk project default, unwinding any
@@ -519,6 +538,9 @@ func (c *Config) StoredProjectID() string {
 	}
 	if c.envProjectID.set {
 		return c.envProjectID.disk
+	}
+	if c.flagProjectID.set {
+		return c.flagProjectID.disk
 	}
 	return c.ProjectID
 }
@@ -555,9 +577,10 @@ func Save(profile string, cfg *Config) error {
 		}
 	}
 	revert(cfg.envAPIKey, &out.APIKey)
-	// Order matters: the env override's disk value is the per-dir binding when
-	// both applied, so unwind env first, then the per-dir binding, landing back
-	// on the profile's own project.
+	// Order matters: each override's disk value is the layer beneath it, so
+	// unwind from the top down — the --project-id flag, then RC_PROJECT_ID, then
+	// the per-dir binding — landing back on the profile's own project.
+	revert(cfg.flagProjectID, &out.ProjectID)
 	revert(cfg.envProjectID, &out.ProjectID)
 	revert(cfg.dirProjectID, &out.ProjectID)
 	revert(cfg.envBaseURL, &out.BaseURL)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -423,6 +423,27 @@ func dirProjectID() (string, bool, error) {
 	return dirProjectIDFrom(wd)
 }
 
+// DirBinding reports the nearest .revenuecat.json binding for the current
+// working directory: its file path and the project_id it resolves to. ok is
+// false when no readable, parseable binding applies (an unreadable one is
+// ProjectBindingError's concern, not this). Callers use it to warn when a
+// committed binding will shadow a profile default the user just set or cleared.
+func DirBinding() (path, projectID string, ok bool) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", "", false
+	}
+	p, found := findProjectFile(wd)
+	if !found {
+		return "", "", false
+	}
+	id, resolved, err := dirProjectIDFrom(wd)
+	if err != nil || !resolved {
+		return "", "", false
+	}
+	return p, id, true
+}
+
 func dirProjectIDFrom(start string) (string, bool, error) {
 	path, ok := findProjectFile(start)
 	if !ok {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,11 @@ type Config struct {
 	envProjectID envOverride
 	envBaseURL   envOverride
 
+	// Provenance of the per-directory project binding (see ProjectFileName).
+	// Like the env overrides it applies for a single invocation and is reverted
+	// in Save, so a tree-local project is never baked into the profile on disk.
+	dirProjectID envOverride
+
 	// flagAPIKey holds an --api-key value for this invocation; never serialized.
 	flagAPIKey string
 }
@@ -101,7 +106,6 @@ func (c *Config) BearerToken() string {
 	return tok
 }
 
-// Credential resolves the active auth credential and reports its source.
 func (c *Config) Credential() (token string, source CredentialSource) {
 	if c.flagAPIKey != "" {
 		return c.flagAPIKey, SourceFlag
@@ -194,7 +198,6 @@ func (c *Config) PresentCredentialSources() []CredentialSource {
 	return s
 }
 
-// SetFlagAPIKey records an --api-key value for this invocation.
 func (c *Config) SetFlagAPIKey(key string) { c.flagAPIKey = key }
 
 // SetAPIKey sets an explicit stored API key, clearing any flag or env override.
@@ -378,7 +381,61 @@ func profilePath(profile string) (string, error) {
 	return filepath.Join(dir, name+".json"), nil
 }
 
-// Load reads a profile from disk, layering env vars on top.
+// ProjectFileName is a per-directory project binding, discovered by walking up
+// from the working directory like git finding .git, so a repo can commit it.
+const ProjectFileName = ".revenuecat.json"
+
+type projectFile struct {
+	ProjectID string `json:"project_id"`
+}
+
+// findProjectFile returns the nearest ProjectFileName walking up from start.
+func findProjectFile(start string) (string, bool) {
+	dir := start
+	for {
+		p := filepath.Join(dir, ProjectFileName)
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			return p, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+func dirProjectID() (string, bool) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	return dirProjectIDFrom(wd)
+}
+
+func dirProjectIDFrom(start string) (string, bool) {
+	path, ok := findProjectFile(start)
+	if !ok {
+		return "", false
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var f projectFile
+	if err := json.Unmarshal(b, &f); err != nil {
+		return "", false
+	}
+	if f.ProjectID == "" {
+		return "", false
+	}
+	return f.ProjectID, true
+}
+
+// Load reads a profile from disk, layering the per-directory project binding
+// and env vars on top. The project ID resolves with this precedence (highest
+// first): --project-id flag (applied by the caller) > RC_PROJECT_ID env >
+// nearest .revenuecat.json in the directory tree > profile default.
 // Missing files are not an error — they return a zero Config so first-run
 // commands like `rc login` work cleanly.
 func Load(profile string) (*Config, error) {
@@ -397,6 +454,13 @@ func Load(profile string) (*Config, error) {
 	// Credentials live in the OS keyring when available; overlay them onto
 	// whatever the file held (the file carries them only as a fallback).
 	loadSecrets(profile, cfg)
+	// The per-directory binding overrides the profile default but sits below
+	// RC_PROJECT_ID and --project-id, which are applied after it. Recorded as an
+	// override so Save reverts it rather than persisting a tree-local project.
+	if pid, ok := dirProjectID(); ok {
+		cfg.dirProjectID = envOverride{env: pid, disk: cfg.ProjectID, set: true}
+		cfg.ProjectID = pid
+	}
 	applyEnv := func(o *envOverride, env string, cur *string) {
 		if env == "" {
 			return
@@ -430,7 +494,11 @@ func Save(profile string, cfg *Config) error {
 		}
 	}
 	revert(cfg.envAPIKey, &out.APIKey)
+	// Order matters: the env override's disk value is the per-dir binding when
+	// both applied, so unwind env first, then the per-dir binding, landing back
+	// on the profile's own project.
 	revert(cfg.envProjectID, &out.ProjectID)
+	revert(cfg.dirProjectID, &out.ProjectID)
 	revert(cfg.envBaseURL, &out.BaseURL)
 
 	// Try the OS keyring first; on success the file omits the secrets, on

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -474,6 +474,16 @@ func Load(profile string) (*Config, error) {
 	return cfg, nil
 }
 
+// UseProjectID records a project the user chose explicitly (projects use,
+// projects create --use, the picker). It clears the env/dir project overrides
+// so Save persists the choice even when it equals the injected override value —
+// otherwise the revert would mistake the deliberate write for an untouched override.
+func (c *Config) UseProjectID(id string) {
+	c.ProjectID = id
+	c.envProjectID.set = false
+	c.dirProjectID.set = false
+}
+
 func Save(profile string, cfg *Config) error {
 	path, err := profilePath(profile)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,11 @@ type Config struct {
 	// in Save, so a tree-local project is never baked into the profile on disk.
 	dirProjectID envOverride
 
+	// dirProjectErr holds a nearest .revenuecat.json that exists but could not
+	// be read or parsed. Load records it instead of failing so a higher-
+	// precedence override still bypasses it; ProjectBindingError surfaces it.
+	dirProjectErr error
+
 	// flagAPIKey holds an --api-key value for this invocation; never serialized.
 	flagAPIKey string
 }
@@ -470,13 +475,15 @@ func Load(profile string) (*Config, error) {
 	// The per-directory binding overrides the profile default but sits below
 	// RC_PROJECT_ID and --project-id, which are applied after it. Recorded as an
 	// override so Save reverts it rather than persisting a tree-local project.
-	// A binding file that exists but can't be read or parsed is an error, not a
-	// silent fall-through to another project.
-	pid, ok, err := dirProjectID()
-	if err != nil {
-		return nil, err
-	}
-	if ok {
+	// A binding file that exists but can't be read or parsed is recorded, not
+	// fatal: a higher-precedence override (RC_PROJECT_ID or --project-id) still
+	// wins, and otherwise ProjectBindingError surfaces it rather than silently
+	// falling through to another project.
+	pid, ok, derr := dirProjectID()
+	switch {
+	case derr != nil:
+		cfg.dirProjectErr = derr
+	case ok:
 		cfg.dirProjectID = envOverride{env: pid, disk: cfg.ProjectID, set: true}
 		cfg.ProjectID = pid
 	}
@@ -501,6 +508,31 @@ func (c *Config) UseProjectID(id string) {
 	c.ProjectID = id
 	c.envProjectID.set = false
 	c.dirProjectID.set = false
+}
+
+// StoredProjectID returns the profile's on-disk project default, unwinding any
+// per-invocation overlay (the per-directory binding or RC_PROJECT_ID) that Load
+// layered on top of it.
+func (c *Config) StoredProjectID() string {
+	if c.dirProjectID.set {
+		return c.dirProjectID.disk
+	}
+	if c.envProjectID.set {
+		return c.envProjectID.disk
+	}
+	return c.ProjectID
+}
+
+// ProjectBindingError reports a nearest .revenuecat.json that exists but could
+// not be read or parsed. It returns nil when a higher-precedence override wins
+// anyway — RC_PROJECT_ID (env) or an explicit --project-id (flagSet) — since
+// those bypass the tree binding entirely. Otherwise the malformed file would
+// silently retarget another project, so callers surface this before running.
+func (c *Config) ProjectBindingError(flagSet bool) error {
+	if c.dirProjectErr == nil || flagSet || c.envProjectID.set {
+		return nil
+	}
+	return c.dirProjectErr
 }
 
 func Save(profile string, cfg *Config) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -405,31 +405,31 @@ func findProjectFile(start string) (string, bool) {
 	}
 }
 
-func dirProjectID() (string, bool) {
+func dirProjectID() (string, bool, error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return "", false
+		return "", false, nil
 	}
 	return dirProjectIDFrom(wd)
 }
 
-func dirProjectIDFrom(start string) (string, bool) {
+func dirProjectIDFrom(start string) (string, bool, error) {
 	path, ok := findProjectFile(start)
 	if !ok {
-		return "", false
+		return "", false, nil
 	}
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return "", false
+		return "", false, fmt.Errorf("read %s: %w", path, err)
 	}
 	var f projectFile
 	if err := json.Unmarshal(b, &f); err != nil {
-		return "", false
+		return "", false, fmt.Errorf("parse %s: %w", path, err)
 	}
 	if f.ProjectID == "" {
-		return "", false
+		return "", false, fmt.Errorf("%s: missing or empty project_id", path)
 	}
-	return f.ProjectID, true
+	return f.ProjectID, true, nil
 }
 
 // Load reads a profile from disk, layering the per-directory project binding
@@ -438,7 +438,12 @@ func dirProjectIDFrom(start string) (string, bool) {
 // nearest .revenuecat.json in the directory tree > profile default.
 // Missing files are not an error — they return a zero Config so first-run
 // commands like `rc login` work cleanly.
-func Load(profile string) (*Config, error) {
+// LoadStored reads a profile's config as written on disk, overlaying keyring
+// secrets, without applying any per-invocation override (the per-directory
+// binding, RC_* env vars, or --project-id). Use it to report a profile's own
+// stored defaults, e.g. `profiles list`; use Load for the active resolved
+// config a command should act on.
+func LoadStored(profile string) (*Config, error) {
 	cfg := &Config{BaseURL: ""}
 	path, err := profilePath(profile)
 	if err != nil {
@@ -454,10 +459,24 @@ func Load(profile string) (*Config, error) {
 	// Credentials live in the OS keyring when available; overlay them onto
 	// whatever the file held (the file carries them only as a fallback).
 	loadSecrets(profile, cfg)
+	return cfg, nil
+}
+
+func Load(profile string) (*Config, error) {
+	cfg, err := LoadStored(profile)
+	if err != nil {
+		return nil, err
+	}
 	// The per-directory binding overrides the profile default but sits below
 	// RC_PROJECT_ID and --project-id, which are applied after it. Recorded as an
 	// override so Save reverts it rather than persisting a tree-local project.
-	if pid, ok := dirProjectID(); ok {
+	// A binding file that exists but can't be read or parsed is an error, not a
+	// silent fall-through to another project.
+	pid, ok, err := dirProjectID()
+	if err != nil {
+		return nil, err
+	}
+	if ok {
 		cfg.dirProjectID = envOverride{env: pid, disk: cfg.ProjectID, set: true}
 		cfg.ProjectID = pid
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -569,7 +569,7 @@ func TestLogin_FlagProjectMatchingDirBindingPersists(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Mirrors root.go applying --project-id equal to the tree binding.
+	// Mirrors login (clearProjectBinding) adopting --project-id equal to the tree binding.
 	cfg.UseProjectID("proj_dir")
 	if err := config.Save("default", cfg); err != nil {
 		t.Fatal(err)
@@ -696,6 +696,68 @@ func TestUseProjectID_PersistsChoiceEqualToDirBinding(t *testing.T) {
 	}
 	if got.ProjectID != "proj_dir" {
 		t.Errorf("explicit UseProjectID matching the dir binding must persist, got %q", got.ProjectID)
+	}
+}
+
+func TestOverrideProjectID_NotPersistedByIncidentalSave(t *testing.T) {
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": t.TempDir(), "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+	if err := config.Save("default", &config.Config{ProjectID: "proj_profile"}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A general command runs with --project-id; the override is in effect...
+	cfg.OverrideProjectID("proj_flag")
+	if cfg.ProjectID != "proj_flag" {
+		t.Fatalf("override should take effect for this invocation, got %q", cfg.ProjectID)
+	}
+	if got := cfg.StoredProjectID(); got != "proj_profile" {
+		t.Errorf("override must not change the stored default, StoredProjectID got %q", got)
+	}
+	// ...and then something persists config (e.g. an OAuth token refresh).
+	if err := config.Save("default", cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ProjectID != "proj_profile" {
+		t.Errorf("a one-shot --project-id must not be baked into the profile default, got %q", got.ProjectID)
+	}
+}
+
+func TestOverrideProjectID_MatchingDirBindingNotPersisted(t *testing.T) {
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": t.TempDir(), "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+	if err := config.Save("default", &config.Config{ProjectID: "proj_profile"}); err != nil {
+		t.Fatal(err)
+	}
+
+	work := t.TempDir()
+	writeProjectFile(t, work, "proj_dir")
+	t.Chdir(work)
+
+	cfg, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// --project-id equal to the tree binding, on a non-login command.
+	cfg.OverrideProjectID("proj_dir")
+	if err := config.Save("default", cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(t.TempDir())
+	got, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ProjectID != "proj_profile" {
+		t.Errorf("--project-id matching the dir binding must revert on an incidental save, got %q", got.ProjectID)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -482,7 +482,11 @@ func TestLoad_MalformedPerDirFileErrors(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Chdir(dir)
-		if _, err := config.Load("default"); err == nil {
+		cfg, err := config.Load("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ProjectBindingError(false) == nil {
 			t.Fatal("want error on malformed .revenuecat.json, got nil")
 		}
 	})
@@ -498,10 +502,110 @@ func TestLoad_MalformedPerDirFileErrors(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Chdir(dir)
-		if _, err := config.Load("default"); err == nil {
+		cfg, err := config.Load("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ProjectBindingError(false) == nil {
 			t.Fatal("want error when .revenuecat.json has no project_id, got nil")
 		}
 	})
+}
+
+func TestProjectBindingError_HigherOverridesBypassMalformedFile(t *testing.T) {
+	writeBad := func(t *testing.T) {
+		t.Helper()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, config.ProjectFileName), []byte("not json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(dir)
+	}
+
+	t.Run("RC_PROJECT_ID wins over malformed file", func(t *testing.T) {
+		t.Setenv("RC_CONFIG_DIR", t.TempDir())
+		clearProjectEnv(t)
+		writeBad(t)
+		t.Setenv("RC_PROJECT_ID", "proj_env")
+
+		cfg, err := config.Load("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ProjectID != "proj_env" {
+			t.Errorf("RC_PROJECT_ID should apply despite malformed file, got %q", cfg.ProjectID)
+		}
+		if err := cfg.ProjectBindingError(false); err != nil {
+			t.Errorf("malformed file must not block RC_PROJECT_ID, got %v", err)
+		}
+	})
+
+	t.Run("--project-id flag bypasses malformed file", func(t *testing.T) {
+		t.Setenv("RC_CONFIG_DIR", t.TempDir())
+		clearProjectEnv(t)
+		writeBad(t)
+
+		cfg, err := config.Load("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := cfg.ProjectBindingError(true); err != nil {
+			t.Errorf("malformed file must not block an explicit --project-id, got %v", err)
+		}
+	})
+}
+
+func TestLogin_FlagProjectMatchingDirBindingPersists(t *testing.T) {
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": t.TempDir(), "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+	if err := config.Save("default", &config.Config{ProjectID: "proj_old"}); err != nil {
+		t.Fatal(err)
+	}
+
+	work := t.TempDir()
+	writeProjectFile(t, work, "proj_dir")
+	t.Chdir(work)
+
+	cfg, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mirrors root.go applying --project-id equal to the tree binding.
+	cfg.UseProjectID("proj_dir")
+	if err := config.Save("default", cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(t.TempDir())
+	got, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ProjectID != "proj_dir" {
+		t.Errorf("--project-id matching the dir binding must persist over the old default, got %q", got.ProjectID)
+	}
+}
+
+func TestStoredProjectID_UnwindsOverlay(t *testing.T) {
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	clearProjectEnv(t)
+	if err := config.Save("default", &config.Config{ProjectID: "proj_profile"}); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	writeProjectFile(t, dir, "proj_dir")
+	t.Chdir(dir)
+	t.Setenv("RC_PROJECT_ID", "proj_env")
+
+	cfg, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ProjectID != "proj_env" {
+		t.Fatalf("setup: want env overlay active, got %q", cfg.ProjectID)
+	}
+	if got := cfg.StoredProjectID(); got != "proj_profile" {
+		t.Errorf("StoredProjectID should unwind overlays to the profile default, got %q", got)
+	}
 }
 
 func TestLoadStored_IgnoresPerDirBindingAndEnv(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -359,6 +359,160 @@ func TestSetAPIKey_SupersedesEnvOverride(t *testing.T) {
 	}
 }
 
+func writeProjectFile(t *testing.T, dir, projectID string) {
+	t.Helper()
+	body := []byte(`{"project_id": "` + projectID + `"}`)
+	if err := os.WriteFile(filepath.Join(dir, config.ProjectFileName), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func clearProjectEnv(t *testing.T) {
+	t.Helper()
+	setEnv(t, map[string]string{"RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+}
+
+func TestLoad_PerDirProjectFile(t *testing.T) {
+	t.Run("found in a parent directory", func(t *testing.T) {
+		t.Setenv("RC_CONFIG_DIR", t.TempDir())
+		clearProjectEnv(t)
+
+		root := t.TempDir()
+		writeProjectFile(t, root, "proj_dir")
+		nested := filepath.Join(root, "a", "b", "c")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(nested)
+
+		cfg, err := config.Load("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ProjectID != "proj_dir" {
+			t.Errorf("per-dir file in parent should be found by walking up: got %q", cfg.ProjectID)
+		}
+	})
+
+	t.Run("nearest file wins", func(t *testing.T) {
+		t.Setenv("RC_CONFIG_DIR", t.TempDir())
+		clearProjectEnv(t)
+
+		root := t.TempDir()
+		writeProjectFile(t, root, "proj_far")
+		nested := filepath.Join(root, "child")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeProjectFile(t, nested, "proj_near")
+		t.Chdir(nested)
+
+		cfg, err := config.Load("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ProjectID != "proj_near" {
+			t.Errorf("nearest .revenuecat.json should win: got %q, want proj_near", cfg.ProjectID)
+		}
+	})
+
+	t.Run("beats profile default", func(t *testing.T) {
+		t.Setenv("RC_CONFIG_DIR", t.TempDir())
+		clearProjectEnv(t)
+		if err := config.Save("default", &config.Config{ProjectID: "proj_profile"}); err != nil {
+			t.Fatal(err)
+		}
+
+		dir := t.TempDir()
+		writeProjectFile(t, dir, "proj_dir")
+		t.Chdir(dir)
+
+		cfg, err := config.Load("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ProjectID != "proj_dir" {
+			t.Errorf("per-dir file should beat profile default: got %q, want proj_dir", cfg.ProjectID)
+		}
+	})
+
+	t.Run("env beats per-dir file", func(t *testing.T) {
+		t.Setenv("RC_CONFIG_DIR", t.TempDir())
+		clearProjectEnv(t)
+
+		dir := t.TempDir()
+		writeProjectFile(t, dir, "proj_dir")
+		t.Chdir(dir)
+		t.Setenv("RC_PROJECT_ID", "proj_env")
+
+		cfg, err := config.Load("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ProjectID != "proj_env" {
+			t.Errorf("RC_PROJECT_ID should beat per-dir file: got %q, want proj_env", cfg.ProjectID)
+		}
+	})
+
+	t.Run("absent file falls back to profile", func(t *testing.T) {
+		t.Setenv("RC_CONFIG_DIR", t.TempDir())
+		clearProjectEnv(t)
+		if err := config.Save("default", &config.Config{ProjectID: "proj_profile"}); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Chdir(t.TempDir())
+
+		cfg, err := config.Load("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ProjectID != "proj_profile" {
+			t.Errorf("with no per-dir file, should fall back to profile default: got %q", cfg.ProjectID)
+		}
+	})
+}
+
+func TestSave_DoesNotPersistPerDirProject(t *testing.T) {
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": t.TempDir(), "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+	if err := config.Save("default", &config.Config{APIKey: "sk_disk", ProjectID: "proj_profile"}); err != nil {
+		t.Fatal(err)
+	}
+
+	work := t.TempDir()
+	writeProjectFile(t, work, "proj_dir")
+	t.Chdir(work)
+
+	cfg, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ProjectID != "proj_dir" {
+		t.Fatalf("setup: want per-dir project active, got %q", cfg.ProjectID)
+	}
+	if err := config.Save("default", cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg2, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg2.ProjectID = "proj_chosen"
+	if err := config.Save("default", cfg2); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(t.TempDir())
+	got, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ProjectID != "proj_chosen" {
+		t.Errorf("want explicit change persisted and per-dir project reverted, got %q", got.ProjectID)
+	}
+}
+
 func TestProfileName_RejectsPathTraversal(t *testing.T) {
 	dir := t.TempDir()
 	setEnv(t, map[string]string{"RC_CONFIG_DIR": dir, "RC_PROFILE": "", "RC_API_KEY": ""})

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -473,6 +473,58 @@ func TestLoad_PerDirProjectFile(t *testing.T) {
 	})
 }
 
+func TestLoad_MalformedPerDirFileErrors(t *testing.T) {
+	t.Run("invalid JSON", func(t *testing.T) {
+		t.Setenv("RC_CONFIG_DIR", t.TempDir())
+		clearProjectEnv(t)
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, config.ProjectFileName), []byte("not json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(dir)
+		if _, err := config.Load("default"); err == nil {
+			t.Fatal("want error on malformed .revenuecat.json, got nil")
+		}
+	})
+
+	t.Run("missing project_id key", func(t *testing.T) {
+		t.Setenv("RC_CONFIG_DIR", t.TempDir())
+		clearProjectEnv(t)
+		if err := config.Save("default", &config.Config{ProjectID: "proj_profile"}); err != nil {
+			t.Fatal(err)
+		}
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, config.ProjectFileName), []byte(`{"projectId": "typo_key"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(dir)
+		if _, err := config.Load("default"); err == nil {
+			t.Fatal("want error when .revenuecat.json has no project_id, got nil")
+		}
+	})
+}
+
+func TestLoadStored_IgnoresPerDirBindingAndEnv(t *testing.T) {
+	t.Setenv("RC_CONFIG_DIR", t.TempDir())
+	clearProjectEnv(t)
+	if err := config.Save("default", &config.Config{ProjectID: "proj_profile"}); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	writeProjectFile(t, dir, "proj_dir")
+	t.Chdir(dir)
+	t.Setenv("RC_PROJECT_ID", "proj_env")
+
+	cfg, err := config.LoadStored("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ProjectID != "proj_profile" {
+		t.Errorf("LoadStored should report the profile's stored default, got %q", cfg.ProjectID)
+	}
+}
+
 func TestSave_DoesNotPersistPerDirProject(t *testing.T) {
 	setEnv(t, map[string]string{"RC_CONFIG_DIR": t.TempDir(), "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
 	if err := config.Save("default", &config.Config{APIKey: "sk_disk", ProjectID: "proj_profile"}); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -513,6 +513,36 @@ func TestSave_DoesNotPersistPerDirProject(t *testing.T) {
 	}
 }
 
+func TestUseProjectID_PersistsChoiceEqualToDirBinding(t *testing.T) {
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": t.TempDir(), "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+	if err := config.Save("default", &config.Config{APIKey: "sk_disk", ProjectID: "proj_profile"}); err != nil {
+		t.Fatal(err)
+	}
+
+	work := t.TempDir()
+	writeProjectFile(t, work, "proj_dir")
+	t.Chdir(work)
+
+	cfg, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// User explicitly selects the project the directory already binds to.
+	cfg.UseProjectID("proj_dir")
+	if err := config.Save("default", cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(t.TempDir())
+	got, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ProjectID != "proj_dir" {
+		t.Errorf("explicit UseProjectID matching the dir binding must persist, got %q", got.ProjectID)
+	}
+}
+
 func TestProfileName_RejectsPathTraversal(t *testing.T) {
 	dir := t.TempDir()
 	setEnv(t, map[string]string{"RC_CONFIG_DIR": dir, "RC_PROFILE": "", "RC_API_KEY": ""})


### PR DESCRIPTION
Bind a directory tree to a project with a `.revenuecat.json` holding a `project_id`, found by walking up from the working dir like git finds `.git` (nearest wins).

Precedence, highest first: `--project-id` → `RC_PROJECT_ID` → nearest `.revenuecat.json` → profile default. The binding is a one-shot override like the env vars, so `Save` never bakes a tree-local project into the profile on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the active project is resolved for every command, so a committed file can silently retarget API calls; malformed files now fail unless a higher override is set.
> 
> **Overview**
> Adds a commit-able `.revenuecat.json` (`project_id`) discovered by walking up from the working directory (nearest wins). Project resolution is now **`--project-id` > `RC_PROJECT_ID` > dir binding > profile default**.
> 
> The binding is treated as a per-invocation overlay: `Save` reverts it (and env/flag overlays) so a tree-local project is never baked into the profile. Explicit choices go through `UseProjectID`; `--project-id` on ordinary commands uses `OverrideProjectID` (login still adopts the flag as the stored default). Malformed bindings error unless env/flag already wins.
> 
> `projects use` / `create --use` warn (and include `dir_binding_shadow` in `--json`) when a directory file will still override the profile default just set. `profiles list` uses `LoadStored` so it shows on-disk defaults, not overlays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498dde70fc287b9c9225901bc4811b823ff7702b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->