### PR TITLE
feat(setup): guided rail + rc setup google on it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.13
 
 require (
 	github.com/NimbleMarkets/ntcharts v0.5.1
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
@@ -27,7 +28,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.20.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/itchyny/gojq v0.12.19
 	github.com/keybase/go-keychain v0.0.1
+	github.com/muesli/termenv v0.16.0
 	github.com/oapi-codegen/oapi-codegen/v2 v2.8.0
 	github.com/oapi-codegen/runtime v1.7.0
 	github.com/spf13/cobra v1.10.2
@@ -70,7 +71,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/oasdiff/yaml v0.1.1 // indirect
 	github.com/oasdiff/yaml3 v0.0.14 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -109,10 +109,8 @@ func newSetupGoogleCmd() *cobra.Command {
 				packageName = chosenApp.PlayStore.PackageName
 			}
 
-			// Sign in.
-			fl.Step("Sign in to Google")
-			fl.Say("Your sign-in stays local — RevenueCat never sees your Google credentials.")
-			fl.Say("Use the account with access to this app's Play Console and Cloud project.")
+			// Sign in. Offer two equally-fine ways in (not a yes/no — "no" reads
+			// as wrong when copying the link is a perfectly good choice).
 			open := func(u string) error {
 				if rt.Out.IsJSON() {
 					// Info/LinkLine are suppressed in JSON mode, but the sign-in URL
@@ -120,19 +118,27 @@ func newSetupGoogleCmd() *cobra.Command {
 					fmt.Fprintln(os.Stderr, "Sign in to Google to continue: "+u)
 					return nil
 				}
-				openIt := !noBrowser
-				if openIt && rt.CanPrompt() {
-					ok, err := fl.Confirm("Open Google sign-in in your browser?", true)
+				method := "open"
+				if noBrowser {
+					method = "copy"
+				} else if rt.CanPrompt() {
+					choice, err := fl.Select("Sign in to Google",
+						[]tui.Option{
+							{Label: "Open in my browser", Value: "open"},
+							{Label: "Copy the link — I'll open it myself", Value: "copy"},
+						},
+						"Your sign-in stays local — RevenueCat never sees your Google credentials.",
+						"Use the account with access to this app's Play Console and Cloud project.",
+					)
 					if err != nil {
 						return err
 					}
-					openIt = ok
+					method = choice
 				}
-				switch {
-				case openIt && openBrowser(u) == nil:
+				if method == "open" && openBrowser(u) == nil {
 					fl.Say("Opened your browser. Sign in with the right account.")
-				default:
-					fl.Say("Sign in with this link (click it, or copy it into your browser):")
+				} else {
+					fl.Say("Sign in with this link:")
 					fl.URL(u)
 				}
 				fl.Say("Waiting for sign-in…")

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -120,15 +120,20 @@ func newSetupGoogleCmd() *cobra.Command {
 					fmt.Fprintln(os.Stderr, "Sign in to Google to continue: "+u)
 					return nil
 				}
-				switch {
-				case noBrowser:
-					fl.Link("Sign in here:", "Google sign-in ↗", u)
-				default:
-					if err := openBrowser(u); err != nil {
-						fl.Link("Couldn't open your browser — sign in here:", "Google sign-in ↗", u)
-					} else {
-						fl.Link("Opened your browser · didn't open?", "reopen ↗", u)
+				openIt := !noBrowser
+				if openIt && rt.CanPrompt() {
+					ok, err := fl.Confirm("Open Google sign-in in your browser?", true)
+					if err != nil {
+						return err
 					}
+					openIt = ok
+				}
+				switch {
+				case openIt && openBrowser(u) == nil:
+					fl.Say("Opened your browser. Sign in with the right account.")
+				default:
+					fl.Say("Sign in with this link (click it, or copy it into your browser):")
+					fl.URL(u)
 				}
 				fl.Say("Waiting for sign-in…")
 				return nil

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -92,8 +92,6 @@ func newSetupGoogleCmd() *cobra.Command {
 				return errors.New("rc setup google is interactive: run it in a terminal, or pass --yes with the app id, --project, and --developer-id")
 			}
 
-			// App — confirm the only one, or pick among several. Its package name
-			// drives the Google setup.
 			rc, err := rt.API()
 			if err != nil {
 				return err
@@ -158,7 +156,6 @@ func newSetupGoogleCmd() *cobra.Command {
 			}
 			result := googleSetupResult{Email: creds.Email, RCAppID: chosenApp.ID}
 
-			// Google Cloud project — or create a new one.
 			if projectID == "" {
 				if !rt.CanPrompt() {
 					return errors.New("--project is required under --no-input")
@@ -219,8 +216,6 @@ func newSetupGoogleCmd() *cobra.Command {
 			}
 			result.DeveloperID = developerID
 
-			// Package name comes from the chosen RevenueCat app. Only prompt if
-			// that app has no package set yet.
 			if packageName == "" {
 				if !rt.CanPrompt() {
 					return fmt.Errorf("app %s has no package name set — pass --package", chosenApp.ID)
@@ -234,7 +229,6 @@ func newSetupGoogleCmd() *cobra.Command {
 
 			saEmail := google.ServiceAccountEmail(projectID)
 
-			// Review + single consent.
 			fl.Step("Review")
 			fl.Item(fmt.Sprintf("Enable %d Google APIs", len(google.RequiredAPIs)))
 			fl.Item("Create " + saEmail)
@@ -252,8 +246,8 @@ func newSetupGoogleCmd() *cobra.Command {
 				}
 			}
 
-			// Setting up. Enable APIs first — it can pause for the Android Publisher
-			// terms of service — then the rest fills in on the rail ledger.
+			// Enable APIs first — it can pause for the Android Publisher terms of
+			// service, which needs the human before the ledger steps can run.
 			fl.Step("Setting up")
 			if err := enableAPIsWithToS(ctx, rt, creds.TokenSource, projectID, noBrowser, creds.Email); err != nil {
 				return err

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -256,71 +256,85 @@ func newSetupGoogleCmd() *cobra.Command {
 				return err
 			}
 
-			// 5. Execute.
+			// 5. Execute. Enable APIs first — it can pause for the Android
+			// Publisher terms of service, so it runs before the live ledger takes
+			// over the screen. The remaining steps fill in on the ledger.
 			rt.Out.Info("Enabling Google APIs…")
 			if err := enableAPIsWithToS(ctx, rt, creds.TokenSource, projectID, noBrowser, creds.Email); err != nil {
 				return err
 			}
 			result.EnabledAPIs = google.RequiredAPIs
+			result.ServiceAccount = saEmail
+			result.GrantedRoles = google.ProjectRoles
+			result.PackageName = packageName
 
-			rt.Out.Info("Creating the RevenueCat service account…")
-			created, email, err := google.EnsureServiceAccount(ctx, creds.TokenSource, projectID)
+			led := tui.NewLedger(os.Stderr, !rt.CanPrompt(),
+				"Create the RevenueCat service account",
+				"Grant Google Cloud roles",
+				"Create the service-account key",
+				"Add the service account to Google Play",
+				"Save the credential",
+			)
+			led.Start()
+
+			created, _, err := google.EnsureServiceAccount(ctx, creds.TokenSource, projectID)
 			if err != nil {
+				led.Fail(0, "failed")
+				led.Stop()
 				return googleHint(rt, err)
 			}
-			saEmail = email
-			result.ServiceAccount = saEmail
 			result.ServiceAccountNew = created
 			if created {
-				rt.Out.Success("Created service account " + saEmail)
+				led.Done(0, "created")
 			} else {
-				rt.Out.Success("Found existing service account " + saEmail)
+				led.Done(0, "already existed")
 			}
 
-			rt.Out.Info("Granting Google Cloud roles…")
+			led.Running(1)
 			added, err := google.GrantProjectRoles(ctx, creds.TokenSource, projectID, saEmail)
 			if err != nil {
+				led.Fail(1, "failed")
+				led.Stop()
 				return googleHint(rt, err)
 			}
-			result.GrantedRoles = google.ProjectRoles
 			if len(added) == 0 {
-				rt.Out.Success("Cloud roles already granted")
+				led.Done(1, "already granted")
 			} else {
-				rt.Out.Success("Granted " + strings.Join(added, ", "))
+				led.Done(1, "")
 			}
 
-			rt.Out.Info("Creating the service-account key…")
+			led.Running(2)
 			keyData, keyName, err := google.CreateKey(ctx, creds.TokenSource, projectID, saEmail)
 			if err != nil {
+				led.Fail(2, "failed")
+				led.Stop()
 				return googleHint(rt, err)
 			}
-			rt.Out.Success("Created service-account key (in memory)")
+			led.Done(2, "in memory")
 
-			rt.Out.Info("Adding the service account to Google Play…")
+			led.Running(3)
 			play, err := google.AddServiceAccountToPlay(ctx, creds.TokenSource, developerID, saEmail, packageName, projectID)
 			if err != nil {
+				led.Fail(3, "failed")
+				led.Stop()
 				return googleHint(rt, err)
 			}
 			result.PlayUserCreated = play.UserCreated
 			result.PlayGrantConfigured = true
-			switch {
-			case play.UserCreated:
-				rt.Out.Success("Added the service account to Play and granted access to " + packageName)
-			case play.GrantUpdated:
-				rt.Out.Success("Updated Play permissions for " + packageName)
-			case play.GrantCreated:
-				rt.Out.Success("Granted Play access to " + packageName)
-			default:
-				rt.Out.Success("Play access already configured for " + packageName)
-			}
+			led.Done(3, packageName)
 
 			// Persist the credential before pruning older keys — Google returns
-			// private key material only once, so a failure here must not happen
-			// after the old keys are already deleted.
+			// private key material only once, so a failure here must not delete
+			// the old keys first.
+			led.Running(4)
 			if err := os.WriteFile(keyOut, keyData, 0o600); err != nil {
+				led.Fail(4, "failed")
+				led.Stop()
 				return fmt.Errorf("write key to %s: %w", keyOut, err)
 			}
 			result.KeyPath = keyOut
+			led.Done(4, keyOut)
+			led.Stop()
 
 			if !keepOldKeys {
 				if pruned, perr := google.PruneUserKeys(ctx, creds.TokenSource, projectID, saEmail, keyName); perr != nil {
@@ -330,7 +344,7 @@ func newSetupGoogleCmd() *cobra.Command {
 				}
 			}
 
-			rt.Out.Success("Google Play setup complete")
+			rt.Out.Success("Google Play connected 🎉")
 			if err := rt.Out.RenderCard(output.Card{
 				Title:    "Google Play — " + packageName,
 				Subtitle: creds.Email,

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -101,12 +101,10 @@ func newSetupGoogleCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fl.Step("App")
-			chosenApp, err := resolvePlayApp(ctx, rt, rc, rcProject, argAt(args, 0))
+			chosenApp, err := resolvePlayApp(ctx, rt, rc, fl, rcProject, argAt(args, 0))
 			if err != nil {
 				return err
 			}
-			fl.Receipt("App", playAppLabel(chosenApp))
 			if packageName == "" {
 				packageName = chosenApp.PlayStore.PackageName
 			}
@@ -145,21 +143,20 @@ func newSetupGoogleCmd() *cobra.Command {
 			result := googleSetupResult{Email: creds.Email, RCAppID: chosenApp.ID}
 
 			// Google Cloud project — or create a new one.
-			fl.Step("Google Cloud project")
 			if projectID == "" {
 				projects, err := google.ListProjects(ctx, creds.TokenSource)
 				if err != nil {
 					return err
 				}
-				choices := []Choice[string]{{Value: createNewProjectSentinel, Label: "➕ Create a new project", Flag: "--project"}}
+				opts := []tui.Option{{Label: "➕ Create a new project", Value: createNewProjectSentinel}}
 				for _, p := range projects {
 					label := p.ID
 					if p.DisplayName != "" {
 						label = fmt.Sprintf("%s (%s)", p.DisplayName, p.ID)
 					}
-					choices = append(choices, Choice[string]{Value: p.ID, Label: label, Flag: "--project"})
+					opts = append(opts, tui.Option{Label: label, Value: p.ID})
 				}
-				projectID, err = decide(rt, "Project", nil, choices)
+				projectID, err = fl.Select("Google Cloud project", opts)
 				if err != nil {
 					return err
 				}
@@ -170,26 +167,23 @@ func newSetupGoogleCmd() *cobra.Command {
 					}
 				}
 			} else {
+				fl.Step("Google Cloud project")
 				fl.Receipt("Project", projectID)
 			}
 			result.ProjectID = projectID
 
 			// Play developer account (no discovery API — must be supplied).
-			fl.Step("Play developer account")
 			if developerID == "" {
 				if !rt.CanPrompt() {
 					return errors.New("--developer-id is required under --no-input (Google exposes no API to discover it; find it in your Play Console URL)")
 				}
-				fl.Say("Google has no API for this — copy it from your Play Console URL.")
-				fl.Link("Open", "Play Console ↗", "https://play.google.com/console/")
-				fl.Say("Your ID is the number after /developers/ in the URL.")
-				var raw string
-				if err := tui.Form(rt.Globals.NoInput).
-					Field(huh.NewInput().
-						Title("Play Console URL or 19-digit ID").
-						Placeholder("…/developers/1234567890123456789/…").
-						Value(&raw).Validate(tui.Required("developer account ID"))).
-					Run(); err != nil {
+				desc := []string{
+					"Google has no API for this — copy it from your Play Console URL.",
+					rt.Out.LinkText("Open Play Console ↗", "https://play.google.com/console/"),
+					"Your ID is the number after /developers/ in the URL.",
+				}
+				raw, err := fl.Input("Play developer account", "…/developers/1234567890123456789/…", tui.Required("developer account ID"), desc...)
+				if err != nil {
 					return err
 				}
 				developerID, err = google.ParseDeveloperID(raw)
@@ -197,13 +191,14 @@ func newSetupGoogleCmd() *cobra.Command {
 					return err
 				}
 			} else {
+				fl.Step("Play developer account")
 				developerID, err = google.ParseDeveloperID(developerID)
 				if err != nil {
 					return err
 				}
+				fl.Receipt("Developer account", developerID)
 			}
 			result.DeveloperID = developerID
-			fl.Receipt("Developer account", developerID)
 
 			// 4. Package name comes from the chosen RevenueCat app. Only prompt if
 			// that app has no package set yet.
@@ -231,8 +226,14 @@ func newSetupGoogleCmd() *cobra.Command {
 			fl.Say(keyPlanStep(keepOldKeys))
 			fl.Say("Add to Google Play · grant access to " + packageName)
 			fl.Say("Save the credential to " + keyOut)
-			if err := confirmOrAbort(rt, "Continue?"); err != nil {
-				return err
+			if !rt.Globals.AssumeYes {
+				ok, err := fl.Confirm("Continue?", true)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return errors.New("cancelled")
+				}
 			}
 
 			// Setting up. Enable APIs first — it can pause for the Android Publisher
@@ -416,7 +417,7 @@ func keyPlanStep(keepOldKeys bool) string {
 // resolvePlayApp picks the RevenueCat Play app to configure: use the given id
 // (confirmed), confirm the only one, or pick among several. Returns the app so
 // its package name can drive the Google setup.
-func resolvePlayApp(ctx context.Context, rt *Runtime, rc *api.Client, projectID, appIDArg string) (*api.App, error) {
+func resolvePlayApp(ctx context.Context, rt *Runtime, rc *api.Client, fl *tui.Flow, projectID, appIDArg string) (*api.App, error) {
 	if appIDArg != "" {
 		app, err := rc.Apps.Get(ctx, projectID, appIDArg)
 		if err != nil {
@@ -425,7 +426,7 @@ func resolvePlayApp(ctx context.Context, rt *Runtime, rc *api.Client, projectID,
 		if app.Type != "play_store" || app.PlayStore == nil {
 			return nil, fmt.Errorf("app %s is not a Google Play app", appIDArg)
 		}
-		if err := confirmPlayApp(rt, app); err != nil {
+		if err := confirmPlayApp(rt, fl, app); err != nil {
 			return nil, err
 		}
 		return app, nil
@@ -444,7 +445,7 @@ func resolvePlayApp(ctx context.Context, rt *Runtime, rc *api.Client, projectID,
 	case 0:
 		return nil, errors.New("no Google Play apps in this project — create one first (rc apps create)")
 	case 1:
-		if err := confirmPlayApp(rt, &play[0]); err != nil {
+		if err := confirmPlayApp(rt, fl, &play[0]); err != nil {
 			return nil, err
 		}
 		return &play[0], nil
@@ -452,11 +453,11 @@ func resolvePlayApp(ctx context.Context, rt *Runtime, rc *api.Client, projectID,
 		if !rt.CanPrompt() {
 			return nil, errors.New("multiple Google Play apps in this project — pass the app id: rc setup google <app-id>")
 		}
-		items := make([]PickerItem, len(play))
+		opts := make([]tui.Option, len(play))
 		for i := range play {
-			items[i] = PickerItem{ID: play[i].ID, Label: playAppLabel(&play[i])}
+			opts[i] = tui.Option{Label: playAppLabel(&play[i]), Value: play[i].ID}
 		}
-		id, err := selectID(rt, "Google Play app", items, "")
+		id, err := fl.Select("App", opts)
 		if err != nil {
 			return nil, err
 		}
@@ -470,11 +471,11 @@ func resolvePlayApp(ctx context.Context, rt *Runtime, rc *api.Client, projectID,
 }
 
 // confirmPlayApp asks the human to confirm the app before doing anything to it.
-func confirmPlayApp(rt *Runtime, app *api.App) error {
+func confirmPlayApp(rt *Runtime, fl *tui.Flow, app *api.App) error {
 	if rt.Globals.AssumeYes || !rt.CanPrompt() {
 		return nil
 	}
-	ok, err := tui.ConfirmDefault(rt.Globals.NoInput, "Set up Google Play for "+playAppLabel(app)+"?", true)
+	ok, err := fl.Confirm("Set up Google Play for "+playAppLabel(app)+"?", true)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
@@ -138,7 +139,11 @@ func newSetupGoogleCmd() *cobra.Command {
 				if method == "open" && openBrowser(u) == nil {
 					fl.Say("Opened your browser. Sign in with the right account.")
 				} else {
-					fl.Say("Sign in with this link:")
+					if clipboard.WriteAll(u) == nil {
+						fl.Say("Copied the link to your clipboard — paste it into your browser:")
+					} else {
+						fl.Say("Sign in with this link:")
+					}
 					fl.URL(u)
 				}
 				fl.Say("Waiting for sign-in…")

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/revenuecat/cli/internal/api"
 	"github.com/revenuecat/cli/internal/google"
-	"github.com/revenuecat/cli/internal/output"
 	"github.com/revenuecat/cli/internal/tui"
 )
 
@@ -85,15 +84,15 @@ func newSetupGoogleCmd() *cobra.Command {
 				return google.ErrNoClientID
 			}
 
-			rt.Out.Title("Google Play configuration")
-			rt.Out.Lead("Signs in to Google locally and creates the credential RevenueCat needs. Nothing changes without your OK.")
+			fl := tui.NewFlow(os.Stderr, !rt.CanPrompt())
+			fl.Intro("RevenueCat · Google Play setup")
 
 			if !rt.CanPrompt() && !rt.Globals.AssumeYes {
 				return errors.New("rc setup google is interactive: run it in a terminal, or pass --yes with the app id, --project, and --developer-id")
 			}
 
-			// Choose the RevenueCat Play app to configure — confirm the only one,
-			// or pick among several. Its package name drives the Google setup.
+			// App — confirm the only one, or pick among several. Its package name
+			// drives the Google setup.
 			rc, err := rt.API()
 			if err != nil {
 				return err
@@ -102,23 +101,20 @@ func newSetupGoogleCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			fl.Step("App")
 			chosenApp, err := resolvePlayApp(ctx, rt, rc, rcProject, argAt(args, 0))
 			if err != nil {
 				return err
 			}
+			fl.Receipt("App", playAppLabel(chosenApp))
 			if packageName == "" {
 				packageName = chosenApp.PlayStore.PackageName
 			}
 
-			// 1. Authenticate. Print the URL first, then let the user open it
-			// (Stripe-style) so they can pick the browser / Google account that
-			// has their Play + Cloud access.
-			if !rt.Globals.AssumeYes && rt.CanPrompt() {
-				rt.Out.Notice(
-					"Your Google sign-in stays local — RevenueCat never sees your Google",
-					"credentials or tokens. The service-account key is created in memory.",
-				)
-			}
+			// Sign in.
+			fl.Step("Sign in to Google")
+			fl.Say("Your sign-in stays local — RevenueCat never sees your Google credentials.")
+			fl.Say("Use the account with access to this app's Play Console and Cloud project.")
 			open := func(u string) error {
 				if rt.Out.IsJSON() {
 					// Info/LinkLine are suppressed in JSON mode, but the sign-in URL
@@ -126,31 +122,17 @@ func newSetupGoogleCmd() *cobra.Command {
 					fmt.Fprintln(os.Stderr, "Sign in to Google to continue: "+u)
 					return nil
 				}
-				rt.Out.Blank()
-				rt.Out.Info("Sign in to Google to continue — use the browser/account that has your Play + Cloud access:")
-				rt.Out.LinkLine(u)
-				rt.Out.Blank()
 				switch {
 				case noBrowser:
-					rt.Out.Info("Waiting for you to finish sign-in in your browser…")
-					return nil
-				case rt.Globals.AssumeYes || !rt.CanPrompt():
-					// non-interactive / --yes: open without pausing
+					fl.Link("Sign in here:", "Google sign-in ↗", u)
 				default:
-					openIt, err := tui.ConfirmDefault(rt.Globals.NoInput, "Press Enter to open it in your browser (or choose No to open it yourself)", true)
-					if err != nil {
-						return err
-					}
-					if !openIt {
-						rt.Out.Info("Open the URL above to finish. Waiting…")
-						return nil
+					if err := openBrowser(u); err != nil {
+						fl.Link("Couldn't open your browser — sign in here:", "Google sign-in ↗", u)
+					} else {
+						fl.Link("Opened your browser · didn't open?", "reopen ↗", u)
 					}
 				}
-				if err := openBrowser(u); err != nil {
-					rt.Out.Warn("Couldn't open a browser automatically — open the URL above. Waiting…")
-				} else {
-					rt.Out.Info("Opened your browser. Waiting for sign-in to complete…")
-				}
+				fl.Say("Waiting for sign-in…")
 				return nil
 			}
 			creds, err := google.Authenticate(ctx, clientID, clientSecret, google.DefaultScopes, open)
@@ -158,11 +140,12 @@ func newSetupGoogleCmd() *cobra.Command {
 				return err
 			}
 			if creds.Email != "" {
-				rt.Out.Answer("Signed in", creds.Email)
+				fl.Receipt("Signed in", creds.Email)
 			}
 			result := googleSetupResult{Email: creds.Email, RCAppID: chosenApp.ID}
 
-			// 2. Choose the GCP project — or create a new one.
+			// Google Cloud project — or create a new one.
+			fl.Step("Google Cloud project")
 			if projectID == "" {
 				projects, err := google.ListProjects(ctx, creds.TokenSource)
 				if err != nil {
@@ -176,7 +159,7 @@ func newSetupGoogleCmd() *cobra.Command {
 					}
 					choices = append(choices, Choice[string]{Value: p.ID, Label: label, Flag: "--project"})
 				}
-				projectID, err = decide(rt, "Google Cloud project", nil, choices)
+				projectID, err = decide(rt, "Project", nil, choices)
 				if err != nil {
 					return err
 				}
@@ -186,29 +169,25 @@ func newSetupGoogleCmd() *cobra.Command {
 						return err
 					}
 				}
+			} else {
+				fl.Receipt("Project", projectID)
 			}
 			result.ProjectID = projectID
 
-			// 3. Play developer account ID (no discovery API — must be supplied).
+			// Play developer account (no discovery API — must be supplied).
+			fl.Step("Play developer account")
 			if developerID == "" {
 				if !rt.CanPrompt() {
 					return errors.New("--developer-id is required under --no-input (Google exposes no API to discover it; find it in your Play Console URL)")
 				}
-				rt.Out.Notice(
-					"Google has no API for your Play developer account ID, so paste it here.",
-				)
-				rt.Out.Info("1. Open your Play Console:")
-				rt.Out.LinkLine("https://play.google.com/console/")
-				rt.Out.Info("2. Copy the page URL — it looks like:")
-				rt.Out.Info("      …/developers/1234567890123456789/app-list   (that number is your ID)")
-				rt.Out.Info("3. Paste the whole URL below — I'll pull out the ID (or paste just the number).")
-				rt.Out.Info("Can't find it?")
-				rt.Out.LinkLine("https://support.google.com/googleplay/android-developer/answer/13634081")
+				fl.Say("Google has no API for this — copy it from your Play Console URL.")
+				fl.Link("Open", "Play Console ↗", "https://play.google.com/console/")
+				fl.Say("Your ID is the number after /developers/ in the URL.")
 				var raw string
 				if err := tui.Form(rt.Globals.NoInput).
 					Field(huh.NewInput().
-						Title("Paste your Play Console URL (or the 19-digit ID)").
-						Placeholder("https://play.google.com/console/u/0/developers/1234567890123456789/app-list").
+						Title("Play Console URL or 19-digit ID").
+						Placeholder("…/developers/1234567890123456789/…").
 						Value(&raw).Validate(tui.Required("developer account ID"))).
 					Run(); err != nil {
 					return err
@@ -224,6 +203,7 @@ func newSetupGoogleCmd() *cobra.Command {
 				}
 			}
 			result.DeveloperID = developerID
+			fl.Receipt("Developer account", developerID)
 
 			// 4. Package name comes from the chosen RevenueCat app. Only prompt if
 			// that app has no package set yet.
@@ -243,23 +223,21 @@ func newSetupGoogleCmd() *cobra.Command {
 				keyOut = "revenuecat-play-key.json"
 			}
 
-			// Plan + single consent.
-			rt.Out.Plan([]string{
-				"Enable " + fmt.Sprintf("%d", len(google.RequiredAPIs)) + " Google APIs on " + projectID,
-				"Create service account " + saEmail,
-				"Grant " + strings.Join(google.ProjectRoles, " + "),
-				keyPlanStep(keepOldKeys),
-				"Add the service account to Play and grant access to " + packageName,
-				"Write the key to " + keyOut + " for upload to RevenueCat",
-			})
+			// Review + single consent.
+			fl.Step("Review")
+			fl.Say(fmt.Sprintf("Enable %d Google APIs", len(google.RequiredAPIs)))
+			fl.Say("Create " + saEmail)
+			fl.Say("Grant " + strings.Join(google.ProjectRoles, " + "))
+			fl.Say(keyPlanStep(keepOldKeys))
+			fl.Say("Add to Google Play · grant access to " + packageName)
+			fl.Say("Save the credential to " + keyOut)
 			if err := confirmOrAbort(rt, "Continue?"); err != nil {
 				return err
 			}
 
-			// 5. Execute. Enable APIs first — it can pause for the Android
-			// Publisher terms of service, so it runs before the live ledger takes
-			// over the screen. The remaining steps fill in on the ledger.
-			rt.Out.Info("Enabling Google APIs…")
+			// Setting up. Enable APIs first — it can pause for the Android Publisher
+			// terms of service — then the rest fills in on the rail ledger.
+			fl.Step("Setting up")
 			if err := enableAPIsWithToS(ctx, rt, creds.TokenSource, projectID, noBrowser, creds.Email); err != nil {
 				return err
 			}
@@ -268,7 +246,7 @@ func newSetupGoogleCmd() *cobra.Command {
 			result.GrantedRoles = google.ProjectRoles
 			result.PackageName = packageName
 
-			led := tui.NewLedger(os.Stderr, !rt.CanPrompt(),
+			led := fl.Ledger(
 				"Create the RevenueCat service account",
 				"Grant Google Cloud roles",
 				"Create the service-account key",
@@ -338,32 +316,20 @@ func newSetupGoogleCmd() *cobra.Command {
 
 			if !keepOldKeys {
 				if pruned, perr := google.PruneUserKeys(ctx, creds.TokenSource, projectID, saEmail, keyName); perr != nil {
-					rt.Out.Warn("Couldn't remove older keys on the service account: " + perr.Error())
+					fl.Warn("Couldn't remove older keys on the service account: " + perr.Error())
 				} else if pruned > 0 {
-					rt.Out.Info(fmt.Sprintf("Removed %d older key(s) from the RevenueCat service account (pass --keep-old-keys to keep them).", pruned))
+					fl.Say(fmt.Sprintf("Removed %d older key(s) (pass --keep-old-keys to keep them).", pruned))
 				}
 			}
 
-			rt.Out.Success("Google Play connected 🎉")
-			if err := rt.Out.RenderCard(output.Card{
-				Title:    "Google Play — " + packageName,
-				Subtitle: creds.Email,
-				Sections: []output.CardSection{{
-					Heading: "Configured",
-					Lines: []output.CardLine{
-						{Key: "GCP project", Value: projectID},
-						{Key: "Service account", Value: saEmail},
-						{Key: "Cloud roles", Value: strings.Join(google.ProjectRoles, ", ")},
-						{Key: "Play access", Value: packageName + " (view + financial + orders)"},
-						{Key: "Credential key", Value: keyOut},
-					},
-				}},
-				Raw: result,
-			}); err != nil {
-				return err
+			if rt.Out.IsJSON() {
+				return rt.Out.Render(result)
 			}
-			rt.Out.Info("RevenueCat can't yet accept the Play credential over the API. For now, upload " + keyOut + " to this app in the dashboard:")
-			rt.Out.LinkLine("https://app.revenuecat.com/projects/" + rcProject + "/apps/" + chosenApp.ID)
+			uploadURL := "https://app.revenuecat.com/projects/" + rcProject + "/apps/" + chosenApp.ID
+			fl.Outro("Google Play connected 🎉",
+				"One step left (until the API accepts it directly): upload the credential to your app.",
+				rt.Out.LinkText("Upload "+keyOut+" ↗", uploadURL),
+			)
 			return nil
 		},
 	}

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -120,7 +120,7 @@ func newSetupGoogleCmd() *cobra.Command {
 				method := "open"
 				if noBrowser {
 					method = "copy"
-				} else if rt.CanPrompt() {
+				} else if rt.CanPrompt() && !rt.Globals.AssumeYes {
 					choice, err := fl.Select("Sign in to Google",
 						[]tui.Option{
 							{Label: "Open in my browser", Value: "open"},
@@ -265,6 +265,7 @@ func newSetupGoogleCmd() *cobra.Command {
 			)
 			led.Start()
 
+			led.Running(0)
 			created, _, err := google.EnsureServiceAccount(ctx, creds.TokenSource, projectID)
 			if err != nil {
 				led.Fail(0, "failed")

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -160,6 +160,9 @@ func newSetupGoogleCmd() *cobra.Command {
 
 			// Google Cloud project — or create a new one.
 			if projectID == "" {
+				if !rt.CanPrompt() {
+					return errors.New("--project is required under --no-input")
+				}
 				projects, err := google.ListProjects(ctx, creds.TokenSource)
 				if err != nil {
 					return err
@@ -216,7 +219,7 @@ func newSetupGoogleCmd() *cobra.Command {
 			}
 			result.DeveloperID = developerID
 
-			// 4. Package name comes from the chosen RevenueCat app. Only prompt if
+			// Package name comes from the chosen RevenueCat app. Only prompt if
 			// that app has no package set yet.
 			if packageName == "" {
 				if !rt.CanPrompt() {
@@ -230,9 +233,6 @@ func newSetupGoogleCmd() *cobra.Command {
 			result.PackageName = packageName
 
 			saEmail := google.ServiceAccountEmail(projectID)
-			if keyOut == "" {
-				keyOut = "revenuecat-play-key.json"
-			}
 
 			// Review + single consent.
 			fl.Step("Review")
@@ -261,7 +261,6 @@ func newSetupGoogleCmd() *cobra.Command {
 			result.EnabledAPIs = google.RequiredAPIs
 			result.ServiceAccount = saEmail
 			result.GrantedRoles = google.ProjectRoles
-			result.PackageName = packageName
 
 			led := fl.Ledger(
 				"Create the RevenueCat service account",
@@ -312,6 +311,7 @@ func newSetupGoogleCmd() *cobra.Command {
 			if err != nil {
 				led.Fail(3, "failed")
 				led.Stop()
+				rt.Out.Hint("Granting Play access needs the signed-in account to be a Play Console owner/admin, and the app (" + packageName + ") must exist in Play Console — create it there first if it doesn't.")
 				return googleHint(rt, err)
 			}
 			result.PlayUserCreated = play.UserCreated
@@ -362,6 +362,7 @@ func newSetupGoogleCmd() *cobra.Command {
 				fl.Outro("Almost there",
 					"Upload the credential to finish:",
 					rt.Out.LinkText("Upload "+keyOut+" ↗", uploadURL),
+					keyOut+" is a private key — delete it once uploaded.",
 				)
 			}
 			return nil

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -85,7 +85,7 @@ func newSetupGoogleCmd() *cobra.Command {
 				return google.ErrNoClientID
 			}
 
-			fl := tui.NewFlow(os.Stderr, !rt.CanPrompt(), rt.Out.NoColor())
+			fl := tui.NewFlow(os.Stderr, !rt.CanPrompt(), rt.Out.NoColor(), rt.Globals.Quiet)
 			fl.Intro("RevenueCat · Google Play setup")
 
 			if !rt.CanPrompt() && !rt.Globals.AssumeYes {

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -241,7 +241,7 @@ func newSetupGoogleCmd() *cobra.Command {
 			fl.Say("Grant " + strings.Join(google.ProjectRoles, " + "))
 			fl.Say(keyPlanStep(keepOldKeys))
 			fl.Say("Add to Google Play · grant access to " + packageName)
-			fl.Say("Save the credential to " + keyOut)
+			fl.Say("Upload the credential to RevenueCat")
 			if !rt.Globals.AssumeYes {
 				ok, err := fl.Confirm("Continue?", true)
 				if err != nil {
@@ -268,7 +268,7 @@ func newSetupGoogleCmd() *cobra.Command {
 				"Grant Google Cloud roles",
 				"Create the service-account key",
 				"Add the service account to Google Play",
-				"Save the credential",
+				"Upload the credential to RevenueCat",
 			)
 			led.Start()
 
@@ -318,17 +318,28 @@ func newSetupGoogleCmd() *cobra.Command {
 			result.PlayGrantConfigured = true
 			led.Done(3, packageName)
 
-			// Persist the credential before pruning older keys — Google returns
-			// private key material only once, so a failure here must not delete
-			// the old keys first.
+			// Upload the credential to RevenueCat via API v2. If that fails, fall
+			// back to writing the key so the human can upload it in the dashboard —
+			// but surface the real error so a transient/auth/validation failure
+			// isn't silently mistaken for "endpoint not available". This runs
+			// before pruning old keys: Google returns key material only once.
 			led.Running(4)
-			if err := os.WriteFile(keyOut, keyData, 0o600); err != nil {
+			credJSON := string(keyData)
+			_, upErr := rc.Apps.Update(ctx, rcProject, chosenApp.ID, api.AppUpdate{
+				PlayStore: &api.PlayStoreAppConfig{PlayServiceAccountCredentialsJSON: &credJSON},
+			})
+			if upErr == nil {
+				result.CredentialUploaded = true
+				led.Done(4, "uploaded to RevenueCat")
+			} else if writeErr := os.WriteFile(keyOut, keyData, 0o600); writeErr == nil {
+				result.KeyPath = keyOut
+				led.Done(4, "saved to "+keyOut+" (upload it in the dashboard)")
+				fl.Warn("RevenueCat didn't accept the upload: " + upErr.Error())
+			} else {
 				led.Fail(4, "failed")
 				led.Stop()
-				return fmt.Errorf("write key to %s: %w", keyOut, err)
+				return fmt.Errorf("upload credential (%v) and write key to %s (%v)", upErr, keyOut, writeErr)
 			}
-			result.KeyPath = keyOut
-			led.Done(4, keyOut)
 			led.Stop()
 
 			if !keepOldKeys {
@@ -343,10 +354,16 @@ func newSetupGoogleCmd() *cobra.Command {
 				return rt.Out.Render(result)
 			}
 			uploadURL := "https://app.revenuecat.com/projects/" + rcProject + "/apps/" + chosenApp.ID
-			fl.Outro("Google Play connected 🎉",
-				"One step left (until the API accepts it directly): upload the credential to your app.",
-				rt.Out.LinkText("Upload "+keyOut+" ↗", uploadURL),
-			)
+			if result.CredentialUploaded {
+				fl.Outro("Google Play connected 🎉",
+					rt.Out.LinkText("Open your app in RevenueCat ↗", uploadURL),
+				)
+			} else {
+				fl.Outro("Almost there",
+					"Upload the credential to finish:",
+					rt.Out.LinkText("Upload "+keyOut+" ↗", uploadURL),
+				)
+			}
 			return nil
 		},
 	}

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -236,12 +236,12 @@ func newSetupGoogleCmd() *cobra.Command {
 
 			// Review + single consent.
 			fl.Step("Review")
-			fl.Say(fmt.Sprintf("Enable %d Google APIs", len(google.RequiredAPIs)))
-			fl.Say("Create " + saEmail)
-			fl.Say("Grant " + strings.Join(google.ProjectRoles, " + "))
-			fl.Say(keyPlanStep(keepOldKeys))
-			fl.Say("Add to Google Play · grant access to " + packageName)
-			fl.Say("Upload the credential to RevenueCat")
+			fl.Item(fmt.Sprintf("Enable %d Google APIs", len(google.RequiredAPIs)))
+			fl.Item("Create " + saEmail)
+			fl.Item("Grant " + strings.Join(google.ProjectRoles, " + "))
+			fl.Item(keyPlanStep(keepOldKeys))
+			fl.Item("Add to Google Play · grant access to " + packageName)
+			fl.Item("Upload the credential to RevenueCat")
 			if !rt.Globals.AssumeYes {
 				ok, err := fl.Confirm("Continue?", true)
 				if err != nil {

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -85,7 +85,7 @@ func newSetupGoogleCmd() *cobra.Command {
 				return google.ErrNoClientID
 			}
 
-			fl := tui.NewFlow(os.Stderr, !rt.CanPrompt())
+			fl := tui.NewFlow(os.Stderr, !rt.CanPrompt(), rt.Out.NoColor())
 			fl.Intro("RevenueCat · Google Play setup")
 
 			if !rt.CanPrompt() && !rt.Globals.AssumeYes {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/itchyny/gojq"
+	"github.com/muesli/termenv"
 )
 
 // ErrBadFormat signals an unparseable --format expression. CLI maps this to
@@ -47,6 +48,12 @@ type Renderer struct {
 
 func NewRenderer(stdout, stderr io.Writer, jsonMode, noColor, quiet bool, format string) *Renderer {
 	noColor = noColor || os.Getenv("NO_COLOR") != ""
+	if noColor {
+		// Make --no-color reach direct lipgloss usage too (guided rail, prompts,
+		// ledger), not just this Renderer's own styling. termenv already honors
+		// the NO_COLOR env var; this covers the flag.
+		lipgloss.SetColorProfile(termenv.Ascii)
+	}
 	r := &Renderer{
 		stdout:  stdout,
 		stderr:  stderr,

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -371,15 +371,11 @@ func (r *Renderer) Info(msg string) {
 	fmt.Fprintln(r.stderr, r.style(r.info, "· ")+msg)
 }
 
-// Step is a guided-flow section header: a blank line, then a brand ◇ glyph and a
-// bold title. Heavier than Info, lighter than Title (which owns the top-of-flow
-// ▍ banner) — use it to break a long interactive flow into legible sections.
-func (r *Renderer) Step(title string) {
-	if r.json || r.quiet {
-		return
-	}
-	fmt.Fprintln(r.stderr)
-	fmt.Fprintln(r.stderr, r.style(r.accent, "◇ ")+r.style(StyleTitle, title))
+// Hyperlink wraps styledLabel in an OSC 8 terminal hyperlink pointing at url.
+// Supporting terminals make it clickable; others render the label text. This is
+// the one place the OSC 8 escape lives.
+func Hyperlink(styledLabel, url string) string {
+	return "\x1b]8;;" + url + "\x1b\\" + styledLabel + "\x1b]8;;\x1b\\"
 }
 
 // LinkText renders a clickable hyperlink (OSC 8) with a custom label instead of
@@ -389,20 +385,17 @@ func (r *Renderer) LinkText(label, url string) string {
 	if r.noColor {
 		return label + " (" + url + ")"
 	}
-	styled := lipgloss.NewStyle().Foreground(BrandRed).Underline(true).Render(label)
-	return "\x1b]8;;" + url + "\x1b\\" + styled + "\x1b]8;;\x1b\\"
+	return Hyperlink(lipgloss.NewStyle().Foreground(BrandRed).Underline(true).Render(label), url)
 }
 
-// Link renders a URL as a clickable terminal hyperlink (OSC 8), underlined and
-// in the brand accent so it stands out from surrounding text. Falls back to the
-// plain URL when color is off (also our proxy for a dumb/non-interactive term),
-// so nothing leaks escape codes into piped or --no-color output.
+// Link renders a URL as a clickable, underlined brand-accent hyperlink. Falls
+// back to the plain URL when color is off (our proxy for a dumb/non-interactive
+// terminal), so nothing leaks escape codes into piped or --no-color output.
 func (r *Renderer) Link(url string) string {
 	if r.noColor {
 		return url
 	}
-	styled := lipgloss.NewStyle().Foreground(BrandRed).Underline(true).Render(url)
-	return "\x1b]8;;" + url + "\x1b\\" + styled + "\x1b]8;;\x1b\\"
+	return Hyperlink(lipgloss.NewStyle().Foreground(BrandRed).Underline(true).Render(url), url)
 }
 
 // LinkLine prints a single indented, clickable link on its own line (stderr

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -68,6 +68,10 @@ func NewRenderer(stdout, stderr io.Writer, jsonMode, noColor, quiet bool, format
 
 func (r *Renderer) IsJSON() bool { return r.json }
 
+// NoColor reports whether all ANSI output is disabled (--no-color or NO_COLOR),
+// so callers composing their own escapes (e.g. OSC 8 hyperlinks) can skip them.
+func (r *Renderer) NoColor() bool { return r.noColor }
+
 // Tone is a semantic style for callers that compose their own output.
 type Tone int
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -51,7 +51,8 @@ func NewRenderer(stdout, stderr io.Writer, jsonMode, noColor, quiet bool, format
 	if noColor {
 		// Make --no-color reach direct lipgloss usage too (guided rail, prompts,
 		// ledger), not just this Renderer's own styling. termenv already honors
-		// the NO_COLOR env var; this covers the flag.
+		// the NO_COLOR env var; this covers the flag. Not restored — it's a global
+		// for the lifetime of a one-shot CLI process that's about to exit.
 		lipgloss.SetColorProfile(termenv.Ascii)
 	}
 	r := &Renderer{

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -371,6 +371,28 @@ func (r *Renderer) Info(msg string) {
 	fmt.Fprintln(r.stderr, r.style(r.info, "· ")+msg)
 }
 
+// Step is a guided-flow section header: a blank line, then a brand ◇ glyph and a
+// bold title. Heavier than Info, lighter than Title (which owns the top-of-flow
+// ▍ banner) — use it to break a long interactive flow into legible sections.
+func (r *Renderer) Step(title string) {
+	if r.json || r.quiet {
+		return
+	}
+	fmt.Fprintln(r.stderr)
+	fmt.Fprintln(r.stderr, r.style(r.accent, "◇ ")+r.style(StyleTitle, title))
+}
+
+// LinkText renders a clickable hyperlink (OSC 8) with a custom label instead of
+// the raw URL, so long auth URLs don't dominate the output. With color off it
+// falls back to "label (url)" so the URL stays copyable.
+func (r *Renderer) LinkText(label, url string) string {
+	if r.noColor {
+		return label + " (" + url + ")"
+	}
+	styled := lipgloss.NewStyle().Foreground(BrandRed).Underline(true).Render(label)
+	return "\x1b]8;;" + url + "\x1b\\" + styled + "\x1b]8;;\x1b\\"
+}
+
 // Link renders a URL as a clickable terminal hyperlink (OSC 8), underlined and
 // in the brand accent so it stands out from surrounding text. Falls back to the
 // plain URL when color is off (also our proxy for a dumb/non-interactive term),

--- a/internal/tui/flow.go
+++ b/internal/tui/flow.go
@@ -61,6 +61,11 @@ func (f *Flow) Step(title string) {
 // Say prints a dim narration line on the rail.
 func (f *Flow) Say(line string) { f.body(flowDimSty.Render(line)) }
 
+// Item prints a bulleted list item on the rail, indented under the current step.
+func (f *Flow) Item(line string) {
+	f.body(flowRailSty.Render("•") + " " + flowDimSty.Render(line))
+}
+
 // Link prints a narration line ending in a clickable label.
 func (f *Flow) Link(text, label, url string) {
 	f.body(flowDimSty.Render(text) + " " + linkText(label, url))

--- a/internal/tui/flow.go
+++ b/internal/tui/flow.go
@@ -21,11 +21,14 @@ import (
 //
 // On a non-TTY (plain), the glyphs are dropped for clean append-only lines.
 type Flow struct {
-	w     io.Writer
-	plain bool
+	w       io.Writer
+	plain   bool
+	noColor bool
 }
 
-func NewFlow(w io.Writer, plain bool) *Flow { return &Flow{w: w, plain: plain} }
+func NewFlow(w io.Writer, plain, noColor bool) *Flow {
+	return &Flow{w: w, plain: plain, noColor: noColor}
+}
 
 func (f *Flow) Intro(title string) {
 	if f.plain {
@@ -54,7 +57,7 @@ func (f *Flow) Item(line string) {
 // URL prints the raw URL, not a hyperlink label, so it stays selectable to copy
 // on terminals that don't support OSC 8.
 func (f *Flow) URL(url string) {
-	if f.plain {
+	if f.plain || f.noColor {
 		f.body(url)
 		return
 	}

--- a/internal/tui/flow.go
+++ b/internal/tui/flow.go
@@ -1,0 +1,120 @@
+package tui
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/revenuecat/cli/internal/output"
+)
+
+// Flow renders a guided, single-experience command as one continuous vertical
+// rail (clack-style): a ┌ intro cap, ◇ step headers and │ narration on a shared
+// spine, and a └ outro cap. It's the shell for human-first `requires_human`
+// flows so the whole command reads as one designed experience rather than a
+// scatter of lines.
+//
+// Interactive prompts (tui.Form / decide / confirm) happen between rail calls —
+// they're the active moments the rail pauses for, then resumes.
+//
+// On a non-TTY (plain), the glyphs are dropped for clean append-only lines.
+type Flow struct {
+	w     io.Writer
+	plain bool
+}
+
+var (
+	flowRailSty  = lipgloss.NewStyle().Foreground(output.BrandRed)
+	flowCapSty   = lipgloss.NewStyle().Foreground(output.BrandRed).Bold(true)
+	flowTitleSty = lipgloss.NewStyle().Bold(true)
+	flowDimSty   = lipgloss.NewStyle().Faint(true)
+	flowOKSty    = lipgloss.NewStyle().Foreground(output.GreenOK).Bold(true)
+	flowWarnSty  = lipgloss.NewStyle().Foreground(output.WarnAmber)
+)
+
+// NewFlow builds a flow writing to w. plain drops the rail (non-TTY/CI).
+func NewFlow(w io.Writer, plain bool) *Flow { return &Flow{w: w, plain: plain} }
+
+func (f *Flow) rail() string { return flowRailSty.Render("│") }
+
+// Intro opens the flow with a ┌ cap and title.
+func (f *Flow) Intro(title string) {
+	if f.plain {
+		fmt.Fprintln(f.w, title)
+		return
+	}
+	fmt.Fprintln(f.w, flowCapSty.Render("┌")+"  "+flowTitleSty.Render(title))
+	fmt.Fprintln(f.w, f.rail())
+}
+
+// Step starts a new section with a ◇ marker, preceded by a rail spacer.
+func (f *Flow) Step(title string) {
+	if f.plain {
+		fmt.Fprintf(f.w, "\n%s\n", title)
+		return
+	}
+	fmt.Fprintln(f.w, f.rail())
+	fmt.Fprintln(f.w, flowCapSty.Render("◇")+"  "+flowTitleSty.Render(title))
+}
+
+// Say prints a dim narration line on the rail.
+func (f *Flow) Say(line string) { f.body(flowDimSty.Render(line)) }
+
+// Link prints a narration line ending in a clickable label.
+func (f *Flow) Link(text, label, url string) {
+	f.body(flowDimSty.Render(text) + " " + linkText(label, url))
+}
+
+// Receipt echoes a confirmed choice as "✓ key  value" on the rail.
+func (f *Flow) Receipt(key, value string) {
+	line := flowOKSty.Render("✓") + " " + key
+	if value != "" {
+		line += "  " + flowDimSty.Render(value)
+	}
+	f.body(line)
+}
+
+// Warn prints a warning line on the rail.
+func (f *Flow) Warn(line string) { f.body(flowWarnSty.Render("! " + line)) }
+
+// Outro closes the flow with a └ cap; extras are indented under it.
+func (f *Flow) Outro(title string, extras ...string) {
+	if f.plain {
+		fmt.Fprintln(f.w, title)
+		for _, e := range extras {
+			fmt.Fprintln(f.w, "  "+e)
+		}
+		return
+	}
+	fmt.Fprintln(f.w, f.rail())
+	fmt.Fprintln(f.w, flowCapSty.Render("└")+"  "+flowTitleSty.Render(title))
+	for _, e := range extras {
+		fmt.Fprintln(f.w, "   "+e)
+	}
+}
+
+// Ledger returns a step ledger whose lines sit on the flow's rail.
+func (f *Flow) Ledger(labels ...string) *Ledger {
+	l := NewLedger(f.w, f.plain, labels...)
+	if !f.plain {
+		l.gutter = f.rail() + "  "
+	}
+	return l
+}
+
+func (f *Flow) body(s string) {
+	if f.plain {
+		fmt.Fprintln(f.w, "  "+s)
+		return
+	}
+	fmt.Fprintln(f.w, f.rail()+"  "+s)
+}
+
+// linkText mirrors output.Renderer.LinkText for use inside the flow (OSC 8
+// clickable label; plain-ish fallback when styling is unavailable is handled by
+// the terminal ignoring the escapes).
+func linkText(label, url string) string {
+	styled := lipgloss.NewStyle().Foreground(output.BrandRed).Underline(true).Render(label)
+	return "\x1b]8;;" + url + "\x1b\\" + styled + "\x1b]8;;\x1b\\"
+}

--- a/internal/tui/flow.go
+++ b/internal/tui/flow.go
@@ -15,8 +15,9 @@ import (
 // flows so the whole command reads as one designed experience rather than a
 // scatter of lines.
 //
-// Interactive prompts (tui.Form / decide / confirm) happen between rail calls —
-// they're the active moments the rail pauses for, then resumes.
+// Interactive prompts (Confirm/Select/Input) happen between rail calls — they're
+// the active moments the rail pauses for, then resumes. Shares its styles and
+// rail helpers with the prompt models (prompt_rail.go).
 //
 // On a non-TTY (plain), the glyphs are dropped for clean append-only lines.
 type Flow struct {
@@ -24,19 +25,8 @@ type Flow struct {
 	plain bool
 }
 
-var (
-	flowRailSty  = lipgloss.NewStyle().Foreground(output.BrandRed)
-	flowCapSty   = lipgloss.NewStyle().Foreground(output.BrandRed).Bold(true)
-	flowTitleSty = lipgloss.NewStyle().Bold(true)
-	flowDimSty   = lipgloss.NewStyle().Faint(true)
-	flowOKSty    = lipgloss.NewStyle().Foreground(output.GreenOK).Bold(true)
-	flowWarnSty  = lipgloss.NewStyle().Foreground(output.WarnAmber)
-)
-
 // NewFlow builds a flow writing to w. plain drops the rail (non-TTY/CI).
 func NewFlow(w io.Writer, plain bool) *Flow { return &Flow{w: w, plain: plain} }
-
-func (f *Flow) rail() string { return flowRailSty.Render("│") }
 
 // Intro opens the flow with a ┌ cap and title.
 func (f *Flow) Intro(title string) {
@@ -44,8 +34,8 @@ func (f *Flow) Intro(title string) {
 		fmt.Fprintln(f.w, title)
 		return
 	}
-	fmt.Fprintln(f.w, flowCapSty.Render("┌")+"  "+flowTitleSty.Render(title))
-	fmt.Fprintln(f.w, f.rail())
+	fmt.Fprintln(f.w, prActiveSty.Render("┌")+"  "+prTitleSty.Render(title))
+	fmt.Fprintln(f.w, railSpacer())
 }
 
 // Step starts a new section with a ◇ marker, preceded by a rail spacer.
@@ -54,21 +44,16 @@ func (f *Flow) Step(title string) {
 		fmt.Fprintf(f.w, "\n%s\n", title)
 		return
 	}
-	fmt.Fprintln(f.w, f.rail())
-	fmt.Fprintln(f.w, flowCapSty.Render("◇")+"  "+flowTitleSty.Render(title))
+	fmt.Fprintln(f.w, railSpacer())
+	fmt.Fprintln(f.w, prActiveSty.Render("◇")+"  "+prTitleSty.Render(title))
 }
 
 // Say prints a dim narration line on the rail.
-func (f *Flow) Say(line string) { f.body(flowDimSty.Render(line)) }
+func (f *Flow) Say(line string) { f.body(prDimSty.Render(line)) }
 
 // Item prints a bulleted list item on the rail, indented under the current step.
 func (f *Flow) Item(line string) {
-	f.body(flowRailSty.Render("•") + " " + flowDimSty.Render(line))
-}
-
-// Link prints a narration line ending in a clickable label.
-func (f *Flow) Link(text, label, url string) {
-	f.body(flowDimSty.Render(text) + " " + linkText(label, url))
+	f.body(prRailSty.Render("•") + " " + prDimSty.Render(line))
 }
 
 // URL prints a full URL on the rail — clickable in capable terminals and
@@ -78,20 +63,20 @@ func (f *Flow) URL(url string) {
 		f.body(url)
 		return
 	}
-	f.body(linkText(url, url))
+	f.body(hyperlink(url, url))
 }
 
 // Receipt echoes a confirmed choice as "✓ key  value" on the rail.
 func (f *Flow) Receipt(key, value string) {
-	line := flowOKSty.Render("✓") + " " + key
+	line := prOKSty.Render("✓") + " " + key
 	if value != "" {
-		line += "  " + flowDimSty.Render(value)
+		line += "  " + prDimSty.Render(value)
 	}
 	f.body(line)
 }
 
 // Warn prints a warning line on the rail.
-func (f *Flow) Warn(line string) { f.body(flowWarnSty.Render("! " + line)) }
+func (f *Flow) Warn(line string) { f.body(prWarnSty.Render("! " + line)) }
 
 // Outro closes the flow with a └ cap; extras are indented under it.
 func (f *Flow) Outro(title string, extras ...string) {
@@ -102,8 +87,8 @@ func (f *Flow) Outro(title string, extras ...string) {
 		}
 		return
 	}
-	fmt.Fprintln(f.w, f.rail())
-	fmt.Fprintln(f.w, flowCapSty.Render("└")+"  "+flowTitleSty.Render(title))
+	fmt.Fprintln(f.w, railSpacer())
+	fmt.Fprintln(f.w, prActiveSty.Render("└")+"  "+prTitleSty.Render(title))
 	for _, e := range extras {
 		fmt.Fprintln(f.w, "   "+e)
 	}
@@ -113,7 +98,7 @@ func (f *Flow) Outro(title string, extras ...string) {
 func (f *Flow) Ledger(labels ...string) *Ledger {
 	l := NewLedger(f.w, f.plain, labels...)
 	if !f.plain {
-		l.gutter = f.rail() + "  "
+		l.gutter = railSpacer() + "  "
 	}
 	return l
 }
@@ -123,13 +108,11 @@ func (f *Flow) body(s string) {
 		fmt.Fprintln(f.w, "  "+s)
 		return
 	}
-	fmt.Fprintln(f.w, f.rail()+"  "+s)
+	fmt.Fprintln(f.w, railBody(s))
 }
 
-// linkText mirrors output.Renderer.LinkText for use inside the flow (OSC 8
-// clickable label; plain-ish fallback when styling is unavailable is handled by
-// the terminal ignoring the escapes).
-func linkText(label, url string) string {
-	styled := lipgloss.NewStyle().Foreground(output.BrandRed).Underline(true).Render(label)
-	return "\x1b]8;;" + url + "\x1b\\" + styled + "\x1b]8;;\x1b\\"
+// hyperlink renders label as a clickable OSC 8 link to url, underlined in the
+// brand accent.
+func hyperlink(label, url string) string {
+	return output.Hyperlink(lipgloss.NewStyle().Foreground(output.BrandRed).Underline(true).Render(label), url)
 }

--- a/internal/tui/flow.go
+++ b/internal/tui/flow.go
@@ -66,6 +66,16 @@ func (f *Flow) Link(text, label, url string) {
 	f.body(flowDimSty.Render(text) + " " + linkText(label, url))
 }
 
+// URL prints a full URL on the rail — clickable in capable terminals and
+// selectable to copy everywhere.
+func (f *Flow) URL(url string) {
+	if f.plain {
+		f.body(url)
+		return
+	}
+	f.body(linkText(url, url))
+}
+
 // Receipt echoes a confirmed choice as "✓ key  value" on the rail.
 func (f *Flow) Receipt(key, value string) {
 	line := flowOKSty.Render("✓") + " " + key

--- a/internal/tui/flow.go
+++ b/internal/tui/flow.go
@@ -25,10 +25,8 @@ type Flow struct {
 	plain bool
 }
 
-// NewFlow builds a flow writing to w. plain drops the rail (non-TTY/CI).
 func NewFlow(w io.Writer, plain bool) *Flow { return &Flow{w: w, plain: plain} }
 
-// Intro opens the flow with a ┌ cap and title.
 func (f *Flow) Intro(title string) {
 	if f.plain {
 		fmt.Fprintln(f.w, title)
@@ -38,7 +36,6 @@ func (f *Flow) Intro(title string) {
 	fmt.Fprintln(f.w, railSpacer())
 }
 
-// Step starts a new section with a ◇ marker, preceded by a rail spacer.
 func (f *Flow) Step(title string) {
 	if f.plain {
 		fmt.Fprintf(f.w, "\n%s\n", title)
@@ -48,16 +45,14 @@ func (f *Flow) Step(title string) {
 	fmt.Fprintln(f.w, prActiveSty.Render("◇")+"  "+prTitleSty.Render(title))
 }
 
-// Say prints a dim narration line on the rail.
 func (f *Flow) Say(line string) { f.body(prDimSty.Render(line)) }
 
-// Item prints a bulleted list item on the rail, indented under the current step.
 func (f *Flow) Item(line string) {
 	f.body(prRailSty.Render("•") + " " + prDimSty.Render(line))
 }
 
-// URL prints a full URL on the rail — clickable in capable terminals and
-// selectable to copy everywhere.
+// URL prints the raw URL, not a hyperlink label, so it stays selectable to copy
+// on terminals that don't support OSC 8.
 func (f *Flow) URL(url string) {
 	if f.plain {
 		f.body(url)
@@ -66,7 +61,6 @@ func (f *Flow) URL(url string) {
 	f.body(hyperlink(url, url))
 }
 
-// Receipt echoes a confirmed choice as "✓ key  value" on the rail.
 func (f *Flow) Receipt(key, value string) {
 	line := prOKSty.Render("✓") + " " + key
 	if value != "" {
@@ -75,10 +69,8 @@ func (f *Flow) Receipt(key, value string) {
 	f.body(line)
 }
 
-// Warn prints a warning line on the rail.
 func (f *Flow) Warn(line string) { f.body(prWarnSty.Render("! " + line)) }
 
-// Outro closes the flow with a └ cap; extras are indented under it.
 func (f *Flow) Outro(title string, extras ...string) {
 	if f.plain {
 		fmt.Fprintln(f.w, title)
@@ -94,7 +86,6 @@ func (f *Flow) Outro(title string, extras ...string) {
 	}
 }
 
-// Ledger returns a step ledger whose lines sit on the flow's rail.
 func (f *Flow) Ledger(labels ...string) *Ledger {
 	l := NewLedger(f.w, f.plain, labels...)
 	if !f.plain {
@@ -111,8 +102,6 @@ func (f *Flow) body(s string) {
 	fmt.Fprintln(f.w, railBody(s))
 }
 
-// hyperlink renders label as a clickable OSC 8 link to url, underlined in the
-// brand accent.
 func hyperlink(label, url string) string {
 	return output.Hyperlink(lipgloss.NewStyle().Foreground(output.BrandRed).Underline(true).Render(label), url)
 }

--- a/internal/tui/flow.go
+++ b/internal/tui/flow.go
@@ -24,13 +24,17 @@ type Flow struct {
 	w       io.Writer
 	plain   bool
 	noColor bool
+	quiet   bool
 }
 
-func NewFlow(w io.Writer, plain, noColor bool) *Flow {
-	return &Flow{w: w, plain: plain, noColor: noColor}
+func NewFlow(w io.Writer, plain, noColor, quiet bool) *Flow {
+	return &Flow{w: w, plain: plain, noColor: noColor, quiet: quiet}
 }
 
 func (f *Flow) Intro(title string) {
+	if f.quiet {
+		return
+	}
 	if f.plain {
 		fmt.Fprintln(f.w, title)
 		return
@@ -40,6 +44,9 @@ func (f *Flow) Intro(title string) {
 }
 
 func (f *Flow) Step(title string) {
+	if f.quiet {
+		return
+	}
 	if f.plain {
 		fmt.Fprintf(f.w, "\n%s\n", title)
 		return
@@ -75,6 +82,9 @@ func (f *Flow) Receipt(key, value string) {
 func (f *Flow) Warn(line string) { f.body(prWarnSty.Render("! " + line)) }
 
 func (f *Flow) Outro(title string, extras ...string) {
+	if f.quiet {
+		return
+	}
 	if f.plain {
 		fmt.Fprintln(f.w, title)
 		for _, e := range extras {
@@ -90,6 +100,9 @@ func (f *Flow) Outro(title string, extras ...string) {
 }
 
 func (f *Flow) Ledger(labels ...string) *Ledger {
+	if f.quiet {
+		return NewLedger(io.Discard, true, labels...)
+	}
 	l := NewLedger(f.w, f.plain, labels...)
 	if !f.plain {
 		l.gutter = railSpacer() + "  "
@@ -98,6 +111,9 @@ func (f *Flow) Ledger(labels ...string) *Ledger {
 }
 
 func (f *Flow) body(s string) {
+	if f.quiet {
+		return
+	}
 	if f.plain {
 		fmt.Fprintln(f.w, "  "+s)
 		return

--- a/internal/tui/ledger.go
+++ b/internal/tui/ledger.go
@@ -26,11 +26,12 @@ import (
 //	l.Running(1); /* work */; l.Fail(1, "quota exceeded")
 //	l.Stop()
 type Ledger struct {
-	w     io.Writer
-	plain bool
-	steps []ledgerStep
-	prog  *tea.Program
-	done  chan struct{}
+	w      io.Writer
+	plain  bool
+	gutter string // left prefix for each line (e.g. a flow rail); default "  "
+	steps  []ledgerStep
+	prog   *tea.Program
+	done   chan struct{}
 }
 
 type ledgerStatus int
@@ -61,7 +62,7 @@ func NewLedger(w io.Writer, plain bool, labels ...string) *Ledger {
 	for i, l := range labels {
 		steps[i] = ledgerStep{label: l}
 	}
-	return &Ledger{w: w, plain: plain, steps: steps}
+	return &Ledger{w: w, plain: plain, gutter: "  ", steps: steps}
 }
 
 // Start begins rendering. On a TTY it launches the live region; in plain mode it
@@ -76,7 +77,7 @@ func (l *Ledger) Start() {
 	// (raw mode, eaten keystrokes), and WithoutSignalHandler leaves Ctrl+C to
 	// the process — otherwise it would quit only the spinner while setup keeps
 	// mutating cloud resources, so a cancel could look successful.
-	l.prog = tea.NewProgram(ledgerModel{steps: l.steps, sp: sp},
+	l.prog = tea.NewProgram(ledgerModel{steps: l.steps, sp: sp, gutter: l.gutter},
 		tea.WithOutput(l.w), tea.WithInput(nil), tea.WithoutSignalHandler())
 	l.done = make(chan struct{})
 	go func() {
@@ -138,8 +139,9 @@ func (l *Ledger) printPlain(s ledgerStep) {
 
 // ledgerModel is the bubbletea model driving the live (TTY) render.
 type ledgerModel struct {
-	steps []ledgerStep
-	sp    spinner.Model
+	steps  []ledgerStep
+	sp     spinner.Model
+	gutter string
 }
 
 type ledgerStatusMsg struct {
@@ -171,23 +173,24 @@ func (m ledgerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m ledgerModel) View() string {
-	return renderLedger(m.steps, m.sp.View())
+	return renderLedger(m.steps, m.sp.View(), m.gutter)
 }
 
 // renderLedger draws the step list; spinnerFrame is the glyph for the running
-// step. Pulled out so it can be unit-tested without a running program.
-func renderLedger(steps []ledgerStep, spinnerFrame string) string {
+// step and gutter is the per-line left prefix. Pulled out so it can be
+// unit-tested without a running program.
+func renderLedger(steps []ledgerStep, spinnerFrame, gutter string) string {
 	var b strings.Builder
 	for _, s := range steps {
 		switch s.status {
 		case ledgerDone:
-			b.WriteString("  " + ledgerCheck.Render("✓") + " " + s.label)
+			b.WriteString(gutter + ledgerCheck.Render("✓") + " " + s.label)
 		case ledgerFailed:
-			b.WriteString("  " + ledgerCross.Render("✗") + " " + s.label)
+			b.WriteString(gutter + ledgerCross.Render("✗") + " " + s.label)
 		case ledgerRunning:
-			b.WriteString("  " + spinnerFrame + s.label)
+			b.WriteString(gutter + spinnerFrame + s.label)
 		default:
-			b.WriteString("  " + ledgerPendSty.Render("○ "+s.label))
+			b.WriteString(gutter + ledgerPendSty.Render("○ "+s.label))
 		}
 		if s.note != "" {
 			b.WriteString(ledgerNoteSty.Render("  " + s.note))

--- a/internal/tui/ledger_test.go
+++ b/internal/tui/ledger_test.go
@@ -13,7 +13,7 @@ func TestRenderLedger(t *testing.T) {
 		{label: "Grant roles", note: "quota exceeded", status: ledgerFailed},
 		{label: "Create key", status: ledgerPending},
 	}
-	out := renderLedger(steps, "* ")
+	out := renderLedger(steps, "* ", "  ")
 
 	for _, want := range []string{"Enable APIs", "Create service account", "Grant roles", "Create key", "quota exceeded"} {
 		if !strings.Contains(out, want) {

--- a/internal/tui/prompt_rail.go
+++ b/internal/tui/prompt_rail.go
@@ -20,7 +20,6 @@ import (
 // ErrPromptCancelled is returned when the user aborts a rail prompt (esc/ctrl-c).
 var ErrPromptCancelled = errors.New("cancelled")
 
-// Option is one choice in a rail Select.
 type Option struct {
 	Label string
 	Value string
@@ -42,8 +41,7 @@ func railHead(glyph, title string) string {
 }
 func railBody(s string) string { return prRailSty.Render("│") + "  " + s }
 
-// Confirm asks a yes/no question on the rail. Returns the choice; def is the
-// initial selection. In plain mode it returns def without prompting.
+// Confirm returns def without prompting in plain mode.
 func (f *Flow) Confirm(question string, def bool) (bool, error) {
 	if f.plain {
 		return def, nil
@@ -59,7 +57,6 @@ func (f *Flow) Confirm(question string, def bool) (bool, error) {
 	return cm.yes, nil
 }
 
-// Select shows a single-choice list on the rail and returns the chosen value.
 func (f *Flow) Select(title string, opts []Option, desc ...string) (string, error) {
 	if f.plain {
 		return "", errors.New("cannot show a picker in non-interactive mode")
@@ -78,7 +75,7 @@ func (f *Flow) Select(title string, opts []Option, desc ...string) (string, erro
 	return sm.opts[sm.cursor].Value, nil
 }
 
-// Input asks for a line of text on the rail. validate may be nil.
+// Input's validate may be nil.
 func (f *Flow) Input(title, placeholder string, validate func(string) error, desc ...string) (string, error) {
 	if f.plain {
 		return "", errors.New("cannot prompt for input in non-interactive mode")

--- a/internal/tui/prompt_rail.go
+++ b/internal/tui/prompt_rail.go
@@ -33,6 +33,7 @@ var (
 	prSelSty    = lipgloss.NewStyle().Foreground(output.AccentViolet).Bold(true)
 	prDimSty    = lipgloss.NewStyle().Faint(true)
 	prOKSty     = lipgloss.NewStyle().Foreground(output.GreenOK).Bold(true)
+	prWarnSty   = lipgloss.NewStyle().Foreground(output.WarnAmber)
 )
 
 func railSpacer() string { return prRailSty.Render("│") }

--- a/internal/tui/prompt_rail.go
+++ b/internal/tui/prompt_rail.go
@@ -1,0 +1,270 @@
+package tui
+
+import (
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/revenuecat/cli/internal/output"
+)
+
+// Rail-native prompts: confirm / select / text-input rendered on the Flow's
+// vertical spine (clack-style ◆ active → ◇ resolved), so a guided flow stays one
+// cohesive experience instead of popping out separate boxes. They're methods on
+// Flow. huh remains the prompt layer for ordinary (data) commands.
+
+// ErrPromptCancelled is returned when the user aborts a rail prompt (esc/ctrl-c).
+var ErrPromptCancelled = errors.New("cancelled")
+
+// Option is one choice in a rail Select.
+type Option struct {
+	Label string
+	Value string
+}
+
+var (
+	prRailSty   = lipgloss.NewStyle().Foreground(output.BrandRed)
+	prActiveSty = lipgloss.NewStyle().Foreground(output.BrandRed).Bold(true)
+	prTitleSty  = lipgloss.NewStyle().Bold(true)
+	prSelSty    = lipgloss.NewStyle().Foreground(output.AccentViolet).Bold(true)
+	prDimSty    = lipgloss.NewStyle().Faint(true)
+	prOKSty     = lipgloss.NewStyle().Foreground(output.GreenOK).Bold(true)
+)
+
+func railSpacer() string { return prRailSty.Render("│") }
+func railHead(glyph, title string) string {
+	return prActiveSty.Render(glyph) + "  " + prTitleSty.Render(title)
+}
+func railBody(s string) string { return prRailSty.Render("│") + "  " + s }
+
+// Confirm asks a yes/no question on the rail. Returns the choice; def is the
+// initial selection. In plain mode it returns def without prompting.
+func (f *Flow) Confirm(question string, def bool) (bool, error) {
+	if f.plain {
+		return def, nil
+	}
+	m, err := runRailPrompt(f.w, confirmModel{title: question, yes: def})
+	if err != nil {
+		return false, err
+	}
+	cm := m.(confirmModel)
+	if cm.cancelled {
+		return false, ErrPromptCancelled
+	}
+	return cm.yes, nil
+}
+
+// Select shows a single-choice list on the rail and returns the chosen value.
+func (f *Flow) Select(title string, opts []Option, desc ...string) (string, error) {
+	if f.plain {
+		return "", errors.New("cannot show a picker in non-interactive mode")
+	}
+	if len(opts) == 0 {
+		return "", errors.New("no options to choose from")
+	}
+	m, err := runRailPrompt(f.w, selectModel{title: title, desc: desc, opts: opts})
+	if err != nil {
+		return "", err
+	}
+	sm := m.(selectModel)
+	if sm.cancelled {
+		return "", ErrPromptCancelled
+	}
+	return sm.opts[sm.cursor].Value, nil
+}
+
+// Input asks for a line of text on the rail. validate may be nil.
+func (f *Flow) Input(title, placeholder string, validate func(string) error, desc ...string) (string, error) {
+	if f.plain {
+		return "", errors.New("cannot prompt for input in non-interactive mode")
+	}
+	ti := textinput.New()
+	ti.Placeholder = placeholder
+	ti.Focus()
+	m, err := runRailPrompt(f.w, inputModel{title: title, desc: desc, ti: ti, validate: validate})
+	if err != nil {
+		return "", err
+	}
+	im := m.(inputModel)
+	if im.cancelled {
+		return "", ErrPromptCancelled
+	}
+	return strings.TrimSpace(im.ti.Value()), nil
+}
+
+func runRailPrompt(w io.Writer, m tea.Model) (tea.Model, error) {
+	return tea.NewProgram(m, tea.WithOutput(w)).Run()
+}
+
+// ---- confirm ----
+
+type confirmModel struct {
+	title     string
+	yes       bool
+	done      bool
+	cancelled bool
+}
+
+func (m confirmModel) Init() tea.Cmd { return nil }
+
+func (m confirmModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "left", "right", "tab", "h", "l":
+		m.yes = !m.yes
+	case "y", "Y":
+		m.yes, m.done = true, true
+		return m, tea.Quit
+	case "n", "N":
+		m.yes, m.done = false, true
+		return m, tea.Quit
+	case "enter":
+		m.done = true
+		return m, tea.Quit
+	case "esc", "ctrl+c":
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m confirmModel) View() string {
+	if m.done {
+		ans := "No"
+		if m.yes {
+			ans = "Yes"
+		}
+		return railSpacer() + "\n" + railHead("◇", m.title) + "\n" + railBody(prOKSty.Render("✓")+" "+ans) + "\n"
+	}
+	yes, no := "Yes", "No"
+	if m.yes {
+		yes = prSelSty.Render("▸ Yes")
+		no = prDimSty.Render("No")
+	} else {
+		yes = prDimSty.Render("Yes")
+		no = prSelSty.Render("▸ No")
+	}
+	return railSpacer() + "\n" + railHead("◆", m.title) + "\n" + railBody(yes+"    "+no) + "\n"
+}
+
+// ---- select ----
+
+type selectModel struct {
+	title     string
+	desc      []string
+	opts      []Option
+	cursor    int
+	done      bool
+	cancelled bool
+}
+
+func (m selectModel) Init() tea.Cmd { return nil }
+
+func (m selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "down", "j":
+		if m.cursor < len(m.opts)-1 {
+			m.cursor++
+		}
+	case "enter":
+		m.done = true
+		return m, tea.Quit
+	case "esc", "ctrl+c":
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m selectModel) View() string {
+	var b strings.Builder
+	b.WriteString(railSpacer() + "\n")
+	if m.done {
+		b.WriteString(railHead("◇", m.title) + "\n")
+		b.WriteString(railBody(prOKSty.Render("✓")+" "+m.opts[m.cursor].Label) + "\n")
+		return b.String()
+	}
+	b.WriteString(railHead("◆", m.title) + "\n")
+	for _, d := range m.desc {
+		b.WriteString(railBody(prDimSty.Render(d)) + "\n")
+	}
+	for i, o := range m.opts {
+		if i == m.cursor {
+			b.WriteString(railBody(prSelSty.Render("▸ "+o.Label)) + "\n")
+		} else {
+			b.WriteString(railBody("  "+o.Label) + "\n")
+		}
+	}
+	return b.String()
+}
+
+// ---- input ----
+
+type inputModel struct {
+	title     string
+	desc      []string
+	ti        textinput.Model
+	validate  func(string) error
+	errMsg    string
+	done      bool
+	cancelled bool
+}
+
+func (m inputModel) Init() tea.Cmd { return textinput.Blink }
+
+func (m inputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if key, ok := msg.(tea.KeyMsg); ok {
+		switch key.String() {
+		case "enter":
+			v := strings.TrimSpace(m.ti.Value())
+			if m.validate != nil {
+				if err := m.validate(v); err != nil {
+					m.errMsg = err.Error()
+					return m, nil
+				}
+			}
+			m.done = true
+			return m, tea.Quit
+		case "esc", "ctrl+c":
+			m.cancelled = true
+			return m, tea.Quit
+		}
+	}
+	var cmd tea.Cmd
+	m.ti, cmd = m.ti.Update(msg)
+	return m, cmd
+}
+
+func (m inputModel) View() string {
+	var b strings.Builder
+	b.WriteString(railSpacer() + "\n")
+	if m.done {
+		b.WriteString(railHead("◇", m.title) + "\n")
+		b.WriteString(railBody(prOKSty.Render("✓")+" "+strings.TrimSpace(m.ti.Value())) + "\n")
+		return b.String()
+	}
+	b.WriteString(railHead("◆", m.title) + "\n")
+	for _, d := range m.desc {
+		b.WriteString(railBody(prDimSty.Render(d)) + "\n")
+	}
+	b.WriteString(railBody(m.ti.View()) + "\n")
+	if m.errMsg != "" {
+		b.WriteString(railBody(lipgloss.NewStyle().Foreground(output.ErrorRed).Render("! "+m.errMsg)) + "\n")
+	}
+	return b.String()
+}


### PR DESCRIPTION
Adds the guided rail — one continuous experience for human-first setup commands (intro cap, step headers and narration on a shared spine, rail-native confirm/select/input prompts, outro cap) — and moves `rc setup google` onto it so the whole command reads as one designed flow instead of scattered lines.

```
rc setup google
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Google Cloud/Play provisioning and new credential upload to RevenueCat; failures still fall back to a local key file, but mis-upload or partial setup could leave confusing state.
> 
> **Overview**
> Introduces a **guided rail** TUI (`tui.Flow`) for human-first setup: one vertical spine with intro/step/outro, rail-aligned **confirm/select/input** prompts, and a **ledger** whose steps can sit on the same gutter.
> 
> **`rc setup google`** is rebuilt on that rail instead of scattered `Title`/`Plan`/`Info` lines. Google sign-in becomes an explicit choice between opening the browser or **copying the OAuth link** (clipboard). Setup progress runs through a five-step ledger (service account, roles, key, Play, upload).
> 
> **Credential handling changes materially:** the flow tries to **upload the Play service-account JSON to RevenueCat via API v2** first; on failure it writes `--key-out` and warns with the real API error instead of always treating upload as unavailable. Success/fallback endings use rail **outros** with dashboard links (`LinkText`), not the previous summary card.
> 
> **Output:** `--no-color` forces ASCII lipgloss globally; **`LinkText`** / shared **`Hyperlink`** support labeled OSC 8 links in rail text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eaf1eacc0f558f9a07e8b0ce9ec6bd255e284dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->