### PR TITLE
fix(paywalls): error on a missing draft revision instead of sending 0

### DIFF
--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -430,12 +430,12 @@ func seedSessionFromServer(ctx context.Context, rt *Runtime, projectID string, p
 	if paywall.OfferingID != "" {
 		offeringID = &paywall.OfferingID
 	}
-	// seedSessionFromServer already errored if components were missing, so a
-	// missing revision here just seeds 0 and the next fetch supplies the real one.
-	revision := 0
-	if version.Revision != nil {
-		revision = *version.Revision
+	// The revision is the PATCH's stale-write token; persistPaywallDesign sends
+	// it without refetching, so a missing one has to error rather than seed 0.
+	if version.Revision == nil {
+		return nil, fmt.Errorf("paywall %s has no draft or published revision to update against", paywallID)
 	}
+	revision := *version.Revision
 	return &paywallAISession{
 		Version:   1,
 		ProjectID: projectID,

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -430,8 +430,8 @@ func seedSessionFromServer(ctx context.Context, rt *Runtime, projectID string, p
 	if paywall.OfferingID != "" {
 		offeringID = &paywall.OfferingID
 	}
-	// Persist guards the PATCH with the session revision; normalize a server
-	// response without one, like currentDraftRevision does.
+	// seedSessionFromServer already errored if components were missing, so a
+	// missing revision here just seeds 0 and the next fetch supplies the real one.
 	revision := 0
 	if version.Revision != nil {
 		revision = *version.Revision
@@ -754,7 +754,16 @@ func currentDraftRevision(ctx context.Context, client *api.Client, projectID, pa
 	if err != nil {
 		return 0, err
 	}
-	return paywallRevision(paywall), nil
+	if paywall.Components != nil {
+		if d := paywall.Components.Draft; d != nil && d.Revision != nil {
+			return *d.Revision, nil
+		}
+		if p := paywall.Components.Published; p != nil && p.Revision != nil {
+			return *p.Revision, nil
+		}
+	}
+	// revision is the update PATCH's stale-write token, so error rather than send a bogus 0.
+	return 0, fmt.Errorf("paywall %s has no draft or published revision to update against", paywallID)
 }
 
 // reportPaywallAIActivity prints activity items not yet shown; snapshots carry

--- a/internal/cli/paywalls_ai_test.go
+++ b/internal/cli/paywalls_ai_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+func TestCurrentDraftRevision(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		want    int
+		wantErr bool
+	}{
+		{"draft revision", `{"id":"pw","components":{"published":null,"draft":{"revision":7}}}`, 7, false},
+		{"falls back to published", `{"id":"pw","components":{"published":{"revision":3},"draft":null}}`, 3, false},
+		{"no revision errors", `{"id":"pw","components":{"published":null,"draft":null}}`, 0, true},
+		{"no components errors", `{"id":"pw"}`, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer srv.Close()
+			client := api.NewClient(api.Options{APIKey: "sk", BaseURL: srv.URL})
+
+			got, err := currentDraftRevision(context.Background(), client, "proj", "pw")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got revision %d", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("revision = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/paywalls_ai_test.go
+++ b/internal/cli/paywalls_ai_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -8,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/revenuecat/cli/internal/api"
+	"github.com/revenuecat/cli/internal/config"
+	"github.com/revenuecat/cli/internal/output"
 )
 
 func TestCurrentDraftRevision(t *testing.T) {
@@ -43,6 +46,50 @@ func TestCurrentDraftRevision(t *testing.T) {
 			}
 			if got != tc.want {
 				t.Fatalf("revision = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSeedSessionFromServer(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		want    int
+		wantErr bool
+	}{
+		{"seeds draft revision", `{"id":"pw","components":{"draft":{"revision":7,"components_config":{"c":1},"default_locale":"en_US"}}}`, 7, false},
+		{"components but nil revision errors", `{"id":"pw","components":{"draft":{"components_config":{"c":1},"default_locale":"en_US"}}}`, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer srv.Close()
+
+			var stdout, stderr bytes.Buffer
+			rt := &Runtime{
+				Globals: &Globals{NoInput: true, Version: "test"},
+				Config:  &config.Config{APIKey: "sk", ProjectID: "proj", BaseURL: srv.URL},
+				Ctx:     context.Background(),
+				Out:     output.NewRenderer(&stdout, &stderr, true, true, false, ""),
+				client:  api.NewClient(api.Options{APIKey: "sk", BaseURL: srv.URL}),
+			}
+
+			session, err := seedSessionFromServer(context.Background(), rt, "proj", "pw")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got session with revision %v", session.Revision)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if session.Revision == nil || *session.Revision != tc.want {
+				t.Fatalf("revision = %v, want %d", session.Revision, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
`currentDraftRevision` returned `0` when a fetched paywall had no draft/published revision. But the spec is explicit that the draft `revision` on the update PATCH is an optimistic-concurrency token — *"The current draft revision. Used to reject stale writes"* — and `internal/api/paywalls.go` echoes it (*"Revision must match the server's current draft revision"*). So defaulting to `0` isn't harmless: the server rejects it as a stale write (or worse) instead of surfacing the real problem.

A paywall fetched via `GetWithComponents` with no draft/published revision is a broken state, so this now returns a clear error instead of a `0` revision. Callers already propagate the error.

Added a table test (`TestCurrentDraftRevision`) covering draft, published-fallback, and the two no-revision error paths.

Follow-up: when #111's `paywallRevision` helper lands (it wraps the same logic, currently returning `0`), it should get the same guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI error-handling change around concurrency tokens; no API contract or persist-path rewrite. Callers already propagate the error.
> 
> **Overview**
> Stops Paywalls AI from treating a missing draft/published `revision` as `0` when seeding a session or fetching the current draft revision.
> 
> `revision` is the optimistic-concurrency token on the draft PATCH. Defaulting to `0` produced stale-write 409s (or worse) instead of a clear failure. `currentDraftRevision` and `seedSessionFromServer` now error if neither draft nor published revision is present.
> 
> Adds table tests for draft, published fallback, and the no-revision error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd413316f7499898e10768d03f7a23ff172ac66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->