### PR TITLE
ci: pin staticcheck + bump go.mod to patched 1.25.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: staticcheck
         uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
         with:
-          version: latest
+          version: "2025.1.1"
           install-go: false
       - name: govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/revenuecat/cli
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/NimbleMarkets/ntcharts v0.5.1


### PR DESCRIPTION
Makes CI deterministic and green after two tools floated out from under the repo (companion to the Go-pin #131).

**1. Pin staticcheck** to `2025.1.1` — `version: latest` floated to v0.8.0, which requires go ≥1.26 (we target 1.25) and newly flags SA4023 on the Keychain platform stub.

**2. Bump go.mod to 1.25.13** — pinning CI to go.mod (from #131) surfaced stdlib CVEs present in 1.25.12 and fixed in 1.25.13 (net/url, crypto/tls, net/http, encoding/xml). The old floating `stable` masked these by being newer.

Verified locally on 1.25.13: gofmt clean, staticcheck `2025.1.1` reports 0 findings, govulncheck "No vulnerabilities found."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI toolchain pin and a Go patch-version bump only; no application or auth logic changes. The 1.25.13 bump is a security patch of the compiler/stdlib, not a behavior change in this repo.
> 
> **Overview**
> Pins CI `staticcheck` to `2025.1.1` instead of `latest`, so the linter stays compatible with Go 1.25 and does not pick up newer versions that require 1.26.
> 
> Bumps `go.mod` from `1.25.12` to `1.25.13` so CI (which uses `go-version-file: go.mod`) installs the patched toolchain with stdlib CVE fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb05cafb5447fea5526cf16caf9bf994f7ed372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->