### PR TITLE
ci: pin Go to go.mod version instead of floating stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - name: Install Python deps for codegen
         run: python3 -m pip install pyyaml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - name: Build with native Keychain support
         run: CGO_ENABLED=1 go build ./...


### PR DESCRIPTION
CI used `go-version: stable`, which just floated to go1.27 — and go1.27's gofmt reformats a file the repo (on go 1.25.12) considers already formatted, so the gofmt check started failing out from under us on PRs that hadn't changed. Pin to `go.mod` so the toolchain and gofmt are deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only toolchain pin with no application, auth, or data-handling changes. Risk is limited to CI using the declared Go version rather than latest stable.
> 
> **Overview**
> Pins GitHub Actions `setup-go` in both `check` and `darwin-build` to the version in `go.mod` (`1.25.12`) instead of `go-version: stable`.
> 
> This keeps CI (especially `gofmt`) on the same toolchain as the repo so a newer floating Go release cannot fail formatting checks on unchanged files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e3a18e79aec7eb6c5abe2e17a952e2c86dedd89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->