### PR TITLE
feat(api): error-type predicates + fix rate-limit exit code

### DIFF
--- a/internal/api/error_predicates.go
+++ b/internal/api/error_predicates.go
@@ -44,11 +44,12 @@ func IsRateLimited(err error) bool {
 	return ok && (t == string(RateLimitedTypeRateLimitError) || t == "rate_limit_exceeded")
 }
 
-// IsUnauthorized reports a 401/403. The spec type is authentication_error;
-// parseError's bodyless fallback uses unauthorized.
+// IsUnauthorized reports a 401 (authentication_error) or 403 (authorization_error);
+// parseError's bodyless fallback for both uses unauthorized.
 func IsUnauthorized(err error) bool {
 	t, ok := apiErrorType(err)
-	return ok && (t == string(UnauthorizedTypeAuthenticationError) || t == "unauthorized")
+	return ok && (t == string(UnauthorizedTypeAuthenticationError) ||
+		t == string(ForbiddenTypeAuthorizationError) || t == "unauthorized")
 }
 
 // IsServerError reports a 500/502 server_error.

--- a/internal/api/error_predicates.go
+++ b/internal/api/error_predicates.go
@@ -1,0 +1,58 @@
+package api
+
+import "errors"
+
+// Error-type predicates. Callers should classify API errors through these
+// instead of comparing APIError.Type to string literals: the type strings come
+// from the OpenAPI spec (and its generated constants), so a spec rename becomes
+// a compile error here rather than a silently-dropped match at each call site.
+//
+// The rate-limit and unauthorized predicates also accept the legacy strings that
+// parseError synthesizes for a bodyless 4xx, so they match both a real API
+// response and the fallback.
+
+func apiErrorType(err error) (string, bool) {
+	var e *APIError
+	if errors.As(err, &e) {
+		return e.Type, true
+	}
+	return "", false
+}
+
+// IsAlreadyExists reports a 409 resource_already_exists.
+func IsAlreadyExists(err error) bool {
+	t, ok := apiErrorType(err)
+	return ok && t == string(ConflictTypeResourceAlreadyExists)
+}
+
+// IsNotFound reports a 404 resource_missing.
+func IsNotFound(err error) bool {
+	t, ok := apiErrorType(err)
+	return ok && t == string(NotFoundTypeResourceMissing)
+}
+
+// IsParameterError reports a 400/422 parameter_error.
+func IsParameterError(err error) bool {
+	t, ok := apiErrorType(err)
+	return ok && t == string(BadRequestTypeParameterError)
+}
+
+// IsRateLimited reports a 429. The spec type is rate_limit_error; parseError's
+// bodyless fallback uses rate_limit_exceeded.
+func IsRateLimited(err error) bool {
+	t, ok := apiErrorType(err)
+	return ok && (t == string(RateLimitedTypeRateLimitError) || t == "rate_limit_exceeded")
+}
+
+// IsUnauthorized reports a 401/403. The spec type is authentication_error;
+// parseError's bodyless fallback uses unauthorized.
+func IsUnauthorized(err error) bool {
+	t, ok := apiErrorType(err)
+	return ok && (t == string(UnauthorizedTypeAuthenticationError) || t == "unauthorized")
+}
+
+// IsServerError reports a 500/502 server_error.
+func IsServerError(err error) bool {
+	t, ok := apiErrorType(err)
+	return ok && t == string(InternalErrorTypeServerError)
+}

--- a/internal/api/error_predicates_test.go
+++ b/internal/api/error_predicates_test.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestErrorPredicates(t *testing.T) {
+	cases := []struct {
+		name string
+		pred func(error) bool
+		typ  string
+	}{
+		{"already_exists", IsAlreadyExists, "resource_already_exists"},
+		{"not_found", IsNotFound, "resource_missing"},
+		{"parameter_error", IsParameterError, "parameter_error"},
+		{"rate_limited", IsRateLimited, "rate_limit_error"},
+		{"unauthorized", IsUnauthorized, "authentication_error"},
+		{"server_error", IsServerError, "server_error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			match := &APIError{Type: tc.typ}
+			if !tc.pred(match) {
+				t.Errorf("should match type %q", tc.typ)
+			}
+			if !tc.pred(fmt.Errorf("wrap: %w", match)) {
+				t.Error("should match through a wrapped error")
+			}
+			if tc.pred(&APIError{Type: "something_else"}) {
+				t.Error("should not match an unrelated type")
+			}
+			if tc.pred(errors.New("plain")) {
+				t.Error("should not match a non-APIError")
+			}
+		})
+	}
+}
+
+// parseError synthesizes these strings for a bodyless 4xx, so the predicates
+// must accept them alongside the spec types.
+func TestRateLimitedAndUnauthorizedAcceptLegacyFallbackTypes(t *testing.T) {
+	if !IsRateLimited(&APIError{Type: "rate_limit_exceeded"}) {
+		t.Error("IsRateLimited should accept the legacy rate_limit_exceeded fallback")
+	}
+	if !IsUnauthorized(&APIError{Type: "unauthorized"}) {
+		t.Error("IsUnauthorized should accept the legacy unauthorized fallback")
+	}
+}

--- a/internal/api/error_predicates_test.go
+++ b/internal/api/error_predicates_test.go
@@ -47,4 +47,8 @@ func TestRateLimitedAndUnauthorizedAcceptLegacyFallbackTypes(t *testing.T) {
 	if !IsUnauthorized(&APIError{Type: "unauthorized"}) {
 		t.Error("IsUnauthorized should accept the legacy unauthorized fallback")
 	}
+	// 403 carries authorization_error, distinct from the 401 authentication_error.
+	if !IsUnauthorized(&APIError{Type: "authorization_error"}) {
+		t.Error("IsUnauthorized should match a 403 authorization_error")
+	}
 }

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -209,16 +209,13 @@ func ExitCodeFor(err error) int {
 	if errors.As(err, &ue) || errors.As(err, &uce) || isCobraUsage(err) {
 		return 2
 	}
-	var apiErr *api.APIError
-	if errors.As(err, &apiErr) {
-		switch apiErr.Type {
-		case "unauthorized", "authentication_error":
-			return 4
-		case "resource_missing":
-			return 5
-		case "rate_limit_exceeded":
-			return 6
-		}
+	switch {
+	case api.IsUnauthorized(err):
+		return 4
+	case api.IsNotFound(err):
+		return 5
+	case api.IsRateLimited(err):
+		return 6
 	}
 	if errors.Is(err, ErrNotAuthenticated) {
 		return 4

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -25,6 +25,7 @@ func TestExitCodeFor_Matrix(t *testing.T) {
 		{"not-authenticated", ErrNotAuthenticated, 4},
 		{"api-unauthorized", &api.APIError{Type: "unauthorized"}, 4},
 		{"api-auth-error", &api.APIError{Type: "authentication_error"}, 4},
+		{"api-forbidden", &api.APIError{Type: "authorization_error"}, 4},
 		{"api-resource-missing", &api.APIError{Type: "resource_missing"}, 5},
 		{"api-rate-limit-legacy", &api.APIError{Type: "rate_limit_exceeded"}, 6},
 		{"api-rate-limit-spec", &api.APIError{Type: "rate_limit_error"}, 6},

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -26,7 +26,9 @@ func TestExitCodeFor_Matrix(t *testing.T) {
 		{"api-unauthorized", &api.APIError{Type: "unauthorized"}, 4},
 		{"api-auth-error", &api.APIError{Type: "authentication_error"}, 4},
 		{"api-resource-missing", &api.APIError{Type: "resource_missing"}, 5},
-		{"api-rate-limit", &api.APIError{Type: "rate_limit_exceeded"}, 6},
+		{"api-rate-limit-legacy", &api.APIError{Type: "rate_limit_exceeded"}, 6},
+		{"api-rate-limit-spec", &api.APIError{Type: "rate_limit_error"}, 6},
+		{"api-wrapped-resource-missing", fmt.Errorf("fetch: %w", &api.APIError{Type: "resource_missing"}), 5},
 		{"api-other", &api.APIError{Type: "http_error"}, 1},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
CLI error handling matched API error types by hardcoded string literals (`apiErr.Type == "resource_missing"`, etc.), even though the v2 spec's error-type enum is already codegen'd into `internal/api/types_gen.go` as constants — they were just unused.

Adds predicates in `internal/api` backed by those constants:
`IsAlreadyExists`, `IsNotFound`, `IsParameterError`, `IsRateLimited`, `IsUnauthorized`, `IsServerError`. A future spec rename becomes a **compile error** instead of a silently-dropped match at each call site.

**Bonus — fixes a real bug.** `ExitCodeFor` only matched the synthesized `rate_limit_exceeded` fallback, not the spec's `rate_limit_error` that a real 429 actually carries — so real rate-limit errors returned exit `1` instead of `6`. `IsRateLimited` accepts both, so it's fixed and locked by a matrix test case.

`ExitCodeFor` is swept onto the predicates now. The other literal sites (paywalls attach/detach from #111, and the `parseError` synthesized fallbacks) can move over as they land — the predicates already accept the legacy fallback strings, so nothing regresses in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI exit-code mapping for auth, not-found, and rate-limit errors (a script-facing contract). Behavior is expanded (403 and spec 429 now map correctly) rather than narrowed.
> 
> **Overview**
> Adds `IsAlreadyExists`, `IsNotFound`, `IsParameterError`, `IsRateLimited`, `IsUnauthorized`, and `IsServerError` so callers classify `APIError`s via OpenAPI-generated type constants instead of string literals. Spec renames then fail at compile time. Rate-limit and unauthorized predicates also accept the bodyless-4xx fallback strings from `parseError`.
> 
> `ExitCodeFor` now uses those predicates. That **fixes a bug**: real 429s carry `rate_limit_error` and previously fell through to exit `1` instead of `6`. 403 `authorization_error` now maps to exit `4` as well. Wrapped errors are classified correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bfa87603024124bd3f46eb2dd1fac8f6bc438c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->