### PR TITLE
feat(cli): destructive-command tiers — confirm + interactive-only deletes

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -351,11 +351,16 @@ but no longer associated with this app.
 
 Reversibility: irreversible.
 
-Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc apps delete app_old --yes`,
+Interactive-only: run it yourself in a terminal. It is unavailable under
+--json or --no-input so automation can't delete apps. --yes skips the
+confirmation prompt once you're in a terminal.`,
+		Example: `  rc apps delete app_old`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
+			if err := requireInteractive(rt, cmd.CommandPath()); err != nil {
+				return err
+			}
 			projectID, err := requireProject(rt)
 			if err != nil {
 				return err

--- a/internal/cli/confirm.go
+++ b/internal/cli/confirm.go
@@ -16,7 +16,7 @@ func requireInteractive(rt *Runtime, action string) error {
 		return nil
 	}
 	return WithHint(
-		fmt.Errorf("%s is interactive-only and can't run with --json or --no-input", action),
+		fmt.Errorf("%s is interactive-only: it needs a real terminal and can't run with --json or --no-input", action),
 		"Run it yourself in an interactive terminal. It is intentionally unavailable to automation because it is irreversible.",
 	)
 }

--- a/internal/cli/confirm.go
+++ b/internal/cli/confirm.go
@@ -6,6 +6,21 @@ import (
 	"github.com/revenuecat/cli/internal/tui"
 )
 
+// requireInteractive gates the most destructive, irreversible commands to a
+// person at a real terminal. Unlike confirmOrAbort, --yes cannot bypass it and
+// there is no non-interactive path: --json, --no-input, and non-TTY sessions
+// are all refused. This keeps automation from firing deletes that are hard or
+// impossible to undo — those stay a deliberate, human-only action.
+func requireInteractive(rt *Runtime, action string) error {
+	if rt.CanPrompt() {
+		return nil
+	}
+	return WithHint(
+		fmt.Errorf("%s is interactive-only and can't run with --json or --no-input", action),
+		"Run it yourself in an interactive terminal. It is intentionally unavailable to automation because it is irreversible.",
+	)
+}
+
 // confirmOrAbort is the one way a command asks consent before acting. It owns
 // the full contract in one place — --yes skips it, --no-input without --yes
 // fails it, declining aborts with a uniform error — so no command can

--- a/internal/cli/destructive_guard_test.go
+++ b/internal/cli/destructive_guard_test.go
@@ -192,6 +192,8 @@ func TestDestructiveCommands_RefuseUnderNoInputWithoutYes(t *testing.T) {
 		{"subscriptions", "refund", "sub_x"},
 		{"products", "store", "discard", "plan_x"},
 		{"customer", "revoke", "cust_x", "ent_x"},
+		{"customer", "grant", "cust_x", "ent_x", "--duration", "monthly"},
+		{"customer", "transfer", "cust_x", "--to", "cust_y"},
 	}
 	for _, args := range commands {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {

--- a/internal/cli/destructive_guard_test.go
+++ b/internal/cli/destructive_guard_test.go
@@ -1,177 +1,18 @@
 package cli_test
 
 import (
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"io/fs"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/revenuecat/cli/internal/config"
 )
 
-// Reversible, soft state changes (archive/restore/set-current/enable/disable)
-// are deliberately excluded — the codebase documents those as "no prompt".
-var destructiveVerbs = map[string]bool{
-	"delete":            true,
-	"revoke":            true,
-	"refund":            true,
-	"cancel":            true,
-	"transfer":          true,
-	"grant":             true,
-	"push":              true,
-	"publish":           true,
-	"unpublish":         true,
-	"apply":             true,
-	"discard":           true,
-	"simulate-purchase": true,
-}
-
-func TestDestructiveCommands_RouteThroughConfirmOrAbort(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
-	if err != nil {
-		t.Fatalf("parse package: %v", err)
-	}
-
-	// Which named functions ask for consent — directly or transitively — so a
-	// command whose RunE delegates the prompt to a helper still counts as
-	// guarded (e.g. `products store apply` → applyStoreStatePlan).
-	guarding := guardingFuncs(pkgs)
-
-	found := 0
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			ast.Inspect(file, func(n ast.Node) bool {
-				lit, ok := n.(*ast.CompositeLit)
-				if !ok || !isCobraCommand(lit.Type) {
-					return true
-				}
-				verb, runE := commandVerbAndRunE(lit)
-				if !destructiveVerbs[verb] {
-					return true
-				}
-				found++
-				if !runEGuarded(runE, guarding) {
-					pos := fset.Position(lit.Pos())
-					t.Errorf("%s: destructive command %q reaches its action without confirmOrAbort — gate it via confirmOrAbort(rt, ...) so --yes/--no-input behave uniformly", pos, verb)
-				}
-				return true
-			})
-		}
-	}
-	if found == 0 {
-		t.Fatal("no destructive commands found — the guard is not scanning the command definitions")
-	}
-}
-
-// guardingFuncs returns the names of functions whose bodies reach confirmOrAbort,
-// following one function calling another to a fixpoint.
-func guardingFuncs(pkgs map[string]*ast.Package) map[string]bool {
-	calls := map[string]map[string]bool{}
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				fn, ok := decl.(*ast.FuncDecl)
-				if !ok || fn.Body == nil {
-					continue
-				}
-				calls[fn.Name.Name] = calledIdents(fn.Body)
-			}
-		}
-	}
-	guarding := map[string]bool{}
-	for name, callees := range calls {
-		if callees["confirmOrAbort"] {
-			guarding[name] = true
-		}
-	}
-	for changed := true; changed; {
-		changed = false
-		for name, callees := range calls {
-			if guarding[name] {
-				continue
-			}
-			for callee := range callees {
-				if guarding[callee] {
-					guarding[name] = true
-					changed = true
-					break
-				}
-			}
-		}
-	}
-	return guarding
-}
-
-func calledIdents(n ast.Node) map[string]bool {
-	set := map[string]bool{}
-	ast.Inspect(n, func(nn ast.Node) bool {
-		if call, ok := nn.(*ast.CallExpr); ok {
-			if id, ok := call.Fun.(*ast.Ident); ok {
-				set[id.Name] = true
-			}
-		}
-		return true
-	})
-	return set
-}
-
-func isCobraCommand(t ast.Expr) bool {
-	sel, ok := t.(*ast.SelectorExpr)
-	if !ok || sel.Sel.Name != "Command" {
-		return false
-	}
-	pkg, ok := sel.X.(*ast.Ident)
-	return ok && pkg.Name == "cobra"
-}
-
-func commandVerbAndRunE(lit *ast.CompositeLit) (verb string, runE ast.Expr) {
-	for _, elt := range lit.Elts {
-		kv, ok := elt.(*ast.KeyValueExpr)
-		if !ok {
-			continue
-		}
-		key, ok := kv.Key.(*ast.Ident)
-		if !ok {
-			continue
-		}
-		switch key.Name {
-		case "Use":
-			if bl, ok := kv.Value.(*ast.BasicLit); ok && bl.Kind == token.STRING {
-				if use, err := strconv.Unquote(bl.Value); err == nil {
-					if fields := strings.Fields(use); len(fields) > 0 {
-						verb = fields[0]
-					}
-				}
-			}
-		case "RunE":
-			runE = kv.Value
-		}
-	}
-	return verb, runE
-}
-
-func runEGuarded(runE ast.Expr, guarding map[string]bool) bool {
-	switch v := runE.(type) {
-	case *ast.FuncLit:
-		for callee := range calledIdents(v.Body) {
-			if callee == "confirmOrAbort" || guarding[callee] {
-				return true
-			}
-		}
-	case *ast.Ident:
-		return guarding[v.Name]
-	}
-	return false
-}
-
+// Every command that removes or mutates real state must refuse to act under
+// --no-input unless --yes is passed, and --yes must let it through. This drives
+// the real commands; a new destructive command is covered by adding it here.
+//
 // The fake server allows read-only GET preflight (some commands fetch state to
 // decide whether extra confirmation is needed) but fails the test on any write,
 // proving nothing is destroyed before consent.

--- a/internal/cli/destructive_guard_test.go
+++ b/internal/cli/destructive_guard_test.go
@@ -1,0 +1,251 @@
+package cli_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/config"
+)
+
+// Reversible, soft state changes (archive/restore/set-current/enable/disable)
+// are deliberately excluded — the codebase documents those as "no prompt".
+var destructiveVerbs = map[string]bool{
+	"delete":            true,
+	"revoke":            true,
+	"refund":            true,
+	"cancel":            true,
+	"transfer":          true,
+	"grant":             true,
+	"push":              true,
+	"publish":           true,
+	"unpublish":         true,
+	"apply":             true,
+	"discard":           true,
+	"simulate-purchase": true,
+}
+
+func TestDestructiveCommands_RouteThroughConfirmOrAbort(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	// Which named functions ask for consent — directly or transitively — so a
+	// command whose RunE delegates the prompt to a helper still counts as
+	// guarded (e.g. `products store apply` → applyStoreStatePlan).
+	guarding := guardingFuncs(pkgs)
+
+	found := 0
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				lit, ok := n.(*ast.CompositeLit)
+				if !ok || !isCobraCommand(lit.Type) {
+					return true
+				}
+				verb, runE := commandVerbAndRunE(lit)
+				if !destructiveVerbs[verb] {
+					return true
+				}
+				found++
+				if !runEGuarded(runE, guarding) {
+					pos := fset.Position(lit.Pos())
+					t.Errorf("%s: destructive command %q reaches its action without confirmOrAbort — gate it via confirmOrAbort(rt, ...) so --yes/--no-input behave uniformly", pos, verb)
+				}
+				return true
+			})
+		}
+	}
+	if found == 0 {
+		t.Fatal("no destructive commands found — the guard is not scanning the command definitions")
+	}
+}
+
+// guardingFuncs returns the names of functions whose bodies reach confirmOrAbort,
+// following one function calling another to a fixpoint.
+func guardingFuncs(pkgs map[string]*ast.Package) map[string]bool {
+	calls := map[string]map[string]bool{}
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				calls[fn.Name.Name] = calledIdents(fn.Body)
+			}
+		}
+	}
+	guarding := map[string]bool{}
+	for name, callees := range calls {
+		if callees["confirmOrAbort"] {
+			guarding[name] = true
+		}
+	}
+	for changed := true; changed; {
+		changed = false
+		for name, callees := range calls {
+			if guarding[name] {
+				continue
+			}
+			for callee := range callees {
+				if guarding[callee] {
+					guarding[name] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+	return guarding
+}
+
+func calledIdents(n ast.Node) map[string]bool {
+	set := map[string]bool{}
+	ast.Inspect(n, func(nn ast.Node) bool {
+		if call, ok := nn.(*ast.CallExpr); ok {
+			if id, ok := call.Fun.(*ast.Ident); ok {
+				set[id.Name] = true
+			}
+		}
+		return true
+	})
+	return set
+}
+
+func isCobraCommand(t ast.Expr) bool {
+	sel, ok := t.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Command" {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "cobra"
+}
+
+func commandVerbAndRunE(lit *ast.CompositeLit) (verb string, runE ast.Expr) {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch key.Name {
+		case "Use":
+			if bl, ok := kv.Value.(*ast.BasicLit); ok && bl.Kind == token.STRING {
+				if use, err := strconv.Unquote(bl.Value); err == nil {
+					if fields := strings.Fields(use); len(fields) > 0 {
+						verb = fields[0]
+					}
+				}
+			}
+		case "RunE":
+			runE = kv.Value
+		}
+	}
+	return verb, runE
+}
+
+func runEGuarded(runE ast.Expr, guarding map[string]bool) bool {
+	switch v := runE.(type) {
+	case *ast.FuncLit:
+		for callee := range calledIdents(v.Body) {
+			if callee == "confirmOrAbort" || guarding[callee] {
+				return true
+			}
+		}
+	case *ast.Ident:
+		return guarding[v.Name]
+	}
+	return false
+}
+
+// The fake server allows read-only GET preflight (some commands fetch state to
+// decide whether extra confirmation is needed) but fails the test on any write,
+// proving nothing is destroyed before consent.
+func TestDestructiveCommands_RefuseUnderNoInputWithoutYes(t *testing.T) {
+	commands := [][]string{
+		{"apps", "delete", "app_x"},
+		{"products", "delete", "prod_x"},
+		{"products", "push", "prod_x"},
+		{"paywalls", "delete", "pw_x"},
+		{"paywalls", "publish", "pw_x"},
+		{"paywalls", "unpublish", "pw_x"},
+		{"offerings", "delete", "ofrng_x"},
+		{"packages", "delete", "pkg_x"},
+		{"entitlements", "delete", "ent_x"},
+		{"webhooks", "delete", "wh_x"},
+		{"purchases", "refund", "txn_x"},
+		{"subscriptions", "cancel", "sub_x"},
+		{"subscriptions", "refund", "sub_x"},
+		{"products", "store", "discard", "plan_x"},
+		{"customer", "revoke", "cust_x", "ent_x"},
+	}
+	for _, args := range commands {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			configDir := t.TempDir()
+			t.Setenv("RC_CONFIG_DIR", configDir)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("%s %s: state-changing call reached the network before confirmation", r.Method, r.URL.Path)
+					http.Error(w, "unexpected write before confirmation", http.StatusInternalServerError)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			t.Cleanup(server.Close)
+			if err := config.Save("", &config.Config{APIKey: "sk_test", ProjectID: "proj_test", BaseURL: server.URL}); err != nil {
+				t.Fatal(err)
+			}
+
+			runArgs := append(append([]string{}, args...), "--no-input")
+			_, _, err := runCmdInConfigDir(t, configDir, runArgs...)
+			if err == nil {
+				t.Fatal("want refusal under --no-input without --yes")
+			}
+			if !strings.Contains(err.Error(), "pass --yes") {
+				t.Fatalf("want the confirmation gate error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestDestructiveCommand_YesBypassesConfirmation(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", configDir)
+	var deleted bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "/apps/app_x") {
+			deleted = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		http.Error(w, "unexpected request", http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+	if err := config.Save("", &config.Config{APIKey: "sk_test", ProjectID: "proj_test", BaseURL: server.URL}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, errb, err := runCmdInConfigDir(t, configDir, "apps", "delete", "app_x", "--yes", "--no-input")
+	if err != nil {
+		t.Fatalf("--yes should let the delete proceed: %v\nstderr: %s", err, errb)
+	}
+	if !deleted {
+		t.Fatal("--yes did not let the command reach the store delete call")
+	}
+}

--- a/internal/cli/destructive_guard_test.go
+++ b/internal/cli/destructive_guard_test.go
@@ -17,16 +17,14 @@ import (
 // decide whether extra confirmation is needed) but fails the test on any write,
 // proving nothing is destroyed before consent.
 func TestDestructiveCommands_RefuseUnderNoInputWithoutYes(t *testing.T) {
+	// The most destructive, irreversible commands are interactive-only and are
+	// covered separately below; --yes bypasses confirmation for everything here.
 	commands := [][]string{
-		{"apps", "delete", "app_x"},
 		{"products", "delete", "prod_x"},
 		{"products", "push", "prod_x"},
-		{"paywalls", "delete", "pw_x"},
 		{"paywalls", "publish", "pw_x"},
 		{"paywalls", "unpublish", "pw_x"},
-		{"offerings", "delete", "ofrng_x"},
 		{"packages", "delete", "pkg_x"},
-		{"entitlements", "delete", "ent_x"},
 		{"webhooks", "delete", "wh_x"},
 		{"purchases", "refund", "txn_x"},
 		{"subscriptions", "cancel", "sub_x"},
@@ -71,24 +69,64 @@ func TestDestructiveCommand_YesBypassesConfirmation(t *testing.T) {
 	t.Setenv("RC_CONFIG_DIR", configDir)
 	var deleted bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "/apps/app_x") {
+		switch {
+		case r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "/products/prod_x"):
 			deleted = true
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{}`))
-			return
+		case r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
 		}
-		http.Error(w, "unexpected request", http.StatusNotFound)
 	}))
 	t.Cleanup(server.Close)
 	if err := config.Save("", &config.Config{APIKey: "sk_test", ProjectID: "proj_test", BaseURL: server.URL}); err != nil {
 		t.Fatal(err)
 	}
 
-	_, errb, err := runCmdInConfigDir(t, configDir, "apps", "delete", "app_x", "--yes", "--no-input")
+	_, errb, err := runCmdInConfigDir(t, configDir, "products", "delete", "prod_x", "--yes", "--no-input")
 	if err != nil {
 		t.Fatalf("--yes should let the delete proceed: %v\nstderr: %s", err, errb)
 	}
 	if !deleted {
-		t.Fatal("--yes did not let the command reach the store delete call")
+		t.Fatal("--yes did not let the command reach the delete call")
+	}
+}
+
+// The irreversible, customer-facing deletes are interactive-only: --yes does NOT
+// buy a way through, and --json/--no-input are refused outright so automation
+// can't fire them. A new human-only command is covered by adding it here.
+func TestInteractiveOnlyCommands_RefuseEvenWithYes(t *testing.T) {
+	commands := [][]string{
+		{"apps", "delete", "app_x"},
+		{"paywalls", "delete", "pw_x"},
+		{"offerings", "delete", "ofrng_x"},
+		{"entitlements", "delete", "ent_x"},
+	}
+	for _, args := range commands {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			configDir := t.TempDir()
+			t.Setenv("RC_CONFIG_DIR", configDir)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Errorf("%s %s: interactive-only command reached the network", r.Method, r.URL.Path)
+				http.Error(w, "must not touch the network", http.StatusInternalServerError)
+			}))
+			t.Cleanup(server.Close)
+			if err := config.Save("", &config.Config{APIKey: "sk_test", ProjectID: "proj_test", BaseURL: server.URL}); err != nil {
+				t.Fatal(err)
+			}
+
+			// --yes present on purpose: it must NOT bypass the interactive gate.
+			runArgs := append(append([]string{}, args...), "--yes", "--no-input")
+			_, _, err := runCmdInConfigDir(t, configDir, runArgs...)
+			if err == nil {
+				t.Fatal("want refusal: interactive-only even with --yes")
+			}
+			if !strings.Contains(err.Error(), "interactive-only") {
+				t.Fatalf("want the interactive-only gate error, got: %v", err)
+			}
+		})
 	}
 }

--- a/internal/cli/destructive_guard_test.go
+++ b/internal/cli/destructive_guard_test.go
@@ -20,11 +20,9 @@ func TestDestructiveCommands_RefuseUnderNoInputWithoutYes(t *testing.T) {
 	// The most destructive, irreversible commands are interactive-only and are
 	// covered separately below; --yes bypasses confirmation for everything here.
 	commands := [][]string{
-		{"products", "delete", "prod_x"},
 		{"products", "push", "prod_x"},
 		{"paywalls", "publish", "pw_x"},
 		{"paywalls", "unpublish", "pw_x"},
-		{"packages", "delete", "pkg_x"},
 		{"webhooks", "delete", "wh_x"},
 		{"purchases", "refund", "txn_x"},
 		{"subscriptions", "cancel", "sub_x"},
@@ -70,7 +68,7 @@ func TestDestructiveCommand_YesBypassesConfirmation(t *testing.T) {
 	var deleted bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "/products/prod_x"):
+		case r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "/webhooks/wh_x"):
 			deleted = true
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{}`))
@@ -86,7 +84,7 @@ func TestDestructiveCommand_YesBypassesConfirmation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, errb, err := runCmdInConfigDir(t, configDir, "products", "delete", "prod_x", "--yes", "--no-input")
+	_, errb, err := runCmdInConfigDir(t, configDir, "webhooks", "delete", "wh_x", "--yes", "--no-input")
 	if err != nil {
 		t.Fatalf("--yes should let the delete proceed: %v\nstderr: %s", err, errb)
 	}
@@ -104,6 +102,8 @@ func TestInteractiveOnlyCommands_RefuseEvenWithYes(t *testing.T) {
 		{"paywalls", "delete", "pw_x"},
 		{"offerings", "delete", "ofrng_x"},
 		{"entitlements", "delete", "ent_x"},
+		{"products", "delete", "prod_x"},
+		{"packages", "delete", "pkg_x"},
 	}
 	for _, args := range commands {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {

--- a/internal/cli/entitlements.go
+++ b/internal/cli/entitlements.go
@@ -398,11 +398,16 @@ Reversibility: irreversible. If you only need to hide it from current
 Offerings, prefer ` + "`rc entitlements archive`" + ` which can be undone with
 ` + "`rc entitlements restore`" + `.
 
-Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc entitlements delete entl_pro --yes`,
+Interactive-only: run it yourself in a terminal. It is unavailable under
+--json or --no-input so automation can't delete entitlements. --yes skips the
+confirmation prompt once you're in a terminal.`,
+		Example: `  rc entitlements delete entl_pro`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
+			if err := requireInteractive(rt, cmd.CommandPath()); err != nil {
+				return err
+			}
 			projectID, err := requireProject(rt)
 			if err != nil {
 				return err

--- a/internal/cli/offerings.go
+++ b/internal/cli/offerings.go
@@ -549,11 +549,16 @@ terminal to pick from a list.
 Reversibility: irreversible. Prefer ` + "`rc offerings archive`" + ` for
 reversible removal.
 
-Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc offerings delete ofrng_default --yes`,
+Interactive-only: run it yourself in a terminal. It is unavailable under
+--json or --no-input so automation can't delete offerings. --yes skips the
+confirmation prompt once you're in a terminal.`,
+		Example: `  rc offerings delete ofrng_default`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
+			if err := requireInteractive(rt, cmd.CommandPath()); err != nil {
+				return err
+			}
 			projectID, err := requireProject(rt)
 			if err != nil {
 				return err

--- a/internal/cli/packages.go
+++ b/internal/cli/packages.go
@@ -266,11 +266,16 @@ to pick from a list.
 
 Reversibility: irreversible.
 
-Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc packages delete pkg_x --yes`,
+Interactive-only: run it yourself in a terminal. It is unavailable under
+--json or --no-input so automation can't delete packages. --yes skips the
+confirmation prompt once you're in a terminal.`,
+		Example: `  rc packages delete pkg_x`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
+			if err := requireInteractive(rt, cmd.CommandPath()); err != nil {
+				return err
+			}
 			projectID, err := requireProject(rt)
 			if err != nil {
 				return err

--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -427,12 +427,17 @@ unless --force is passed — --yes alone is not enough. It may be serving
 customers or be someone else's in-progress work; get explicit consent from
 the user first.
 
-Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc paywalls delete pw_old --yes
-  rc paywalls delete pw_attached --force --yes`,
+Interactive-only: run it yourself in a terminal. It is unavailable under
+--json or --no-input so automation can't delete paywalls. --yes skips the
+confirmation prompt once you're in a terminal.`,
+		Example: `  rc paywalls delete pw_old
+  rc paywalls delete pw_attached --force`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
+			if err := requireInteractive(rt, cmd.CommandPath()); err != nil {
+				return err
+			}
 			projectID, err := requireProject(rt)
 			if err != nil {
 				return err
@@ -451,19 +456,8 @@ Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`
 			if err != nil {
 				return err
 			}
-			if !force {
-				switch {
-				case paywall.PublishedAt != nil:
-					return WithHint(
-						fmt.Errorf("paywall %s is published — customers may be seeing it", pickedID),
-						"Deletion is irreversible. Unpublish it first (rc paywalls unpublish "+pickedID+"), then detach it (rc paywalls detach "+pickedID+") if you only need to free the offering, or re-run with --force after the user explicitly confirms this paywall should be destroyed.",
-					)
-				case paywall.OfferingID != "":
-					return WithHint(
-						fmt.Errorf("paywall %s is attached to offering %s and may be someone's in-progress work", pickedID, paywall.OfferingID),
-						"Deletion is irreversible. Re-run with --force only after the user explicitly confirms this paywall should be destroyed. To free the offering instead, detach this paywall (rc paywalls detach "+pickedID+") — it stays as a standalone draft.",
-					)
-				}
+			if err := checkPaywallDeletable(paywall, pickedID, force); err != nil {
+				return err
 			}
 			if paywall.PublishedAt != nil {
 				rt.Out.Warn("This paywall is published — customers may be seeing it.")
@@ -483,6 +477,28 @@ Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "delete even when the paywall is attached to an offering or published")
 	return cmd
+}
+
+// checkPaywallDeletable refuses to delete a published or attached paywall unless
+// --force is passed: those may be serving customers or be someone's in-progress
+// work, so deletion needs an explicit override on top of confirmation.
+func checkPaywallDeletable(paywall *api.Paywall, id string, force bool) error {
+	if force {
+		return nil
+	}
+	switch {
+	case paywall.PublishedAt != nil:
+		return WithHint(
+			fmt.Errorf("paywall %s is published — customers may be seeing it", id),
+			"Deletion is irreversible. Unpublish it first (rc paywalls unpublish "+id+"), then detach it (rc paywalls detach "+id+") if you only need to free the offering, or re-run with --force after the user explicitly confirms this paywall should be destroyed.",
+		)
+	case paywall.OfferingID != "":
+		return WithHint(
+			fmt.Errorf("paywall %s is attached to offering %s and may be someone's in-progress work", id, paywall.OfferingID),
+			"Deletion is irreversible. Re-run with --force only after the user explicitly confirms this paywall should be destroyed. To free the offering instead, detach this paywall (rc paywalls detach "+id+") — it stays as a standalone draft.",
+		)
+	}
+	return nil
 }
 
 // wrapPaywallActionGateError explains the beta gate on the paywall

--- a/internal/cli/paywalls_delete_test.go
+++ b/internal/cli/paywalls_delete_test.go
@@ -1,64 +1,35 @@
 package cli
 
 import (
-	"bytes"
-	"context"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
 )
 
-func TestPaywallsDeleteRequiresForceForAttachedOrPublished(t *testing.T) {
-	paywalls := map[string]string{
-		"pw_attached":   `{"object":"paywall","id":"pw_attached","name":"Hero","offering_id":"ofrng_x","created_at":1700000000000,"published_at":null}`,
-		"pw_published":  `{"object":"paywall","id":"pw_published","name":"Live","offering_id":"ofrng_live","created_at":1700000000000,"published_at":1700000000000}`,
-		"pw_standalone": `{"object":"paywall","id":"pw_standalone","created_at":1700000000000,"published_at":null}`,
+// paywalls delete is interactive-only (its refusal to run under automation is
+// covered by the destructive-command guard), so the force-check is exercised
+// directly here: a published or attached paywall needs --force, a standalone
+// draft does not.
+func TestCheckPaywallDeletable(t *testing.T) {
+	published := api.Millis(1700000000000)
+	tests := []struct {
+		name    string
+		paywall *api.Paywall
+		force   bool
+		wantErr bool
+	}{
+		{name: "standalone draft deletes", paywall: &api.Paywall{ID: "pw_standalone"}},
+		{name: "published needs force", paywall: &api.Paywall{ID: "pw_pub", PublishedAt: &published}, wantErr: true},
+		{name: "attached needs force", paywall: &api.Paywall{ID: "pw_att", OfferingID: "ofrng_x"}, wantErr: true},
+		{name: "published with force deletes", paywall: &api.Paywall{ID: "pw_pub", PublishedAt: &published}, force: true},
+		{name: "attached with force deletes", paywall: &api.Paywall{ID: "pw_att", OfferingID: "ofrng_x"}, force: true},
 	}
-	var deletedPaths []string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		id := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
-		switch r.Method {
-		case http.MethodGet:
-			io.WriteString(w, paywalls[id])
-		case http.MethodDelete:
-			deletedPaths = append(deletedPaths, r.URL.Path)
-			io.WriteString(w, `{}`)
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer server.Close()
-	t.Setenv("RC_CONFIG_DIR", t.TempDir())
-	t.Setenv("RC_BASE_URL", server.URL)
-
-	del := func(args ...string) error {
-		root := NewRootCmd("test")
-		root.SetOut(io.Discard)
-		root.SetErr(&bytes.Buffer{})
-		root.SetArgs(append([]string{"paywalls", "delete"}, append(args, "--yes", "--api-key", "sk_test", "--project-id", "proj")...))
-		return root.ExecuteContext(context.Background())
-	}
-
-	for _, id := range []string{"pw_attached", "pw_published"} {
-		if err := del(id); err == nil {
-			t.Fatalf("%s should require --force", id)
-		}
-	}
-	if len(deletedPaths) != 0 {
-		t.Fatalf("refusals must not issue DELETE, got %v", deletedPaths)
-	}
-
-	if err := del("pw_standalone"); err != nil {
-		t.Fatalf("standalone draft should delete without --force: %v", err)
-	}
-	if err := del("pw_attached", "--force"); err != nil {
-		t.Fatalf("--force should delete attached paywall: %v", err)
-	}
-	want := []string{"/projects/proj/paywalls/pw_standalone", "/projects/proj/paywalls/pw_attached"}
-	if len(deletedPaths) != 2 || deletedPaths[0] != want[0] || deletedPaths[1] != want[1] {
-		t.Fatalf("DELETE paths = %v, want %v", deletedPaths, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkPaywallDeletable(tt.paywall, tt.paywall.ID, tt.force)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("checkPaywallDeletable err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -669,11 +669,16 @@ to pick from a list.
 Reversibility: irreversible. Prefer ` + "`rc products archive`" + ` for
 reversible removal.
 
-Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
-		Example: `  rc products delete prod_x --yes`,
+Interactive-only: run it yourself in a terminal. It is unavailable under
+--json or --no-input so automation can't delete products. --yes skips the
+confirmation prompt once you're in a terminal.`,
+		Example: `  rc products delete prod_x`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rt := RuntimeFrom(cmd.Context())
+			if err := requireInteractive(rt, cmd.CommandPath()); err != nil {
+				return err
+			}
 			projectID, err := requireProject(rt)
 			if err != nil {
 				return err


### PR DESCRIPTION
Two tiers for destructive commands, with behavioral guards for both:

**Destructive** (products push, publish/unpublish, webhooks delete, refunds, subscriptions cancel, store discard, customer grant/revoke/transfer): refuse under `--no-input` without `--yes`; `--yes` lets them through. A fake API that only allows GET, so nothing mutates before consent.

**Interactive-only** (apps / paywalls / offerings / entitlements / products / packages delete): must be run by a person in a terminal. `--json` and `--no-input` are refused, and `--yes` can't bypass it. These are irreversible, so we don't want agents firing them — manual, deliberate use only.

A shared `requireInteractive` gate sits next to `confirmOrAbort`. The guard test has one list per tier; a new human-only command is a gate line plus a list entry. The paywall force-check was extracted so it stays unit-tested now that the command itself is interactive-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consent and automation paths for destructive CLI commands, including a breaking restriction that scripts can no longer delete apps, paywalls, offerings, entitlements, products, or packages.
> 
> **Overview**
> Splits destructive CLI actions into two consent tiers so irreversible catalog deletes cannot be fired by automation.
> 
> **Interactive-only** (`apps` / `paywalls` / `offerings` / `entitlements` / `products` / `packages` `delete`): new `requireInteractive` refuses `--json`, `--no-input`, and non-TTY sessions. `--yes` still skips the prompt *only* in a real terminal.
> 
> **Confirm-with-`--yes`**: other mutating commands (push, publish/unpublish, webhooks delete, refunds, cancel, store discard, customer grant/revoke/transfer) still refuse `--no-input` without `--yes`.
> 
> Adds a guard test that drives the real commands against a GET-only fake API, and extracts `checkPaywallDeletable` so the `--force` rule stays unit-tested now that paywall delete is interactive-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fc277a87f7c0bd7f6c30843d61abcbdc49cfdfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->