### PR TITLE
feat(products): live store readiness after apply + price equalization

### DIFF
--- a/internal/cli/products_store.go
+++ b/internal/cli/products_store.go
@@ -99,9 +99,14 @@ creating and reviewing without applying.
 Warnings about review notes, the review screenshot, and subscription group
 localizations are App Review submission requirements, not creation blockers —
 each warning prints a hint naming the exact CSV column or JSON field that
-clears it.`,
+clears it.
+
+For App Store subscriptions, --equalize-base-territory <TERRITORY> fills missing
+territory prices from a base territory (e.g. US) during apply. After applying,
+each product's live readiness is reported (see rc products store apply --help).`,
 		Example: `  rc products store sync app_abc
   rc products store sync app_abc --file catalog.csv
+  rc products store sync app_abc --file catalog.csv --equalize-base-territory US
   cat desired-states.json | rc products store sync app_abc --file - --input-format json --plan-only --json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -156,7 +161,10 @@ not creation blockers — products create fine without them. Provide review
 notes via the app_store_review_notes CSV column (or
 store_state.review_information.notes in JSON); group display names via the
 app_store_subscription_group_localized_name CSV column. A placeholder review
-screenshot is uploaded automatically; replace it before submitting to Apple.`,
+screenshot is uploaded automatically; replace it before submitting to Apple.
+
+For App Store subscriptions, --equalize-base-territory <TERRITORY> (e.g. US)
+fills missing territory prices from a base territory during apply.`,
 		Example: `  rc products store plan app_abc --file catalog.csv --json --no-input
   cat desired-states.json | rc products store plan app_abc --file - --input-format json --json --no-input`,
 		Args: cobra.MaximumNArgs(1),
@@ -225,6 +233,18 @@ applies the plan ID supplied.
 
 Reversibility: writes to the connected store — undo by planning and applying
 the reverse state.
+
+After applying, it reads each product's live store state and reports readiness,
+because a plan the store accepted is not the same as a sellable product:
+  READY       configured and sellable
+  IN_PROGRESS the store is still processing (e.g. in review)
+  INCOMPLETE  something is missing (unpriced territories, missing metadata) —
+              each product prints the next action to take
+  FAILED      the product could not be applied or isn't in the store
+  UNKNOWN     the live state could not be read (the apply still succeeded)
+A non-READY result is reported as a warning, never a plain success. In --json the
+readiness object carries per-product verdict, raw_store_status, unpriced
+territories, store warnings, and next actions.
 
 Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`,
 		Example: `  rc products store apply plan_123 --yes --json --no-input`,

--- a/internal/cli/products_store.go
+++ b/internal/cli/products_store.go
@@ -368,8 +368,9 @@ func applyStoreStatePlan(ctx context.Context, rt *Runtime, client *api.Client, p
 	if plan.Status == "apply_errored" {
 		return fmt.Errorf("store-state plan %s failed while applying: %s", plan.ID, storeStateApplyErrors(plan))
 	}
-	rt.Out.Success("Applied plan " + plan.ID + " to the stores")
-	return renderStoreStatePlanResult(rt, plan)
+	rt.Out.Info("Applied plan " + plan.ID + " to the stores; verifying readiness")
+	report := verifyStoreStateReadiness(ctx, rt, client.StoreState, projectID, plan)
+	return renderStoreStateApplyResult(rt, plan, report)
 }
 
 type storeStatePlansAPI interface {

--- a/internal/cli/products_store.go
+++ b/internal/cli/products_store.go
@@ -369,8 +369,9 @@ func applyStoreStatePlan(ctx context.Context, rt *Runtime, client *api.Client, p
 	}
 	if !slices.Contains(plan.Actions, "apply") {
 		if plan.Status == "planned_and_finished" || (plan.HasChanges != nil && !*plan.HasChanges) {
-			rt.Out.Success("Store state already matches the desired state; nothing to apply")
-			return renderStoreStatePlanResult(rt, plan)
+			rt.Out.Info("Store state already matches the desired state; nothing to apply. Verifying readiness")
+			report := verifyStoreStateReadiness(ctx, rt, client.StoreState, projectID, plan)
+			return renderStoreStateApplyResult(rt, plan, report)
 		}
 		return fmt.Errorf("store-state plan %s cannot be applied from status %s; available actions: %s", plan.ID, plan.Status, strings.Join(plan.Actions, ", "))
 	}

--- a/internal/cli/products_store_input.go
+++ b/internal/cli/products_store_input.go
@@ -17,17 +17,46 @@ import (
 )
 
 type storeStateInputOptions struct {
-	file        string
-	inputFormat string
+	file                  string
+	inputFormat           string
+	equalizeBaseTerritory string
 }
 
 func (o *storeStateInputOptions) addFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	flags.StringVarP(&o.file, "file", "f", "", "desired state file, or - for stdin (env: RC_STORE_STATE_FILE)")
 	flags.StringVar(&o.inputFormat, "input-format", "", "input format for stdin or extensionless files: csv or json")
+	flags.StringVar(&o.equalizeBaseTerritory, "equalize-base-territory", "", "equalize missing subscription prices from this base territory (e.g. US)")
 }
 
 func (o *storeStateInputOptions) desiredStates(rt *Runtime, app *api.App, stdin io.Reader) ([]api.StoreStatePlanDesiredState, error) {
+	states, err := o.gatherDesiredStates(rt, app, stdin)
+	if err != nil {
+		return nil, err
+	}
+	if base := strings.ToUpper(strings.TrimSpace(o.equalizeBaseTerritory)); base != "" {
+		for i := range states {
+			injectEqualizeBaseTerritory(&states[i], base)
+		}
+	}
+	return states, nil
+}
+
+// injectEqualizeBaseTerritory adds an equalization directive under
+// common.pricing without disturbing any territory_prices already set there.
+func injectEqualizeBaseTerritory(state *api.StoreStatePlanDesiredState, base string) {
+	if state.Common == nil {
+		state.Common = map[string]any{}
+	}
+	pricing, ok := state.Common["pricing"].(map[string]any)
+	if !ok {
+		pricing = map[string]any{}
+		state.Common["pricing"] = pricing
+	}
+	pricing["equalize_missing_subscription_prices"] = map[string]any{"base_territory": base}
+}
+
+func (o *storeStateInputOptions) gatherDesiredStates(rt *Runtime, app *api.App, stdin io.Reader) ([]api.StoreStatePlanDesiredState, error) {
 	if o.file == "" {
 		o.file = os.Getenv("RC_STORE_STATE_FILE")
 	}

--- a/internal/cli/products_store_lifecycle_test.go
+++ b/internal/cli/products_store_lifecycle_test.go
@@ -90,6 +90,40 @@ func TestProductsStoreApply_UsesExistingPlanWithoutRecreatingIt(t *testing.T) {
 	}
 }
 
+func TestProductsStoreApply_NoOpStillVerifiesReadiness(t *testing.T) {
+	applied := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/projects/proj/store_state/plans/plan_123":
+			_, _ = io.WriteString(w, `{"id":"plan_123","object":"product_store_state_plan","status":"planned_and_finished","has_changes":false,"actions":["discard"],"summary":{"products_added":0,"products_modified":0,"products_unchanged":1},"desired_states":[],"plan_items":[{"product_id":"prod_1","app_id":"app","store_identifier":"com.example.pro","action":"no_change","diff":[],"warnings":[],"error_message":null,"apply_status":null,"apply_error_message":null}],"error_message":null,"warnings":[]}`)
+		case "/projects/proj/store_state/plans/plan_123/actions/apply":
+			applied = true
+			http.Error(w, "no-op plan must not apply", http.StatusInternalServerError)
+		case "/projects/proj/products/prod_1/store_state":
+			_, _ = io.WriteString(w, `{"project_id":"proj","product_id":"prod_1","store":"app_store","store_status":{"status":"needs_action","raw_store_status":"MISSING_METADATA"},"common":{},"store_state":{}}`)
+		default:
+			http.Error(w, "unexpected request "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	out, _, err := runStoreLifecycleCommand(t, server.URL, "",
+		"products", "store", "apply", "plan_123", "--yes", "--json", "--no-input")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied {
+		t.Fatal("no-op plan issued an apply request")
+	}
+	if !strings.Contains(out, `"overall": "INCOMPLETE"`) {
+		t.Fatalf("no-op apply reported success instead of INCOMPLETE readiness: %s", out)
+	}
+	if !strings.Contains(out, `"raw_store_status": "MISSING_METADATA"`) {
+		t.Fatalf("output missing raw store status: %s", out)
+	}
+}
+
 func TestProductsStoreDiscard_RequiresYesUnderNoInput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "must not request without confirmation", http.StatusInternalServerError)

--- a/internal/cli/products_store_readiness.go
+++ b/internal/cli/products_store_readiness.go
@@ -62,12 +62,14 @@ func readinessSeverity(v readinessVerdict) int {
 }
 
 func worstReadiness(products []productReadiness) readinessVerdict {
-	worst := readinessReady
-	for i, p := range products {
-		if i == 0 {
-			worst = p.Verdict
-			continue
-		}
+	// Nothing verified is not READY: an empty list means every plan item was
+	// unreadable (e.g. a create that left its product ID unset), so claiming
+	// READY would report success without a single live check.
+	if len(products) == 0 {
+		return readinessUnknown
+	}
+	worst := products[0].Verdict
+	for _, p := range products[1:] {
 		if readinessSeverity(p.Verdict) > readinessSeverity(worst) {
 			worst = p.Verdict
 		}
@@ -230,14 +232,20 @@ type storeStateReader interface {
 func verifyStoreStateReadiness(ctx context.Context, rt *Runtime, reader storeStateReader, projectID string, plan *api.StoreStatePlan) *readinessReport {
 	report := &readinessReport{}
 	for _, item := range plan.PlanItems {
+		displayID := optionalString(item.ProductID, optionalString(item.StoreIdentifier, ""))
+		if item.ApplyStatus != nil && *item.ApplyStatus == "failed" {
+			report.Products = append(report.Products, productReadiness{ProductID: displayID, Verdict: readinessFailed})
+			continue
+		}
 		if item.ProductID == nil {
+			// A create can leave the RevenueCat product ID unset on the plan item,
+			// so there's nothing to read back. Record UNKNOWN rather than dropping
+			// the item — otherwise a create-only apply reports READY without a live
+			// check.
+			report.Products = append(report.Products, productReadiness{ProductID: displayID, Verdict: readinessUnknown})
 			continue
 		}
 		productID := *item.ProductID
-		if item.ApplyStatus != nil && *item.ApplyStatus == "failed" {
-			report.Products = append(report.Products, productReadiness{ProductID: productID, Verdict: readinessFailed})
-			continue
-		}
 		state, err := reader.Get(ctx, projectID, productID)
 		if err != nil {
 			if isStoreStateNotFound(err) {

--- a/internal/cli/products_store_readiness.go
+++ b/internal/cli/products_store_readiness.go
@@ -25,6 +25,10 @@ type productReadiness struct {
 	Verdict             readinessVerdict `json:"verdict"`
 	RawStoreStatus      *string          `json:"raw_store_status"`
 	UnpricedTerritories []string         `json:"unpriced_territories"`
+	// Warnings is the store's own remedy text (from the live read) — what to fix
+	// to make the product sellable. NextActions adds CLI-specific guidance.
+	Warnings    []string `json:"warnings,omitempty"`
+	NextActions []string `json:"next_actions,omitempty"`
 }
 
 type readinessReport struct {
@@ -107,7 +111,25 @@ func classifyProductReadiness(productID string, state *api.LiveStoreState, apply
 		verdict = readinessIncomplete
 	}
 	pr.Verdict = verdict
+	pr.Warnings = state.Warnings
+	pr.NextActions = readinessNextActions(pr)
 	return pr
+}
+
+// readinessNextActions turns a non-ready verdict into concrete CLI steps, so an
+// agent isn't left inferring the remedy from a raw status string.
+func readinessNextActions(pr productReadiness) []string {
+	if pr.Verdict == readinessReady || pr.Verdict == readinessInProgress {
+		return nil
+	}
+	var actions []string
+	if len(pr.UnpricedTerritories) > 0 {
+		actions = append(actions, "set prices for the unpriced territories, or fill them from a base territory: re-run with --equalize-base-territory <TERRITORY> (e.g. US)")
+	}
+	if pr.RawStoreStatus != nil && strings.EqualFold(*pr.RawStoreStatus, "MISSING_METADATA") {
+		actions = append(actions, "add the product's required metadata (localizations/review info) and re-apply; attach a real review screenshot with: rc products store screenshot <product-id> --file <path>")
+	}
+	return actions
 }
 
 // classifyRawStoreStatus resolves the store's own raw state. The second return
@@ -126,7 +148,7 @@ func classifyRawStoreStatus(raw *string, priced bool) (readinessVerdict, bool) {
 	case "MISSING_METADATA", "READY_TO_SUBMIT", "PREPARE_FOR_SUBMISSION",
 		"DEVELOPER_ACTION_NEEDED", "REJECTED", "DEVELOPER_REJECTED":
 		return readinessIncomplete, true
-	case "WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_BINARY_APPROVAL", "PROCESSING_CONTENT":
+	case "WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_BINARY_APPROVAL", "PROCESSING_CONTENT", "WAITING_FOR_UPLOAD":
 		return readinessInProgress, true
 	case "REMOVED_FROM_SALE", "DEVELOPER_REMOVED_FROM_SALE", "NOT_FOR_SALE":
 		return readinessIncomplete, true
@@ -216,6 +238,12 @@ func verifyStoreStateReadiness(ctx context.Context, rt *Runtime, reader storeSta
 func printReadinessReport(rt *Runtime, report *readinessReport) {
 	for _, p := range report.Products {
 		rt.Out.Info(formatProductReadiness(p))
+		for _, w := range p.Warnings {
+			rt.Out.Warn("  store: " + w)
+		}
+		for _, a := range p.NextActions {
+			rt.Out.Hint(a)
+		}
 	}
 	msg := fmt.Sprintf("Store readiness: %s", report.Overall)
 	switch report.Overall {

--- a/internal/cli/products_store_readiness.go
+++ b/internal/cli/products_store_readiness.go
@@ -130,7 +130,7 @@ func readinessNextActions(pr productReadiness, store string) []string {
 	if len(pr.UnpricedTerritories) > 0 {
 		switch store {
 		case "app_store":
-			actions = append(actions, "set prices for the unpriced territories, or fill them from a base territory: re-run with --equalize-base-territory <TERRITORY> (e.g. US)")
+			actions = append(actions, "set prices for the unpriced territories, or fill them from a base territory: re-run `products store plan`/`sync` (not `apply`) with --equalize-base-territory <TERRITORY> (e.g. US)")
 		case "play_store":
 			actions = append(actions, "set prices for the unpriced territories, or let Google fill them from a base-plan other-regions price (usd_price / eur_price)")
 		default:

--- a/internal/cli/products_store_readiness.go
+++ b/internal/cli/products_store_readiness.go
@@ -112,19 +112,28 @@ func classifyProductReadiness(productID string, state *api.LiveStoreState, apply
 	}
 	pr.Verdict = verdict
 	pr.Warnings = state.Warnings
-	pr.NextActions = readinessNextActions(pr)
+	pr.NextActions = readinessNextActions(pr, state.Store)
 	return pr
 }
 
 // readinessNextActions turns a non-ready verdict into concrete CLI steps, so an
-// agent isn't left inferring the remedy from a raw status string.
-func readinessNextActions(pr productReadiness) []string {
+// agent isn't left inferring the remedy from a raw status string. The unpriced
+// remedy differs by store — --equalize-base-territory is App Store subscription
+// equalization, so Play products get their own guidance rather than an Apple flag.
+func readinessNextActions(pr productReadiness, store string) []string {
 	if pr.Verdict == readinessReady || pr.Verdict == readinessInProgress {
 		return nil
 	}
 	var actions []string
 	if len(pr.UnpricedTerritories) > 0 {
-		actions = append(actions, "set prices for the unpriced territories, or fill them from a base territory: re-run with --equalize-base-territory <TERRITORY> (e.g. US)")
+		switch store {
+		case "app_store":
+			actions = append(actions, "set prices for the unpriced territories, or fill them from a base territory: re-run with --equalize-base-territory <TERRITORY> (e.g. US)")
+		case "play_store":
+			actions = append(actions, "set prices for the unpriced territories, or let Google fill them from a base-plan other-regions price (usd_price / eur_price)")
+		default:
+			actions = append(actions, "set prices for the unpriced territories")
+		}
 	}
 	if pr.RawStoreStatus != nil && strings.EqualFold(*pr.RawStoreStatus, "MISSING_METADATA") {
 		actions = append(actions, "add the product's required metadata (localizations/review info) and re-apply; attach a real review screenshot with: rc products store screenshot <product-id> --file <path>")

--- a/internal/cli/products_store_readiness.go
+++ b/internal/cli/products_store_readiness.go
@@ -1,0 +1,248 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+type readinessVerdict string
+
+const (
+	readinessReady      readinessVerdict = "READY"
+	readinessInProgress readinessVerdict = "IN_PROGRESS"
+	readinessIncomplete readinessVerdict = "INCOMPLETE"
+	readinessFailed     readinessVerdict = "FAILED"
+	readinessUnknown    readinessVerdict = "UNKNOWN"
+)
+
+type productReadiness struct {
+	ProductID           string           `json:"product_id"`
+	Verdict             readinessVerdict `json:"verdict"`
+	RawStoreStatus      *string          `json:"raw_store_status"`
+	UnpricedTerritories []string         `json:"unpriced_territories"`
+}
+
+type readinessReport struct {
+	Overall  readinessVerdict   `json:"overall"`
+	Products []productReadiness `json:"products"`
+}
+
+// storeStateApplyResult inlines the applied plan and appends the live readiness
+// verdict so --json consumers get both in one envelope.
+type storeStateApplyResult struct {
+	*api.StoreStatePlan
+	Readiness *readinessReport `json:"readiness,omitempty"`
+}
+
+// readinessSeverity ranks verdicts so the overall report can take the worst.
+// UNKNOWN sits below READY: a best-effort read failure must not eclipse a real
+// verdict from a product we could actually inspect.
+func readinessSeverity(v readinessVerdict) int {
+	switch v {
+	case readinessFailed:
+		return 4
+	case readinessIncomplete:
+		return 3
+	case readinessInProgress:
+		return 2
+	case readinessReady:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func worstReadiness(products []productReadiness) readinessVerdict {
+	worst := readinessReady
+	for i, p := range products {
+		if i == 0 {
+			worst = p.Verdict
+			continue
+		}
+		if readinessSeverity(p.Verdict) > readinessSeverity(worst) {
+			worst = p.Verdict
+		}
+	}
+	return worst
+}
+
+// classifyProductReadiness maps a live store read into a readiness verdict. It
+// is pure so the mapping can be exercised without the network.
+func classifyProductReadiness(productID string, state *api.LiveStoreState, applyStatus *string) productReadiness {
+	pr := productReadiness{ProductID: productID}
+	if applyStatus != nil && *applyStatus == "failed" {
+		pr.Verdict = readinessFailed
+		return pr
+	}
+	if state == nil {
+		pr.Verdict = readinessUnknown
+		return pr
+	}
+
+	pr.UnpricedTerritories = unpricedTerritories(state.Common)
+
+	var status string
+	if state.StoreStatus != nil {
+		status = state.StoreStatus.Status
+		pr.RawStoreStatus = state.StoreStatus.RawStoreStatus
+	}
+	if status == "not_found" {
+		pr.Verdict = readinessFailed
+		return pr
+	}
+
+	verdict, resolved := classifyRawStoreStatus(pr.RawStoreStatus, len(pr.UnpricedTerritories) == 0)
+	if !resolved {
+		verdict = classifyNormalizedStatus(status, len(pr.UnpricedTerritories) == 0)
+	}
+
+	// Available-but-unpriced territories force at least INCOMPLETE regardless of
+	// how the store itself reports the product.
+	if len(pr.UnpricedTerritories) > 0 && readinessSeverity(verdict) < readinessSeverity(readinessIncomplete) {
+		verdict = readinessIncomplete
+	}
+	pr.Verdict = verdict
+	return pr
+}
+
+// classifyRawStoreStatus resolves the store's own raw state. The second return
+// is false for raw states not covered here, signalling a fall back to the
+// normalized status.
+func classifyRawStoreStatus(raw *string, priced bool) (readinessVerdict, bool) {
+	if raw == nil {
+		return "", false
+	}
+	switch strings.ToUpper(strings.TrimSpace(*raw)) {
+	case "APPROVED":
+		if priced {
+			return readinessReady, true
+		}
+		return readinessIncomplete, true
+	case "MISSING_METADATA", "READY_TO_SUBMIT", "PREPARE_FOR_SUBMISSION",
+		"DEVELOPER_ACTION_NEEDED", "REJECTED", "DEVELOPER_REJECTED":
+		return readinessIncomplete, true
+	case "WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_BINARY_APPROVAL", "PROCESSING_CONTENT":
+		return readinessInProgress, true
+	case "REMOVED_FROM_SALE", "DEVELOPER_REMOVED_FROM_SALE", "NOT_FOR_SALE":
+		return readinessIncomplete, true
+	default:
+		return "", false
+	}
+}
+
+func classifyNormalizedStatus(status string, priced bool) readinessVerdict {
+	switch status {
+	case "ok":
+		if priced {
+			return readinessReady
+		}
+		return readinessIncomplete
+	case "not_found":
+		return readinessFailed
+	default:
+		return readinessIncomplete
+	}
+}
+
+func unpricedTerritories(common *api.StoreStateCommon) []string {
+	if common == nil || common.Availability == nil {
+		return nil
+	}
+	var priced map[string]api.TerritoryPrice
+	if common.Pricing != nil {
+		priced = common.Pricing.TerritoryPrices
+	}
+	var unpriced []string
+	for territory, available := range common.Availability.Territories {
+		if !available {
+			continue
+		}
+		if _, ok := priced[territory]; !ok {
+			unpriced = append(unpriced, territory)
+		}
+	}
+	sort.Strings(unpriced)
+	return unpriced
+}
+
+func isStoreStateNotFound(err error) bool {
+	var ae *api.APIError
+	if errors.As(err, &ae) {
+		return ae.Status == 404 || ae.Type == "resource_missing"
+	}
+	return false
+}
+
+type storeStateReader interface {
+	Get(ctx context.Context, projectID, productID string) (*api.LiveStoreState, error)
+}
+
+// verifyStoreStateReadiness reads each applied product's live state and reports
+// how ready it is. It is best-effort: a read that errors for reasons other than
+// not-found is recorded as UNKNOWN so a successful apply is never reported as a
+// failure.
+func verifyStoreStateReadiness(ctx context.Context, rt *Runtime, reader storeStateReader, projectID string, plan *api.StoreStatePlan) *readinessReport {
+	report := &readinessReport{}
+	for _, item := range plan.PlanItems {
+		if item.ProductID == nil {
+			continue
+		}
+		productID := *item.ProductID
+		if item.ApplyStatus != nil && *item.ApplyStatus == "failed" {
+			report.Products = append(report.Products, productReadiness{ProductID: productID, Verdict: readinessFailed})
+			continue
+		}
+		state, err := reader.Get(ctx, projectID, productID)
+		if err != nil {
+			if isStoreStateNotFound(err) {
+				report.Products = append(report.Products, productReadiness{ProductID: productID, Verdict: readinessFailed})
+				continue
+			}
+			report.Products = append(report.Products, productReadiness{ProductID: productID, Verdict: readinessUnknown})
+			continue
+		}
+		report.Products = append(report.Products, classifyProductReadiness(productID, state, item.ApplyStatus))
+	}
+	report.Overall = worstReadiness(report.Products)
+	printReadinessReport(rt, report)
+	return report
+}
+
+func printReadinessReport(rt *Runtime, report *readinessReport) {
+	for _, p := range report.Products {
+		rt.Out.Info(formatProductReadiness(p))
+	}
+	msg := fmt.Sprintf("Store readiness: %s", report.Overall)
+	switch report.Overall {
+	case readinessReady:
+		rt.Out.Success(msg)
+	case readinessInProgress, readinessUnknown:
+		rt.Out.Info(msg)
+	default:
+		rt.Out.Warn(msg)
+	}
+}
+
+func formatProductReadiness(p productReadiness) string {
+	parts := []string{string(p.Verdict), p.ProductID}
+	if p.RawStoreStatus != nil && *p.RawStoreStatus != "" {
+		parts = append(parts, "store status "+*p.RawStoreStatus)
+	}
+	line := strings.Join(parts, " ")
+	if len(p.UnpricedTerritories) > 0 {
+		line += fmt.Sprintf(" (available but unpriced: %s)", strings.Join(p.UnpricedTerritories, ", "))
+	}
+	return line
+}
+
+func renderStoreStateApplyResult(rt *Runtime, plan *api.StoreStatePlan, report *readinessReport) error {
+	if rt.Out.IsJSON() {
+		return rt.Out.Render(storeStateApplyResult{StoreStatePlan: plan, Readiness: report})
+	}
+	return renderStoreStatePlanResult(rt, plan)
+}

--- a/internal/cli/products_store_readiness.go
+++ b/internal/cli/products_store_readiness.go
@@ -166,6 +166,10 @@ func classifyRawStoreStatus(raw *string, priced bool) (readinessVerdict, bool) {
 	}
 }
 
+// classifyNormalizedStatus maps RevenueCat's store-agnostic status. Both stores
+// collapse into this enum (Apple maps its raw states into it and also sends a
+// verbatim raw_store_status; Play sends only this), so it's the primary signal
+// for Play, which has no raw state to classify.
 func classifyNormalizedStatus(status string, priced bool) readinessVerdict {
 	switch status {
 	case "ok":
@@ -175,6 +179,12 @@ func classifyNormalizedStatus(status string, priced bool) readinessVerdict {
 		return readinessIncomplete
 	case "not_found":
 		return readinessFailed
+	case "action_in_progress":
+		return readinessInProgress
+	case "needs_action", "inactive_in_store", "draft":
+		return readinessIncomplete
+	case "could_not_check", "unspecified", "unknown", "":
+		return readinessUnknown
 	default:
 		return readinessIncomplete
 	}

--- a/internal/cli/products_store_readiness_test.go
+++ b/internal/cli/products_store_readiness_test.go
@@ -62,6 +62,11 @@ func TestClassifyProductReadiness(t *testing.T) {
 			wantVerdict: readinessInProgress,
 		},
 		{
+			name:        "waiting for upload is in progress",
+			state:       liveState("needs_action", strPtr("WAITING_FOR_UPLOAD"), nil, nil),
+			wantVerdict: readinessInProgress,
+		},
+		{
 			name:        "not found status is failed",
 			state:       liveState("not_found", nil, nil, nil),
 			wantVerdict: readinessFailed,
@@ -99,6 +104,40 @@ func TestClassifyProductReadiness(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReadinessNextActionsAndWarnings(t *testing.T) {
+	priced := map[string]api.TerritoryPrice{"US": {AmountMicros: 1, Currency: "USD"}}
+
+	unpriced := classifyProductReadiness("prod", liveState("ok", strPtr("APPROVED"), map[string]bool{"US": true, "GB": true}, priced), nil)
+	if !anyContains(unpriced.NextActions, "--equalize-base-territory") {
+		t.Errorf("unpriced product should suggest --equalize-base-territory, got %v", unpriced.NextActions)
+	}
+
+	missing := classifyProductReadiness("prod", liveState("needs_action", strPtr("MISSING_METADATA"), nil, nil), nil)
+	if !anyContains(missing.NextActions, "rc products store screenshot") {
+		t.Errorf("missing metadata should mention the screenshot command, got %v", missing.NextActions)
+	}
+
+	ready := classifyProductReadiness("prod", liveState("ok", strPtr("APPROVED"), map[string]bool{"US": true}, priced), nil)
+	if len(ready.NextActions) != 0 {
+		t.Errorf("ready product should have no next actions, got %v", ready.NextActions)
+	}
+
+	st := liveState("needs_action", strPtr("MISSING_METADATA"), nil, nil)
+	st.Warnings = []string{"Incomplete territory pricing"}
+	if got := classifyProductReadiness("prod", st, nil); len(got.Warnings) != 1 || got.Warnings[0] != "Incomplete territory pricing" {
+		t.Errorf("live store warnings should be surfaced verbatim, got %v", got.Warnings)
+	}
+}
+
+func anyContains(list []string, sub string) bool {
+	for _, s := range list {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestWorstReadiness(t *testing.T) {

--- a/internal/cli/products_store_readiness_test.go
+++ b/internal/cli/products_store_readiness_test.go
@@ -15,6 +15,7 @@ func strPtr(s string) *string { return &s }
 
 func liveState(status string, raw *string, territories map[string]bool, priced map[string]api.TerritoryPrice) *api.LiveStoreState {
 	state := &api.LiveStoreState{
+		Store:       "app_store",
 		StoreStatus: &api.StoreStatus{Status: status, RawStoreStatus: raw},
 		Common:      &api.StoreStateCommon{},
 	}
@@ -117,6 +118,17 @@ func TestReadinessNextActionsAndWarnings(t *testing.T) {
 	missing := classifyProductReadiness("prod", liveState("needs_action", strPtr("MISSING_METADATA"), nil, nil), nil)
 	if !anyContains(missing.NextActions, "rc products store screenshot") {
 		t.Errorf("missing metadata should mention the screenshot command, got %v", missing.NextActions)
+	}
+
+	// A Play product must not be told to use the App Store-only equalize flag.
+	playState := liveState("ok", nil, map[string]bool{"US": true, "GB": true}, map[string]api.TerritoryPrice{"US": {AmountMicros: 1, Currency: "USD"}})
+	playState.Store = "play_store"
+	play := classifyProductReadiness("prod", playState, nil)
+	if anyContains(play.NextActions, "--equalize-base-territory") {
+		t.Errorf("Play product should not suggest the App Store equalize flag, got %v", play.NextActions)
+	}
+	if !anyContains(play.NextActions, "usd_price") {
+		t.Errorf("Play product should get Play-specific pricing guidance, got %v", play.NextActions)
 	}
 
 	ready := classifyProductReadiness("prod", liveState("ok", strPtr("APPROVED"), map[string]bool{"US": true}, priced), nil)

--- a/internal/cli/products_store_readiness_test.go
+++ b/internal/cli/products_store_readiness_test.go
@@ -1,0 +1,190 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+func strPtr(s string) *string { return &s }
+
+func liveState(status string, raw *string, territories map[string]bool, priced map[string]api.TerritoryPrice) *api.LiveStoreState {
+	state := &api.LiveStoreState{
+		StoreStatus: &api.StoreStatus{Status: status, RawStoreStatus: raw},
+		Common:      &api.StoreStateCommon{},
+	}
+	if territories != nil {
+		state.Common.Availability = &struct {
+			Territories map[string]bool `json:"territories"`
+		}{Territories: territories}
+	}
+	if priced != nil {
+		state.Common.Pricing = &struct {
+			TerritoryPrices map[string]api.TerritoryPrice `json:"territory_prices"`
+		}{TerritoryPrices: priced}
+	}
+	return state
+}
+
+func TestClassifyProductReadiness(t *testing.T) {
+	usPriced := map[string]api.TerritoryPrice{"US": {AmountMicros: 9990000, Currency: "USD"}}
+	tests := []struct {
+		name         string
+		state        *api.LiveStoreState
+		applyStatus  *string
+		wantVerdict  readinessVerdict
+		wantUnpriced []string
+	}{
+		{
+			name:        "approved and priced is ready",
+			state:       liveState("ok", strPtr("APPROVED"), map[string]bool{"US": true}, usPriced),
+			wantVerdict: readinessReady,
+		},
+		{
+			name:         "approved with unpriced available territory is incomplete",
+			state:        liveState("ok", strPtr("APPROVED"), map[string]bool{"US": true, "GB": true}, usPriced),
+			wantVerdict:  readinessIncomplete,
+			wantUnpriced: []string{"GB"},
+		},
+		{
+			name:        "missing metadata is incomplete",
+			state:       liveState("needs_action", strPtr("MISSING_METADATA"), nil, nil),
+			wantVerdict: readinessIncomplete,
+		},
+		{
+			name:        "waiting for review is in progress",
+			state:       liveState("needs_action", strPtr("WAITING_FOR_REVIEW"), nil, nil),
+			wantVerdict: readinessInProgress,
+		},
+		{
+			name:        "not found status is failed",
+			state:       liveState("not_found", nil, nil, nil),
+			wantVerdict: readinessFailed,
+		},
+		{
+			name:        "nil raw with ok status is ready",
+			state:       liveState("ok", nil, nil, nil),
+			wantVerdict: readinessReady,
+		},
+		{
+			name:        "nil raw with needs_action is incomplete",
+			state:       liveState("needs_action", nil, nil, nil),
+			wantVerdict: readinessIncomplete,
+		},
+		{
+			name:        "apply status failed is failed",
+			state:       liveState("ok", strPtr("APPROVED"), nil, nil),
+			applyStatus: strPtr("failed"),
+			wantVerdict: readinessFailed,
+		},
+		{
+			name:        "unknown raw falls back to normalized status",
+			state:       liveState("ok", strPtr("SOME_FUTURE_STATE"), nil, nil),
+			wantVerdict: readinessReady,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyProductReadiness("prod", tt.state, tt.applyStatus)
+			if got.Verdict != tt.wantVerdict {
+				t.Fatalf("verdict = %s, want %s", got.Verdict, tt.wantVerdict)
+			}
+			if strings.Join(got.UnpricedTerritories, ",") != strings.Join(tt.wantUnpriced, ",") {
+				t.Fatalf("unpriced = %v, want %v", got.UnpricedTerritories, tt.wantUnpriced)
+			}
+		})
+	}
+}
+
+func TestWorstReadiness(t *testing.T) {
+	products := []productReadiness{
+		{Verdict: readinessReady},
+		{Verdict: readinessInProgress},
+		{Verdict: readinessIncomplete},
+	}
+	if got := worstReadiness(products); got != readinessIncomplete {
+		t.Fatalf("worst = %s, want INCOMPLETE", got)
+	}
+	products = append(products, productReadiness{Verdict: readinessFailed})
+	if got := worstReadiness(products); got != readinessFailed {
+		t.Fatalf("worst = %s, want FAILED", got)
+	}
+	if got := worstReadiness(nil); got != readinessReady {
+		t.Fatalf("worst of none = %s, want READY", got)
+	}
+}
+
+func TestDesiredStates_EqualizeBaseTerritory(t *testing.T) {
+	input := `{"desired_states":[
+		{"store":"app_store","create_revenuecat_product":{"store_identifier":"a","type":"subscription","display_name":"A","title":"A"},"common":{"duration":"P1M"}},
+		{"store":"app_store","create_revenuecat_product":{"store_identifier":"b","type":"subscription","display_name":"B","title":"B"},"common":{"pricing":{"territory_prices":{"US":{"amount_micros":9990000,"currency":"USD"}}}}}
+	]}`
+	opts := storeStateInputOptions{file: "-", inputFormat: "json", equalizeBaseTerritory: "us"}
+	rt := &Runtime{Globals: &Globals{NoInput: true}}
+	states, err := opts.desiredStates(rt, &api.App{ID: "app", Type: "app_store"}, strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 2 {
+		t.Fatalf("expected 2 states, got %d", len(states))
+	}
+	for i, state := range states {
+		pricing, ok := state.Common["pricing"].(map[string]any)
+		if !ok {
+			t.Fatalf("state %d missing pricing map", i)
+		}
+		eq, ok := pricing["equalize_missing_subscription_prices"].(map[string]any)
+		if !ok {
+			t.Fatalf("state %d missing equalize directive", i)
+		}
+		if eq["base_territory"] != "US" {
+			t.Fatalf("state %d base_territory = %v, want US", i, eq["base_territory"])
+		}
+	}
+	// Existing territory_prices under pricing must survive the injection.
+	if _, ok := states[1].Common["pricing"].(map[string]any)["territory_prices"]; !ok {
+		t.Fatal("existing territory_prices was clobbered")
+	}
+}
+
+func TestProductsStoreApply_ReportsIncompleteReadiness(t *testing.T) {
+	planJSON := `{"id":"plan_123","object":"product_store_state_plan","status":%q,"has_changes":true,"actions":["apply","discard"],"summary":{"products_added":0,"products_modified":1,"products_unchanged":0},"desired_states":[],"plan_items":[{"product_id":"prod_1","app_id":"app","store_identifier":"com.example.pro","action":"update","diff":[],"warnings":[],"error_message":null,"apply_status":%q,"apply_error_message":null}],"error_message":null,"warnings":[]}`
+	getCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/projects/proj/store_state/plans/plan_123":
+			getCount++
+			if getCount == 1 {
+				_, _ = io.WriteString(w, `{"id":"plan_123","object":"product_store_state_plan","status":"planned","has_changes":true,"actions":["apply","discard"],"summary":{"products_added":0,"products_modified":1,"products_unchanged":0},"desired_states":[],"plan_items":[{"product_id":"prod_1","app_id":"app","store_identifier":"com.example.pro","action":"update","diff":[],"warnings":[],"error_message":null,"apply_status":"pending","apply_error_message":null}],"error_message":null,"warnings":[]}`)
+			} else {
+				_, _ = io.WriteString(w, fmt.Sprintf(planJSON, "applied", "applied"))
+			}
+		case "/projects/proj/store_state/plans/plan_123/actions/apply":
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"id":"plan_123","object":"product_store_state_plan","status":"apply_queued","polling_url":"/poll"}`)
+		case "/projects/proj/products/prod_1/store_state":
+			_, _ = io.WriteString(w, `{"project_id":"proj","product_id":"prod_1","store":"app_store","store_status":{"status":"needs_action","raw_store_status":"MISSING_METADATA"},"common":{},"store_state":{}}`)
+		default:
+			http.Error(w, "unexpected request "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	out, _, err := runStoreLifecycleCommand(t, server.URL, "",
+		"products", "store", "apply", "plan_123", "--yes", "--json", "--no-input")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `"overall": "INCOMPLETE"`) {
+		t.Fatalf("output missing INCOMPLETE readiness: %s", out)
+	}
+	if !strings.Contains(out, `"raw_store_status": "MISSING_METADATA"`) {
+		t.Fatalf("output missing raw store status: %s", out)
+	}
+}

--- a/internal/cli/products_store_readiness_test.go
+++ b/internal/cli/products_store_readiness_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/revenuecat/cli/internal/api"
+	"github.com/revenuecat/cli/internal/output"
 )
 
 func strPtr(s string) *string { return &s }
@@ -185,9 +187,39 @@ func TestWorstReadiness(t *testing.T) {
 	if got := worstReadiness(products); got != readinessFailed {
 		t.Fatalf("worst = %s, want FAILED", got)
 	}
-	if got := worstReadiness(nil); got != readinessReady {
-		t.Fatalf("worst of none = %s, want READY", got)
+	if got := worstReadiness(nil); got != readinessUnknown {
+		t.Fatalf("worst of none = %s, want UNKNOWN", got)
 	}
+}
+
+// A create apply can return plan items whose RevenueCat product ID is still
+// unset. Those items must be recorded as UNKNOWN (unverifiable), never dropped,
+// so a create-only apply never reports READY without a live check.
+func TestVerifyStoreStateReadiness_CreateWithNilProductID(t *testing.T) {
+	rt := &Runtime{Globals: &Globals{NoInput: true}, Out: output.NewRenderer(io.Discard, io.Discard, false, true, false, "")}
+	reader := readerFunc(func(ctx context.Context, projectID, productID string) (*api.LiveStoreState, error) {
+		t.Fatalf("live state must not be read for a nil product ID, got %q", productID)
+		return nil, nil
+	})
+	plan := &api.StoreStatePlan{PlanItems: []api.StoreStatePlanItem{
+		{ProductID: nil, StoreIdentifier: strPtr("com.example.pro"), Action: "create", ApplyStatus: strPtr("applied")},
+	}}
+	report := verifyStoreStateReadiness(context.Background(), rt, reader, "proj", plan)
+	if report.Overall != readinessUnknown {
+		t.Fatalf("overall = %s, want UNKNOWN", report.Overall)
+	}
+	if len(report.Products) != 1 || report.Products[0].Verdict != readinessUnknown {
+		t.Fatalf("products = %+v, want one UNKNOWN item", report.Products)
+	}
+	if report.Products[0].ProductID != "com.example.pro" {
+		t.Fatalf("product display id = %q, want the store identifier", report.Products[0].ProductID)
+	}
+}
+
+type readerFunc func(ctx context.Context, projectID, productID string) (*api.LiveStoreState, error)
+
+func (f readerFunc) Get(ctx context.Context, projectID, productID string) (*api.LiveStoreState, error) {
+	return f(ctx, projectID, productID)
 }
 
 func TestDesiredStates_EqualizeBaseTerritory(t *testing.T) {

--- a/internal/cli/products_store_readiness_test.go
+++ b/internal/cli/products_store_readiness_test.go
@@ -83,6 +83,26 @@ func TestClassifyProductReadiness(t *testing.T) {
 			wantVerdict: readinessIncomplete,
 		},
 		{
+			name:        "normalized action_in_progress is in progress (Play)",
+			state:       liveState("action_in_progress", nil, nil, nil),
+			wantVerdict: readinessInProgress,
+		},
+		{
+			name:        "normalized draft is incomplete (Play base plan not active)",
+			state:       liveState("draft", nil, nil, nil),
+			wantVerdict: readinessIncomplete,
+		},
+		{
+			name:        "normalized inactive_in_store is incomplete (Play)",
+			state:       liveState("inactive_in_store", nil, nil, nil),
+			wantVerdict: readinessIncomplete,
+		},
+		{
+			name:        "normalized could_not_check is unknown",
+			state:       liveState("could_not_check", nil, nil, nil),
+			wantVerdict: readinessUnknown,
+		},
+		{
 			name:        "apply status failed is failed",
 			state:       liveState("ok", strPtr("APPROVED"), nil, nil),
 			applyStatus: strPtr("failed"),


### PR DESCRIPTION
Closes the Product Catalog team's #1 concern: "RevenueCat accepted the plan" was being reported as if "Apple has a sellable product." Now `products store apply`/`sync` verify the live result.

**Stacked on #125** (which captures `raw_store_status`).

## Post-apply readiness
After apply reaches `applied`, it reads each affected product's live store state and classifies it — no longer a blanket "Applied to the stores":
- `APPROVED` + every available territory priced → **READY**
- `MISSING_METADATA` / `READY_TO_SUBMIT` / `DEVELOPER_ACTION_NEEDED` (or any available-but-unpriced territory) → **INCOMPLETE** (lists the unpriced territories)
- `WAITING_FOR_REVIEW` / `IN_REVIEW` / `PENDING_BINARY_APPROVAL` → **IN PROGRESS**
- `not_found` / apply failed → **FAILED**
- read error (network) → **UNKNOWN** (best-effort — a failed *read* never turns a successful apply into a reported failure)

Overall = worst product; a non-READY overall renders as a warning, not a success. `--json` gets a `readiness` object (`overall` + per-product `{product_id, verdict, raw_store_status, unpriced_territories}`) alongside the plan. `sync` gets this automatically (it calls the same apply path).

## Equalization
`--equalize-base-territory US` injects `common.pricing.equalize_missing_subscription_prices` into each desired state (preserving any explicit `territory_prices`), so missing App Store subscription prices get filled during apply.

(Blocker-gating on `warnings[severity=blocker]` already existed.)

Agreements/tax/banking are intentionally out of scope — account-level, not derivable from per-product state.

Tests: classifier table (every verdict), worst-overall, equalization injection, and an apply→readiness integration test asserting a `MISSING_METADATA` result reports INCOMPLETE (not success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes apply/sync output and success signaling for agents (JSON envelope, warning vs success). Classification of store statuses could mis-report readiness, but apply itself is unchanged and live reads are best-effort.
> 
> **Overview**
> `products store apply`/`sync` no longer treat a successful plan apply as a sellable product. After apply (including no-op plans), the CLI reads each product's live store state and reports **READY / IN_PROGRESS / INCOMPLETE / FAILED / UNKNOWN**, with overall = worst product. Non-READY is a warning, not success. `--json` adds a `readiness` object (verdict, `raw_store_status`, unpriced territories, store warnings, next actions).
> 
> Adds `--equalize-base-territory` on plan/sync so missing App Store subscription prices are filled from a base territory during apply, without overwriting existing `territory_prices`. Next-action hints are store-specific (Play is not told to use the Apple flag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e7844ae5cf233ba165f1aef5afca13c3222c32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->