### PR TITLE
feat(api): model store-state response + capture raw_store_status

### DIFF
--- a/docs/specs/v2-beta-overlay.yaml
+++ b/docs/specs/v2-beta-overlay.yaml
@@ -301,6 +301,13 @@ paths:
                     description: >-
                       Store-specific payload; the shape differs by store (App Store
                       vs Play Store) and is intentionally freeform.
+                  warnings:
+                    type: array
+                    description: >-
+                      Live-only human-readable notes about what's missing or needs
+                      attention (e.g. incomplete territory pricing).
+                    items:
+                      type: string
     post:
       summary: Set a product store state
       description: "Accepts desired store metadata for a product and enqueues an asynchronous\n\

--- a/docs/specs/v2-beta-overlay.yaml
+++ b/docs/specs/v2-beta-overlay.yaml
@@ -230,6 +230,77 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  project_id:
+                    type: string
+                  product_id:
+                    type: string
+                  store:
+                    type: string
+                    enum: [app_store, play_store]
+                  store_status:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                        description: RevenueCat-normalized health.
+                        enum: [ok, needs_action, not_found]
+                      raw_store_status:
+                        type: string
+                        nullable: true
+                        description: >-
+                          The store's own status, passed through verbatim. For the
+                          App Store this is Apple's product/subscription state (e.g.
+                          MISSING_METADATA, READY_TO_SUBMIT, APPROVED). Null when the
+                          product has no store presence yet (e.g. Test Store).
+                  common:
+                    type: object
+                    properties:
+                      availability:
+                        type: object
+                        properties:
+                          territories:
+                            type: object
+                            description: region -> available.
+                            additionalProperties:
+                              type: boolean
+                      pricing:
+                        type: object
+                        properties:
+                          territory_prices:
+                            type: object
+                            description: region -> next effective price.
+                            additionalProperties:
+                              type: object
+                              properties:
+                                amount_micros:
+                                  type: integer
+                                  format: int64
+                                currency:
+                                  type: string
+                                start_date:
+                                  type: string
+                                  nullable: true
+                      localizations:
+                        type: object
+                        additionalProperties:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            description:
+                              type: string
+                              nullable: true
+                  store_state:
+                    type: object
+                    additionalProperties: true
+                    description: >-
+                      Store-specific payload; the shape differs by store (App Store
+                      vs Play Store) and is intentionally freeform.
     post:
       summary: Set a product store state
       description: "Accepts desired store metadata for a product and enqueues an asynchronous\n\

--- a/internal/api/store_state_direct.go
+++ b/internal/api/store_state_direct.go
@@ -62,7 +62,12 @@ type LiveStoreState struct {
 }
 
 type StoreStatus struct {
+	// Status is RevenueCat's normalized health: ok | needs_action | not_found.
 	Status string `json:"status"`
+	// RawStoreStatus is the store's own state passed through verbatim (e.g. the
+	// App Store's MISSING_METADATA, READY_TO_SUBMIT, APPROVED); nil when the
+	// product has no store presence yet (e.g. Test Store).
+	RawStoreStatus *string `json:"raw_store_status"`
 }
 
 type StoreStateCommon struct {

--- a/internal/api/store_state_direct.go
+++ b/internal/api/store_state_direct.go
@@ -59,6 +59,9 @@ type LiveStoreState struct {
 	StoreStatus *StoreStatus      `json:"store_status"`
 	Common      *StoreStateCommon `json:"common"`
 	StoreState  map[string]any    `json:"store_state"`
+	// Warnings is a live-only field: human-readable notes about what's missing
+	// or needs attention (e.g. incomplete territory pricing). Empty when clean.
+	Warnings []string `json:"warnings"`
 }
 
 type StoreStatus struct {

--- a/internal/api/store_state_direct_test.go
+++ b/internal/api/store_state_direct_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Guards against the drift that hid raw_store_status: the live store-state
+// response must round-trip into LiveStoreState with every typed field captured.
+func TestLiveStoreState_RoundTrip(t *testing.T) {
+	const body = `{
+	  "project_id": "proj1",
+	  "product_id": "prod1",
+	  "store": "app_store",
+	  "store_status": {"status": "needs_action", "raw_store_status": "MISSING_METADATA"},
+	  "common": {
+	    "availability": {"territories": {"US": true, "GB": false}},
+	    "pricing": {"territory_prices": {"US": {"amount_micros": 9990000, "currency": "USD", "start_date": null}}},
+	    "localizations": {"en-US": {"name": "Pro", "description": null}}
+	  },
+	  "store_state": {"subscription_group_name": "Main"}
+	}`
+
+	var s LiveStoreState
+	if err := json.Unmarshal([]byte(body), &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if s.StoreStatus == nil || s.StoreStatus.Status != "needs_action" {
+		t.Fatalf("store_status.status not captured: %+v", s.StoreStatus)
+	}
+	if s.StoreStatus.RawStoreStatus == nil || *s.StoreStatus.RawStoreStatus != "MISSING_METADATA" {
+		t.Fatalf("raw_store_status not captured: %+v", s.StoreStatus)
+	}
+	if s.Common == nil || s.Common.Availability == nil || !s.Common.Availability.Territories["US"] || s.Common.Availability.Territories["GB"] {
+		t.Fatalf("availability not captured: %+v", s.Common)
+	}
+	price, ok := s.Common.Pricing.TerritoryPrices["US"]
+	if !ok || price.AmountMicros != 9990000 || price.Currency != "USD" {
+		t.Fatalf("pricing not captured: %+v", s.Common.Pricing)
+	}
+	if s.Common.Localizations["en-US"].Name != "Pro" {
+		t.Fatalf("localizations not captured: %+v", s.Common.Localizations)
+	}
+	if s.StoreState["subscription_group_name"] != "Main" {
+		t.Fatalf("freeform store_state not captured: %+v", s.StoreState)
+	}
+}
+
+// A product with no store presence (e.g. Test Store) returns a null
+// raw_store_status; it must decode to nil, not the empty string.
+func TestLiveStoreState_NullRawStatus(t *testing.T) {
+	var s LiveStoreState
+	if err := json.Unmarshal([]byte(`{"store_status":{"status":"ok","raw_store_status":null}}`), &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.StoreStatus.RawStoreStatus != nil {
+		t.Fatalf("null raw_store_status should decode to nil, got %q", *s.StoreStatus.RawStoreStatus)
+	}
+}

--- a/internal/api/store_state_direct_test.go
+++ b/internal/api/store_state_direct_test.go
@@ -15,10 +15,11 @@ func TestLiveStoreState_RoundTrip(t *testing.T) {
 	  "store_status": {"status": "needs_action", "raw_store_status": "MISSING_METADATA"},
 	  "common": {
 	    "availability": {"territories": {"US": true, "GB": false}},
-	    "pricing": {"territory_prices": {"US": {"amount_micros": 9990000, "currency": "USD", "start_date": null}}},
-	    "localizations": {"en-US": {"name": "Pro", "description": null}}
+	    "pricing": {"territory_prices": {"US": {"amount_micros": 9990000, "currency": "USD", "start_date": "2026-09-01"}}},
+	    "localizations": {"en-US": {"name": "Pro", "description": "Full access"}}
 	  },
-	  "store_state": {"subscription_group_name": "Main"}
+	  "store_state": {"subscription_group_name": "Main"},
+	  "warnings": ["Incomplete territory pricing"]
 	}`
 
 	var s LiveStoreState
@@ -36,14 +37,18 @@ func TestLiveStoreState_RoundTrip(t *testing.T) {
 		t.Fatalf("availability not captured: %+v", s.Common)
 	}
 	price, ok := s.Common.Pricing.TerritoryPrices["US"]
-	if !ok || price.AmountMicros != 9990000 || price.Currency != "USD" {
+	if !ok || price.AmountMicros != 9990000 || price.Currency != "USD" || price.StartDate == nil || *price.StartDate != "2026-09-01" {
 		t.Fatalf("pricing not captured: %+v", s.Common.Pricing)
 	}
-	if s.Common.Localizations["en-US"].Name != "Pro" {
+	loc := s.Common.Localizations["en-US"]
+	if loc.Name != "Pro" || loc.Description == nil || *loc.Description != "Full access" {
 		t.Fatalf("localizations not captured: %+v", s.Common.Localizations)
 	}
 	if s.StoreState["subscription_group_name"] != "Main" {
 		t.Fatalf("freeform store_state not captured: %+v", s.StoreState)
+	}
+	if len(s.Warnings) != 1 || s.Warnings[0] != "Incomplete territory pricing" {
+		t.Fatalf("warnings not captured: %+v", s.Warnings)
 	}
 }
 

--- a/internal/api/types_gen.go
+++ b/internal/api/types_gen.go
@@ -29055,6 +29055,45 @@ func (e CreateProductInStore503JSONResponseBodyType) Valid() bool {
 	}
 }
 
+// Defines values for GetProductStoreState200JSONResponseBodyStore.
+const (
+	GetProductStoreState200JSONResponseBodyStoreAppStore  GetProductStoreState200JSONResponseBodyStore = "app_store"
+	GetProductStoreState200JSONResponseBodyStorePlayStore GetProductStoreState200JSONResponseBodyStore = "play_store"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState200JSONResponseBodyStore enum.
+func (e GetProductStoreState200JSONResponseBodyStore) Valid() bool {
+	switch e {
+	case GetProductStoreState200JSONResponseBodyStoreAppStore:
+		return true
+	case GetProductStoreState200JSONResponseBodyStorePlayStore:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetProductStoreState200JSONResponseBodyStoreStatusStatus.
+const (
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusNeedsAction GetProductStoreState200JSONResponseBodyStoreStatusStatus = "needs_action"
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusNotFound    GetProductStoreState200JSONResponseBodyStoreStatusStatus = "not_found"
+	GetProductStoreState200JSONResponseBodyStoreStatusStatusOk          GetProductStoreState200JSONResponseBodyStoreStatusStatus = "ok"
+)
+
+// Valid indicates whether the value is a known member of the GetProductStoreState200JSONResponseBodyStoreStatusStatus enum.
+func (e GetProductStoreState200JSONResponseBodyStoreStatusStatus) Valid() bool {
+	switch e {
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusNeedsAction:
+		return true
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusNotFound:
+		return true
+	case GetProductStoreState200JSONResponseBodyStoreStatusStatusOk:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for SearchPurchases400JSONResponseBodyObject.
 const (
 	SearchPurchases400JSONResponseBodyObjectError SearchPurchases400JSONResponseBodyObject = "error"
@@ -43994,6 +44033,12 @@ type CreateProductInStore503JSONResponseBodyObject string
 
 // CreateProductInStore503JSONResponseBodyType defines parameters for CreateProductInStore.
 type CreateProductInStore503JSONResponseBodyType string
+
+// GetProductStoreState200JSONResponseBodyStore defines parameters for GetProductStoreState.
+type GetProductStoreState200JSONResponseBodyStore string
+
+// GetProductStoreState200JSONResponseBodyStoreStatusStatus defines parameters for GetProductStoreState.
+type GetProductStoreState200JSONResponseBodyStoreStatusStatus string
 
 // SearchPurchasesParams defines parameters for SearchPurchases.
 type SearchPurchasesParams struct {


### PR DESCRIPTION
The `get-product-store-state` response was never modeled — the overlay had a bare `200: OK` and the Go types are hand-written, so `StoreStatus` silently dropped **`raw_store_status`** (the store's own state, e.g. the App Store's `MISSING_METADATA` / `READY_TO_SUBMIT` / `APPROVED`). That's exactly the field the post-apply readiness work needs.

This fixes the foundation:
- **Captures `raw_store_status`** on `StoreStatus` (nullable — the store returns null when there's no store presence yet, e.g. Test Store).
- **Models the response schema** in the beta overlay: `store_status.{status, raw_store_status}`, `common.availability.territories`, `common.pricing.territory_prices`, `common.localizations`. The per-store `store_state` payload stays freeform (App Store vs Play Store shapes differ). `make gen` regenerates the matching status/store enum helpers.
- **Round-trip test** locks the shape so the struct can't drift from the documented response again.

Unblocks the readiness + equalization work (DX-974). No behavior change on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema/type modeling only; no request/response behavior change beyond decoding extra JSON fields that were already returned.
> 
> **Overview**
> Fixes the live `get-product-store-state` model so the client no longer drops the store’s own status.
> 
> `StoreStatus` now includes nullable `raw_store_status` (Apple states like `MISSING_METADATA` / `APPROVED`; null when there is no store presence). `LiveStoreState` also captures live-only `warnings`. The beta overlay finally describes the 200 body (`store_status`, `common` availability/pricing/localizations, freeform `store_state`, `warnings`); generated store/status enums follow. A round-trip JSON test locks the shape so those fields cannot silently disappear again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc6a595c26daa9e6d41ab60f215fbac3b403c6cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->