### PR TITLE
feat(paywalls): add duplicate command (offering dup deferred — needs scope call)

### DIFF
--- a/internal/cli/paywalls.go
+++ b/internal/cli/paywalls.go
@@ -67,6 +67,7 @@ URL, get the user's approval, then rc paywalls publish.`,
 		newPaywallsRewindCmd(),
 		newPaywallsPublishCmd(),
 		newPaywallsUnpublishCmd(),
+		newPaywallsDuplicateCmd(),
 		newPaywallsDeleteCmd(),
 	)
 	return cmd
@@ -279,6 +280,86 @@ builder URL instead — show returns metadata, not visuals.`,
 			return rt.Out.Render(p)
 		},
 	}
+}
+
+func newPaywallsDuplicateCmd() *cobra.Command {
+	var name, offeringID string
+	cmd := &cobra.Command{
+		Use:   "duplicate [id]",
+		Short: "Duplicate a Paywall",
+		Long: `Creates a new paywall from an existing one's components.
+
+The copy starts as a standalone draft (no offering) unless --offering-id is
+given, and its name defaults to "<source name> (copy)". The source is untouched.`,
+		Example: "  rc paywalls duplicate pw_abc\n  rc paywalls duplicate pw_abc --name \"Holiday variant\" --offering-id ofrng_x",
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rt := RuntimeFrom(cmd.Context())
+			projectID, err := requireProject(rt)
+			if err != nil {
+				return err
+			}
+			client, err := rt.API()
+			if err != nil {
+				return err
+			}
+			paywallID, err := requireID(rt, argAt(args, 0), "paywall", func() ([]PickerItem, error) {
+				return paywallPickerItems(cmd.Context(), client, projectID)
+			})
+			if err != nil {
+				return err
+			}
+			src, err := client.Paywalls.GetWithComponents(cmd.Context(), projectID, paywallID)
+			if err != nil {
+				return err
+			}
+			version := paywallComponentsToCopy(src)
+			if version == nil {
+				return fmt.Errorf("paywall %s has no components to duplicate", paywallID)
+			}
+			if name == "" {
+				base := strings.TrimSpace(src.Name)
+				if base == "" {
+					base = "Paywall"
+				}
+				name = base + " (copy)"
+			}
+			dup, err := client.Paywalls.CreateFromComponents(cmd.Context(), projectID, api.PaywallComponentsCreate{
+				OfferingID:              offeringID,
+				Name:                    name,
+				ComponentsConfig:        version.ComponentsConfig,
+				ComponentsLocalizations: version.ComponentsLocalizations,
+				DefaultLocale:           version.DefaultLocale,
+			})
+			if err != nil {
+				var apiErr *api.APIError
+				if offeringID != "" && errors.As(err, &apiErr) && apiErr.Status == 409 {
+					return WithHint(
+						fmt.Errorf("duplicating paywall %s into offering %s: an offering can only have one paywall: %w", paywallID, offeringID, err),
+						"Omit --offering-id to create a standalone copy, or pick an offering that has no paywall yet.",
+					)
+				}
+				return err
+			}
+			rt.Out.Success(fmt.Sprintf("Duplicated %s → %s", paywallID, dup.ID))
+			return rt.Out.Render(dup)
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", `name for the copy (default: source name + " (copy)")`)
+	cmd.Flags().StringVar(&offeringID, "offering-id", "", "attach the copy to this offering (default: standalone)")
+	return cmd
+}
+
+// paywallComponentsToCopy prefers the draft (the current editable state) and
+// falls back to the published version.
+func paywallComponentsToCopy(p *api.Paywall) *api.PaywallComponentsVersion {
+	if p.Components == nil {
+		return nil
+	}
+	if p.Components.Draft != nil {
+		return p.Components.Draft
+	}
+	return p.Components.Published
 }
 
 func newPaywallsDeleteCmd() *cobra.Command {

--- a/internal/cli/paywalls_duplicate_test.go
+++ b/internal/cli/paywalls_duplicate_test.go
@@ -1,0 +1,74 @@
+package cli_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/config"
+)
+
+func TestPaywallsDuplicate_CopiesComponentsWithDefaultName(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", configDir)
+
+	var createBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/paywalls/pw_src"):
+			_, _ = io.WriteString(w, `{"id":"pw_src","name":"Original","components":{"published":null,"draft":{"revision":2,"components_config":{"x":1},"components_localizations":{"en_US":{}},"default_locale":"en_US"}}}`)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/paywalls"):
+			b, _ := io.ReadAll(r.Body)
+			createBody = string(b)
+			_, _ = io.WriteString(w, `{"id":"pw_copy","name":"Original (copy)"}`)
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	if err := config.Save("", &config.Config{APIKey: "sk_test", ProjectID: "proj", BaseURL: srv.URL}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCmdInConfigDir(t, configDir, "paywalls", "duplicate", "pw_src", "--no-input", "--json")
+	if err != nil {
+		t.Fatalf("duplicate: %v", err)
+	}
+	if !strings.Contains(out, "pw_copy") {
+		t.Fatalf("want the new paywall id in output: %s", out)
+	}
+	// The copy carries the source's components and a defaulted name.
+	for _, want := range []string{`"name":"Original (copy)"`, `"components_config":{"x":1}`, `"default_locale":"en_US"`} {
+		if !strings.Contains(createBody, want) {
+			t.Errorf("create body missing %s:\n%s", want, createBody)
+		}
+	}
+}
+
+func TestPaywallsDuplicate_ErrorsWhenSourceHasNoComponents(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", configDir)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("no write should happen when the source has no components: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"pw_src","name":"Original","components":{"published":null,"draft":null}}`)
+	}))
+	t.Cleanup(srv.Close)
+	if err := config.Save("", &config.Config{APIKey: "sk_test", ProjectID: "proj", BaseURL: srv.URL}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := runCmdInConfigDir(t, configDir, "paywalls", "duplicate", "pw_src", "--no-input", "--json")
+	if err == nil || !strings.Contains(err.Error(), "no components") {
+		t.Fatalf("want a no-components error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Adds `rc paywalls duplicate [id]` — copies an existing paywall's components into a new one.

- Standalone draft by default; `--offering-id` to attach (with a hint on the one-paywall-per-offering 409).
- Name defaults to `"<source> (copy)"`; `--name` to override.
- Copies the draft components (falls back to published); the source is untouched.
- Errors clearly if the source has no components.

### Offering duplicate — deferred, blocked on a v2 endpoint (DX-971)
DX-858 also asks for offering duplication. The dashboard does this as a **shallow, server-side** copy via an internal v1 action (`POST /internal/v1/developers/me/projects/{project_id}/offerings/{offering_id}/duplicate` — new identifier/display name + optional "also duplicate the paywall"). There's **no v2 equivalent**, so the CLI can't do it cleanly (a client-side multi-call copy wouldn't be atomic and wouldn't match the dashboard). Filed **DX-971** to add `POST .../offerings/{offering_id}/actions/duplicate` to v2; `rc offerings duplicate` becomes a thin wrapper once that lands.

Tests cover the copy (components + defaulted name in the create body) and the no-components error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
