### PR TITLE
feat(setup): promote apple setup to rc setup apple

### DIFF
--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -90,7 +90,8 @@ names; there's no list endpoint.
 # Onboarding entry points (the two scoped npx surfaces)
 rc setup                                                 # one-shot agent-driven bootstrap; featured in --help/home/README, runs non-interactively for the prompt
 rc setup google [app-id]                                 # interactive: local Google sign-in, bootstrap the Play service-account credential, grant package-scoped access, upload to RC
-rc capital setup                                         # EXPERIMENTAL (hidden from --help until Capital ships): App Store Connect key flow (wraps apps apple setup)
+rc setup apple [app-id]                                  # interactive: App Store Connect sign-in + 2FA, create/upload IAP & ASC keys, vendor number (rc apps apple setup is a hidden alias)
+rc capital setup                                         # EXPERIMENTAL (hidden from --help until Capital ships): App Store Connect key flow (wraps setup apple)
 rc                                                       # bare rc -> getting-started help; --all reveals experimental commands
 
 # Auth / meta
@@ -126,7 +127,7 @@ rc apps delete <id>
 rc apps keys <app-id>                                    # typed public SDK keys for app integration
 rc apps storekit-config <app-id>                         # store_kit_config; optionally writes .storekit JSON
 rc apps apple check [app-id]                             # validate Apple login, 2FA, team, and key access (read-only)
-rc apps apple setup [app-id]                             # interactive: create ASC app record if missing, per-key consent for IAP/ASC keys, auto-fetch vendor number
+rc apps apple setup [app-id]                             # hidden alias of rc setup apple (kept for back-compat)
 
 # Customers — busiest noun
 rc customers show [id]                                    # already embeds active_entitlements; we'll add subs + purchases

--- a/internal/cli/apps.go
+++ b/internal/cli/apps.go
@@ -165,7 +165,7 @@ name, type, and the platform's required identifier (bundle ID, package name, or
 app name) when run interactively.
 
 App Store apps still need Apple credentials before purchases validate — finish
-with rc apps apple setup.`,
+with rc setup apple.`,
 		Example: `  rc apps create --name "Acme iOS" --type app_store --bundle-id com.acme.app
   rc apps create --name "Acme Android" --type play_store --package-name com.acme.app`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -243,7 +243,7 @@ with rc apps apple setup.`,
 			rt.Out.Success(fmt.Sprintf("Created app %s", a.ID))
 			if appType == "app_store" && subscriptionPrivateKey == "" {
 				rt.Out.Warn("Apple credentials are still required before App Store purchases can be validated.")
-				rt.Out.Hint(fmt.Sprintf("Next:  rc apps apple setup %s  (Apple sign-in with 2FA — a human must run this)", a.ID))
+				rt.Out.Hint(fmt.Sprintf("Next:  rc setup apple %s  (Apple sign-in with 2FA — a human must run this)", a.ID))
 			}
 			return rt.Out.Render(a)
 		},
@@ -442,9 +442,9 @@ func appCredentialStatus(a api.App) string {
 	case a.AppStore.SubscriptionKeyConfigured && a.AppStore.AppStoreConnectAPIKeyConfigured:
 		return "ready"
 	case a.AppStore.SubscriptionKeyConfigured || a.AppStore.AppStoreConnectAPIKeyConfigured:
-		return "partial — run: rc apps apple setup"
+		return "partial — run: rc setup apple"
 	default:
-		return "missing — run: rc apps apple setup"
+		return "missing — run: rc setup apple"
 	}
 }
 
@@ -458,7 +458,7 @@ func appleSetupHintForApps(rt *Runtime, apps []api.App) {
 		}
 		if !a.AppStore.SubscriptionKeyConfigured || !a.AppStore.AppStoreConnectAPIKeyConfigured {
 			rt.Out.Warn(fmt.Sprintf("%s is missing Apple credentials — App Store purchases can't be validated until they're set.", a.ID))
-			rt.Out.Hint(fmt.Sprintf("Fix it:  rc apps apple setup %s  (interactive Apple sign-in with 2FA)", a.ID))
+			rt.Out.Hint(fmt.Sprintf("Fix it:  rc setup apple %s  (interactive Apple sign-in with 2FA)", a.ID))
 		}
 	}
 }

--- a/internal/cli/apps_apple.go
+++ b/internal/cli/apps_apple.go
@@ -69,7 +69,7 @@ func ensureAppStoreAppRecord(ctx context.Context, rt *Runtime, apple appleConnec
 	}
 	rt.Out.Warn("No App Store Connect app exists for " + bundleID + " — products and TestFlight need one.")
 	if !rt.CanPrompt() {
-		rt.Out.Warn("Create it in App Store Connect, or re-run rc apps apple setup interactively to create it from here.")
+		rt.Out.Warn("Create it in App Store Connect, or re-run rc setup apple interactively to create it from here.")
 		return nil
 	}
 	create, err := tui.ConfirmDefault(rt.Globals.NoInput,
@@ -270,12 +270,23 @@ Requires an interactive terminal and Apple 2FA: a human must run it. Apple
 credentials go straight to Apple and are never saved or sent to RevenueCat. Use
 check for a read-only dry run before setup.`,
 		Example: `  rc apps apple check app_x     # read-only: verify sign-in and key access
-  rc apps apple setup app_x     # create keys and configure the app`,
+  rc setup apple app_x          # create keys and configure the app`,
 	}
-	cmd.AddCommand(
-		newAppsAppleWorkflowCmd(true, factory),
-		newAppsAppleWorkflowCmd(false, factory),
-	)
+	// The setup subcommand is reachable here for back-compat but hidden from
+	// help — rc setup apple is the promoted path.
+	setup := newAppsAppleWorkflowCmd(false, factory)
+	setup.Hidden = true
+	cmd.AddCommand(newAppsAppleWorkflowCmd(true, factory), setup)
+	return cmd
+}
+
+// newSetupAppleCmd is the promoted rc setup apple, a sibling of rc setup google.
+// Same workflow as rc apps apple setup, named for the setup group.
+func newSetupAppleCmd() *cobra.Command {
+	cmd := newAppsAppleWorkflowCmd(false, newAppleConnectClient)
+	cmd.Use = "apple [app-id]"
+	cmd.Short = "Set up Apple credentials for an App Store app"
+	cmd.Example = "  rc setup apple app_x\n  rc setup apple app_x --sms --phone-number +15551234567"
 	return cmd
 }
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -121,7 +121,7 @@ the step-by-step commands in the docs.`,
 			return runSetup(cmd)
 		},
 	}
-	cmd.AddCommand(newSetupGoogleCmd())
+	cmd.AddCommand(newSetupGoogleCmd(), newSetupAppleCmd())
 	return cmd
 }
 

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -54,7 +54,7 @@ func revenueCatStarterPrompts() []starterPrompt {
 		{
 			ID:     "connect-apple",
 			Title:  "Connect my Apple account",
-			Prompt: "Continue this app's RevenueCat setup with the Apple stage of the create-revenuecat-project skill. Verify the App Store app and bundle ID, run the read-only Apple check first, then give me the local interactive rc apps apple setup command for Apple sign-in and 2FA. Verify the missing In-App Purchase and App Store Connect keys are configured without asking me to paste Apple credentials into chat.",
+			Prompt: "Continue this app's RevenueCat setup with the Apple stage of the create-revenuecat-project skill. Verify the App Store app and bundle ID, run the read-only Apple check first, then give me the local interactive rc setup apple command for Apple sign-in and 2FA. Verify the missing In-App Purchase and App Store Connect keys are configured without asking me to paste Apple credentials into chat.",
 		},
 		{
 			ID:     "sync-store-catalog",

--- a/internal/cli/testdata/snapshots/apps-list.golden
+++ b/internal/cli/testdata/snapshots/apps-list.golden
@@ -1,6 +1,6 @@
 $ rc apps list --no-input --project-id proj_snap --api-key sk_snap
 ! app_snap1 is missing Apple credentials — App Store purchases can't be validated until they're set.
-  Fix it:  rc apps apple setup app_snap1  (interactive Apple sign-in with 2FA)
-ID         NAME                TYPE        CREATED     CREDENTIALS                         
-app_snap1  Moodly (App Store)  app_store   2026-07-16  partial — run: rc apps apple setup
-app_snap2  Test Store          test_store  2026-07-16  —                                 
+  Fix it:  rc setup apple app_snap1  (interactive Apple sign-in with 2FA)
+ID         NAME                TYPE        CREATED     CREDENTIALS                    
+app_snap1  Moodly (App Store)  app_store   2026-07-16  partial — run: rc setup apple
+app_snap2  Test Store          test_store  2026-07-16  —                            


### PR DESCRIPTION
Promotes the Apple setup flow to `rc setup apple`, a sibling of `rc setup google`, so both store setups live under one group and read the same way.

```
rc setup google
rc setup apple
```

`rc apps apple setup` still works (hidden alias), and next-step hints across the CLI now point at `rc setup apple`. `rc apps apple check` stays where it is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI routing and user-facing hints only; the Apple workflow implementation is reused without behavioral changes beyond command discovery and aliases.
> 
> **Overview**
> **Promotes Apple credential onboarding to `rc setup apple`**, alongside `rc setup google`, so store setup commands share one `setup` group. The interactive App Store Connect flow (sign-in, 2FA, IAP/ASC keys, vendor number) is unchanged; it is registered via `newSetupAppleCmd()` on the `setup` command.
> 
> **`rc apps apple setup` remains for back-compat** but is **hidden from help**; `rc apps apple check` stays visible. Docs, credential hints on `rc apps list` / create, the connect-apple starter prompt, and snapshot tests now point users at **`rc setup apple`** instead of `rc apps apple setup`. **`rc capital setup`** is documented as wrapping the promoted Apple setup path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec053c6f1c0c98965cc9efc5c8e0d3c6091fda94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->