### PR TITLE
feat(cli): tag v2 API requests with usage-analytics headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,22 @@ RC_HEADERS=$'X-Some-Header: value' rc offerings list
 
 One header per line; supplied headers override the CLI's defaults.
 
+## Usage analytics
+
+Every authenticated v2 API request carries a few headers so RevenueCat can see
+which commands are used and whether the CLI is driven by a human, an agent, or
+CI — derived from normal request logs, with no separate telemetry and no
+identifier of any kind:
+
+- `User-Agent` — `revenuecat-cli/<version> (<os> <arch>; go<goversion>)`.
+- `X-RC-CLI-Command` — the command path only (e.g. `paywalls.generate`), never
+  arguments, flag values, IDs, emails, or prompts.
+- `X-RC-CLI-Mode` — `interactive`, `agent` (`--json` or `--no-input`), or `ci`
+  (when `$CI` is set).
+
+Set `DO_NOT_TRACK=1` (per [consoledonottrack.com](https://consoledonottrack.com))
+to drop the `X-RC-CLI-*` headers. Requests still go through, just unlabeled.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/internal/cli/analytics.go
+++ b/internal/cli/analytics.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Usage-analytics request headers. The backend derives command usage and the
+// humans-vs-agents split from these on normal request logs.
+const (
+	headerCLICommand = "X-RC-CLI-Command"
+	headerCLIMode    = "X-RC-CLI-Mode"
+)
+
+// dottedCommandPath turns a cobra command path ("rc paywalls generate") into a
+// dotted identifier ("paywalls.generate"). It is deliberately the command path
+// only — never args, flag values, IDs, emails, or prompts — so the header can't
+// carry user or account data. Returns "" for the bare root command.
+func dottedCommandPath(cmd *cobra.Command) string {
+	fields := strings.Fields(commandPath(cmd))
+	if len(fields) <= 1 {
+		return ""
+	}
+	return strings.Join(fields[1:], ".")
+}
+
+// cliMode reports how the CLI is being driven: "ci" under a CI environment,
+// "agent" when output is machine-driven (--json / --no-input), else
+// "interactive".
+func cliMode(g *Globals) string {
+	if os.Getenv("CI") != "" {
+		return "ci"
+	}
+	if g.JSON || g.NoInput {
+		return "agent"
+	}
+	return "interactive"
+}
+
+// doNotTrack honors the DO_NOT_TRACK convention: any truthy value opts out.
+func doNotTrack() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("DO_NOT_TRACK"))) {
+	case "1", "true":
+		return true
+	}
+	return false
+}
+
+// requestHeaders assembles the extra headers sent on every v2 API request: the
+// usage-analytics headers (dropped when DO_NOT_TRACK is set — the request still
+// goes through, just unlabeled) plus any user-supplied RC_HEADERS, which
+// override so operators keep the final say.
+func requestHeaders(g *Globals) http.Header {
+	h := http.Header{}
+	if !doNotTrack() {
+		if g.CommandPath != "" {
+			h.Set(headerCLICommand, g.CommandPath)
+		}
+		h.Set(headerCLIMode, cliMode(g))
+	}
+	for name, values := range customHeaders() {
+		h[http.CanonicalHeaderKey(name)] = values
+	}
+	if len(h) == 0 {
+		return nil
+	}
+	return h
+}

--- a/internal/cli/analytics_test.go
+++ b/internal/cli/analytics_test.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/revenuecat/cli/internal/api"
+)
+
+func TestCommandPath(t *testing.T) {
+	root := &cobra.Command{Use: "rc"}
+	paywalls := &cobra.Command{Use: "paywalls"}
+	generate := &cobra.Command{Use: "generate"}
+	paywalls.AddCommand(generate)
+	root.AddCommand(paywalls)
+
+	cases := map[*cobra.Command]string{
+		root:     "",
+		paywalls: "paywalls",
+		generate: "paywalls.generate",
+	}
+	for cmd, want := range cases {
+		if got := dottedCommandPath(cmd); got != want {
+			t.Errorf("dottedCommandPath(%q) = %q, want %q", cmd.CommandPath(), got, want)
+		}
+	}
+}
+
+func TestCliMode(t *testing.T) {
+	cases := []struct {
+		name string
+		ci   string
+		g    Globals
+		want string
+	}{
+		{"interactive", "", Globals{}, "interactive"},
+		{"json is agent", "", Globals{JSON: true}, "agent"},
+		{"no-input is agent", "", Globals{NoInput: true}, "agent"},
+		{"ci wins over json", "true", Globals{JSON: true}, "ci"},
+		{"ci any value", "1", Globals{}, "ci"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CI", tc.ci)
+			if got := cliMode(&tc.g); got != tc.want {
+				t.Errorf("cliMode = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDoNotTrack(t *testing.T) {
+	cases := map[string]bool{"": false, "0": false, "false": false, "1": true, "true": true, "TRUE": true, " 1 ": true}
+	for val, want := range cases {
+		t.Setenv("DO_NOT_TRACK", val)
+		if got := doNotTrack(); got != want {
+			t.Errorf("doNotTrack() with DO_NOT_TRACK=%q = %v, want %v", val, got, want)
+		}
+	}
+}
+
+func TestRequestHeaders(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("RC_HEADERS", "")
+
+	h := requestHeaders(&Globals{CommandPath: "apps.apple.setup", JSON: true})
+	if got := h.Get(headerCLICommand); got != "apps.apple.setup" {
+		t.Errorf("%s = %q, want apps.apple.setup", headerCLICommand, got)
+	}
+	if got := h.Get(headerCLIMode); got != "agent" {
+		t.Errorf("%s = %q, want agent", headerCLIMode, got)
+	}
+}
+
+func TestRequestHeadersDoNotTrackDropsAnalytics(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "1")
+	t.Setenv("RC_HEADERS", "X-Trace: keep-me")
+
+	h := requestHeaders(&Globals{CommandPath: "paywalls.generate"})
+	if got := h.Get(headerCLICommand); got != "" {
+		t.Errorf("DO_NOT_TRACK must drop %s, got %q", headerCLICommand, got)
+	}
+	if got := h.Get(headerCLIMode); got != "" {
+		t.Errorf("DO_NOT_TRACK must drop %s, got %q", headerCLIMode, got)
+	}
+	if got := h.Get("X-Trace"); got != "keep-me" {
+		t.Errorf("DO_NOT_TRACK must not drop RC_HEADERS, X-Trace = %q, want keep-me", got)
+	}
+}
+
+func TestUserAgentFormat(t *testing.T) {
+	ua := userAgent("1.2.3")
+	if !strings.HasPrefix(ua, "revenuecat-cli/1.2.3 (") {
+		t.Errorf("User-Agent = %q, want revenuecat-cli/1.2.3 prefix", ua)
+	}
+	if !strings.Contains(ua, "; go") {
+		t.Errorf("User-Agent = %q, want a go version segment", ua)
+	}
+}
+
+// TestAnalyticsHeadersReachTheWire drives a real request through the API client
+// built the same way Runtime.API() builds it, and asserts all three headers land.
+func TestAnalyticsHeadersReachTheWire(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("RC_HEADERS", "")
+
+	var gotCmd, gotMode, gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCmd = r.Header.Get(headerCLICommand)
+		gotMode = r.Header.Get(headerCLIMode)
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	g := &Globals{CommandPath: "customers.show", NoInput: true, Version: "9.9.9"}
+	c := api.NewClient(api.Options{
+		APIKey:       "sk_test",
+		BaseURL:      srv.URL,
+		UserAgent:    userAgent(g.Version),
+		ExtraHeaders: requestHeaders(g),
+	})
+	if _, _, err := c.Raw(context.Background(), http.MethodGet, "/anything", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotCmd != "customers.show" {
+		t.Errorf("%s = %q, want customers.show", headerCLICommand, gotCmd)
+	}
+	if gotMode != "agent" {
+		t.Errorf("%s = %q, want agent", headerCLIMode, gotMode)
+	}
+	if !strings.HasPrefix(gotUA, "revenuecat-cli/9.9.9 (") {
+		t.Errorf("User-Agent = %q, want revenuecat-cli/9.9.9 prefix", gotUA)
+	}
+}
+
+func TestDoNotTrackStillSendsRequest(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "1")
+	t.Setenv("RC_HEADERS", "")
+
+	var gotCmd, gotMode, gotUA string
+	var served bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		served = true
+		gotCmd = r.Header.Get(headerCLICommand)
+		gotMode = r.Header.Get(headerCLIMode)
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	g := &Globals{CommandPath: "customers.show", Version: "9.9.9"}
+	c := api.NewClient(api.Options{
+		APIKey:       "sk_test",
+		BaseURL:      srv.URL,
+		UserAgent:    userAgent(g.Version),
+		ExtraHeaders: requestHeaders(g),
+	})
+	if _, _, err := c.Raw(context.Background(), http.MethodGet, "/anything", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if !served {
+		t.Fatal("request must still be made under DO_NOT_TRACK")
+	}
+	if gotCmd != "" || gotMode != "" {
+		t.Errorf("DO_NOT_TRACK must drop analytics headers, got command=%q mode=%q", gotCmd, gotMode)
+	}
+	if !strings.HasPrefix(gotUA, "revenuecat-cli/") {
+		t.Errorf("User-Agent must still be sent under DO_NOT_TRACK, got %q", gotUA)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -28,6 +28,11 @@ type Globals struct {
 	NoColor   bool
 	AssumeYes bool
 	Version   string
+
+	// CommandPath is the dotted path of the command being run (e.g.
+	// "paywalls.generate"), set once in PersistentPreRunE. Used only for the
+	// usage-analytics request header.
+	CommandPath string
 }
 
 func NewRootCmd(version string) *cobra.Command {
@@ -79,6 +84,7 @@ Agent-friendly entrypoints:
 			if g.ProjectID != "" {
 				cfg.ProjectID = g.ProjectID
 			}
+			g.CommandPath = dottedCommandPath(cmd)
 			rt := &Runtime{
 				Globals: g,
 				Config:  cfg,

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -113,7 +113,7 @@ func (r *Runtime) API() (*api.Client, error) {
 		CredentialSource: string(source),
 		BaseURL:          r.Config.BaseURL,
 		UserAgent:        userAgent(r.Globals.Version),
-		ExtraHeaders:     customHeaders(),
+		ExtraHeaders:     requestHeaders(r.Globals),
 	})
 	return r.client, nil
 }
@@ -185,7 +185,7 @@ func userAgent(version string) string {
 	if version == "" {
 		version = "dev"
 	}
-	return fmt.Sprintf("revenuecat-cli/%s (%s/%s)", version, runtime.GOOS, runtime.GOARCH)
+	return fmt.Sprintf("revenuecat-cli/%s (%s %s; go%s)", version, runtime.GOOS, runtime.GOARCH, strings.TrimPrefix(runtime.Version(), "go"))
 }
 
 var ErrNotAuthenticated = errors.New("not authenticated: run `rc login` or pass --api-key / set RC_API_KEY")


### PR DESCRIPTION
Tags every authenticated v2 API request with a few headers so we can see which commands people run and whether the CLI is being driven by a human, an agent, or CI — all derived from normal request logs. No telemetry pipeline, no anonymous ID.

What lands on the wire:

- `User-Agent: revenuecat-cli/<version> (<os> <arch>; go<goversion>)` — conventional product UA (also picks up the Go version now).
- `X-RC-CLI-Command` — the dotted command path only, e.g. `paywalls.generate`. Never args, flag values, IDs, emails, or prompts.
- `X-RC-CLI-Mode` — `interactive`, `agent` (`--json` / `--no-input`), or `ci` (`$CI` set).

It reuses the existing `ExtraHeaders` seam (same path `RC_HEADERS` already flows through), so it applies uniformly to every request the API client makes. `DO_NOT_TRACK` drops the `X-RC-CLI-*` headers while the request still goes through, just unlabeled.

Heads up: the backend needs a follow-up to actually capture `X-RC-CLI-Command` / `X-RC-CLI-Mode` in request logging — the headers arrive fine, but nothing reads them yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds optional, privacy-scoped request metadata headers with an established opt-out; no auth or credential logic changes beyond header assembly.
> 
> **Overview**
> Adds **usage-analytics HTTP headers** on authenticated v2 API traffic so RevenueCat can infer command usage and whether runs are **interactive**, **agent** (`--json` / `--no-input`), or **CI** (`$CI`), from normal request logs—no separate telemetry or IDs.
> 
> **On the wire:** `User-Agent` now includes Go version (`revenuecat-cli/<version> (<os> <arch>; go<goversion>)`). When tracking is enabled, `X-RC-CLI-Command` carries the dotted cobra path only (e.g. `paywalls.generate`, never args or flag values) and `X-RC-CLI-Mode` carries the mode. Headers are assembled in new `requestHeaders` and wired through `Runtime.API()`’s existing `ExtraHeaders` path (same seam as `RC_HEADERS`, which still overrides defaults).
> 
> **Opt-out:** `DO_NOT_TRACK=1` or `true` drops the `X-RC-CLI-*` headers but still sends requests (including `User-Agent`). `Globals.CommandPath` is set once in root `PersistentPreRunE`.
> 
> README documents the behavior; tests cover path/mode/DNT, header assembly, and end-to-end wire delivery via the API client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0e2c6ae52d324d97c7d7d52d3233ccdb35e9c2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->