### PR TITLE
fix(apps): --json/--no-input correctness for create + apple setup key labels

### DIFF
--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -174,13 +174,18 @@ with rc apps apple setup.`,
 			if err != nil {
 				return err
 			}
-			form := tui.Form(rt.Globals.NoInput).
-				Field(huh.NewInput().Title("App name").Value(&name).Validate(tui.Required("name")))
-			if appType == "" && rt.CanPrompt() {
-				form.Field(huh.NewSelect[string]().Title("Type").Options(appTypes...).Value(&appType))
+			if rt.CanPrompt() {
+				form := tui.Form(rt.Globals.NoInput).
+					Field(huh.NewInput().Title("App name").Value(&name).Validate(tui.Required("name")))
+				if appType == "" {
+					form.Field(huh.NewSelect[string]().Title("Type").Options(appTypes...).Value(&appType))
+				}
+				if err := form.Run(); err != nil {
+					return err
+				}
 			}
-			if err := form.Run(); err != nil {
-				return err
+			if name == "" {
+				return fmt.Errorf("--name is required")
 			}
 			if !validAppType(appType) {
 				return fmt.Errorf("--type is required: app_store|play_store|amazon|roku|stripe|rc_billing|paddle")
@@ -268,20 +273,38 @@ with rc apps apple setup.`,
 }
 
 func promptForAppPlatformFields(rt *Runtime, appType string, bundleID, packageName, appName *string) error {
-	form := tui.Form(rt.Globals.NoInput)
-	switch appType {
-	case "amazon":
-		form.Field(huh.NewInput().Title("Package name").Value(packageName).Validate(tui.Required("package name")))
-	case "app_store":
-		form.Field(huh.NewInput().Title("Bundle ID").Value(bundleID).Validate(tui.Required("bundle ID")))
-	case "play_store":
-		form.Field(huh.NewInput().Title("Package name").Value(packageName).Validate(tui.Required("package name")))
-	case "rc_billing":
-		form.Field(huh.NewInput().Title("App name").Value(appName).Validate(tui.Required("app name")))
-	default:
-		return nil
+	if rt.CanPrompt() {
+		form := tui.Form(rt.Globals.NoInput)
+		switch appType {
+		case "amazon":
+			form.Field(huh.NewInput().Title("Package name").Value(packageName).Validate(tui.Required("package name")))
+		case "app_store":
+			form.Field(huh.NewInput().Title("Bundle ID").Value(bundleID).Validate(tui.Required("bundle ID")))
+		case "play_store":
+			form.Field(huh.NewInput().Title("Package name").Value(packageName).Validate(tui.Required("package name")))
+		case "rc_billing":
+			form.Field(huh.NewInput().Title("App name").Value(appName).Validate(tui.Required("app name")))
+		default:
+			return nil
+		}
+		return form.Run()
 	}
-	return form.Run()
+	// Non-interactive: the platform's required identifier must come from a flag.
+	switch appType {
+	case "amazon", "play_store":
+		if *packageName == "" {
+			return fmt.Errorf("--package-name is required for %s", appType)
+		}
+	case "app_store":
+		if *bundleID == "" {
+			return fmt.Errorf("--bundle-id is required for app_store")
+		}
+	case "rc_billing":
+		if *appName == "" {
+			return fmt.Errorf("--app-name is required for rc_billing")
+		}
+	}
+	return nil
 }
 
 func validAppType(appType string) bool {

--- a/internal/cli/apps_apple.go
+++ b/internal/cli/apps_apple.go
@@ -668,7 +668,7 @@ func newAppsAppleWorkflowCmd(checkOnly bool, factory appleConnectFactory) *cobra
 			result.VendorNumberConfigured = vendorNumber != ""
 			result.Failed = failedKeys
 			if len(failedKeys) > 0 {
-				rt.Out.Warn("Partly done: couldn't create the " + strings.Join(failedKeys, " and the ") + ". Everything that succeeded was saved to RevenueCat — resolve the note above and re-run to finish.")
+				rt.Out.Warn("Partly done: couldn't create the " + strings.Join(failedKeys, " and the ") + ". What succeeded was saved to RevenueCat. A failed attempt can still leave a key in App Store Connect that counts toward Apple's limit — check Users and Access → Integrations and reuse or revoke it before re-running.")
 			} else {
 				rt.Out.Success("Apple credentials configured")
 			}
@@ -676,9 +676,14 @@ func newAppsAppleWorkflowCmd(checkOnly bool, factory appleConnectFactory) *cobra
 			if result.ProviderName != "" {
 				subtitle = fmt.Sprintf("App Store Connect team %s (%d)", result.ProviderName, result.ProviderID)
 			}
-			keptOrCreated := func(id, label string) string {
+			keptOrCreated := func(id, label string, wasConfigured bool) string {
 				for _, f := range failedKeys {
 					if f == label {
+						// A failed create leaves RevenueCat untouched, so a key that
+						// was already configured is still in place, not gone.
+						if wasConfigured {
+							return "kept existing (replace failed — see note above)"
+						}
 						return "not created — see note above"
 					}
 				}
@@ -687,6 +692,8 @@ func newAppsAppleWorkflowCmd(checkOnly bool, factory appleConnectFactory) *cobra
 				}
 				return id + " (created)"
 			}
+			inAppWasConfigured := app.AppStore != nil && app.AppStore.SubscriptionKeyConfigured
+			ascWasConfigured := app.AppStore != nil && app.AppStore.AppStoreConnectAPIKeyConfigured
 			vendorLine := "unchanged"
 			if vendorNumber != "" {
 				vendorLine = vendorNumber
@@ -697,8 +704,8 @@ func newAppsAppleWorkflowCmd(checkOnly bool, factory appleConnectFactory) *cobra
 				Sections: []output.CardSection{{
 					Heading: "Configured",
 					Lines: []output.CardLine{
-						{Key: "In-app purchase key", Value: keptOrCreated(result.InAppPurchaseKeyID, inAppKeyLabel)},
-						{Key: "App Store Connect API key", Value: keptOrCreated(result.AppStoreConnectAPIKeyID, ascKeyLabel)},
+						{Key: "In-app purchase key", Value: keptOrCreated(result.InAppPurchaseKeyID, inAppKeyLabel, inAppWasConfigured)},
+						{Key: "App Store Connect API key", Value: keptOrCreated(result.AppStoreConnectAPIKeyID, ascKeyLabel, ascWasConfigured)},
 						{Key: "Vendor number", Value: vendorLine},
 					},
 				}},

--- a/internal/cli/apps_apple_test.go
+++ b/internal/cli/apps_apple_test.go
@@ -309,6 +309,52 @@ func TestAppsAppleSetup_PartialFailureExitsNonZeroAndReportsFailedKey(t *testing
 	}
 }
 
+// A --force replace that fails leaves the previously-configured key in place, so
+// the card must say "kept existing", not "not created".
+func TestAppsAppleSetup_FailedReplaceReadsAsKeptExisting(t *testing.T) {
+	forbidden := errors.New("403 FORBIDDEN_ERROR: The API key in use does not allow this request")
+	apiKey := &appleconnect.Key{Kind: appleconnect.AppStoreConnectKey, ID: "asc1", IssuerID: "iss", PrivateKey: "asc-pem"}
+
+	revenueCat := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/projects/proj/apps/app" {
+			_, _ = io.WriteString(w, `{"id":"app","name":"iOS","type":"app_store","created_at":1,"app_store":{"bundle_id":"com.example.app","subscription_key_configured":true,"app_store_connect_api_key_configured":false}}`)
+			return
+		}
+		http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+	}))
+	t.Cleanup(revenueCat.Close)
+
+	// In-app key already configured; --force tries to replace it and Apple refuses.
+	apple := &fakeAppleSetupClient{
+		inApp: func() (*appleconnect.Key, error) { return nil, forbidden },
+		api:   func() (*appleconnect.Key, error) { return apiKey, nil },
+	}
+	var stdout, stderr bytes.Buffer
+	rt := &Runtime{
+		Globals: &Globals{NoInput: true, AssumeYes: true, Version: "test"},
+		Config:  &config.Config{APIKey: "sk_test", ProjectID: "proj", BaseURL: revenueCat.URL},
+		Ctx:     context.Background(),
+		Out:     output.NewRenderer(&stdout, &stderr, false, true, false, ""),
+		client:  api.NewClient(api.Options{APIKey: "sk_test", BaseURL: revenueCat.URL}),
+	}
+	cmd := newAppsAppleCmdWithFactory(func() (appleConnectClient, error) { return apple, nil })
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetContext(WithRuntime(context.Background(), rt))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"setup", "app", "--force",
+		"--apple-id", "dev@example.com", "--apple-password", "secret", "--verification-code", "123456",
+	})
+	_ = cmd.Execute() // exits non-zero for the failed key; we only assert the label here
+
+	if !strings.Contains(stdout.String(), "kept existing (replace failed") {
+		t.Fatalf("a failed replace of a configured key should read as kept existing, got:\n%s", stdout.String())
+	}
+}
+
 func TestCreateAppStoreAppRecord_NonFatalOnAppleFailure(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/internal/cli/apps_test.go
+++ b/internal/cli/apps_test.go
@@ -63,3 +63,28 @@ func TestAppsCreate_NoInputWithoutTypeErrorsBeforeCreating(t *testing.T) {
 		t.Fatalf("expected created app in output: %s", out)
 	}
 }
+
+// Regression: under --json (non-interactive) the command must error on missing
+// required input, not attempt a prompt and then fail confusingly.
+func TestAppsCreate_JSONErrorsOnMissingInputInsteadOfPrompting(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", configDir)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("no request should be made when required input is missing: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected", http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+	if err := config.Save("", &config.Config{APIKey: "sk_test", ProjectID: "proj_x", BaseURL: server.URL}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := runCmdInConfigDir(t, configDir, "apps", "create", "--json")
+	if err == nil || !strings.Contains(err.Error(), "--name") {
+		t.Fatalf("want a clean --name error under --json, got: %v", err)
+	}
+
+	_, _, err = runCmdInConfigDir(t, configDir, "apps", "create", "--json", "--name", "Acme", "--type", "app_store")
+	if err == nil || !strings.Contains(err.Error(), "--bundle-id") {
+		t.Fatalf("want a clean --bundle-id error under --json, got: %v", err)
+	}
+}


### PR DESCRIPTION
Post-merge Bugbot fixes for the Apple/apps flow.

**`apps create` prompted under `--json` (High, from #106).** On a TTY under `--json`, create still ran the interactive name form (and the platform-field form), so it prompted for the App name, skipped Type, then failed with `--type is required`. Both forms now run only when `rt.CanPrompt()`; non-interactively it validates the flags and errors cleanly on whatever's missing (`--name`, `--type`, `--bundle-id`/`--package-name`/`--app-name`), like `products create`.

**`apps apple setup` mislabeled failed keys (2× Medium, from #112).**
- A `--force` replace that Apple refuses leaves the previously-configured key in place — the card now reads `kept existing (replace failed)` instead of `not created`.
- A failed create can still leave a key in App Store Connect that counts toward Apple's limit, so the partial-failure warning now says to check Users and Access → Integrations and reuse/revoke it before re-running (instead of blindly re-running and minting a duplicate).

Regression tests added for the `--json` path and the failed-replace label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI validation and user-facing copy only; no API, auth, or credential-handling logic changes.
> 
> **Overview**
> `apps create` no longer runs interactive forms unless `CanPrompt()` is true. Under `--json`/`--no-input` it errors on missing flags (`--name`, `--type`, `--bundle-id` / `--package-name` / `--app-name`) instead of prompting then failing confusingly.
> 
> `apps apple setup` now labels a refused `--force` replace as **kept existing (replace failed)** when the key was already configured, and the partial-failure warning tells users a failed create can still occupy an App Store Connect key slot. Regression tests cover both.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b31eab9c877e24fbdb25a824f6163a1419e8b73f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->