### PR TITLE
feat(setup): put rc setup on the guided rail

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -51,6 +51,7 @@ func newAuthSignupCmd() *cobra.Command {
 	var password string
 	var generatePassword bool
 	var savePassword bool
+	var fromSetup bool
 
 	cmd := &cobra.Command{
 		Use:   "signup",
@@ -186,7 +187,7 @@ You must accept the RevenueCat Terms of Service and Privacy Policy:
 			if err := validateSignupPassword(password); err != nil {
 				return err
 			}
-			return signupWithOAuth(cmd.Context(), rt, email, name, password, marketingEmails, savePassword, generatePassword)
+			return signupWithOAuth(cmd.Context(), rt, email, name, password, marketingEmails, savePassword, generatePassword, fromSetup)
 		},
 	}
 
@@ -197,6 +198,9 @@ You must accept the RevenueCat Terms of Service and Privacy Policy:
 	cmd.Flags().BoolVar(&savePassword, "save-password", false, "save the website password in the local macOS login Keychain; does not sync to Apple Passwords/iCloud")
 	cmd.Flags().BoolVar(&acceptTerms, "accept-terms", false, "accept the RevenueCat Terms of Service and Privacy Policy")
 	cmd.Flags().BoolVar(&marketingEmails, "marketing-emails", false, "receive RevenueCat product and marketing emails")
+	// Set by rc setup, which owns the post-signup next-steps guidance itself.
+	cmd.Flags().BoolVar(&fromSetup, "from-setup", false, "")
+	_ = cmd.Flags().MarkHidden("from-setup")
 	return cmd
 }
 
@@ -699,7 +703,7 @@ func loginWithOAuth(ctx context.Context, rt *Runtime) error {
 	return finishLogin(ctx, rt, client)
 }
 
-func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password string, marketingEmails, savePassword, generatedPassword bool) error {
+func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password string, marketingEmails, savePassword, generatedPassword, suppressNextSteps bool) error {
 	verifier, challenge, err := api.GeneratePKCE()
 	if err != nil {
 		return fmt.Errorf("generating PKCE: %w", err)
@@ -774,10 +778,14 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 		rt.Out.Warn("The generated password was not saved. Use password reset if you need dashboard access later.")
 	}
 	rt.Out.Info("Check your email to verify the account.")
-	rt.Out.Info("Next, copy this into a new agent session:")
-	rt.Out.Info(projectSkillTrigger)
-	rt.Out.Hint("Install agent workflows:  rc skills install")
-	rt.Out.Hint("Or start manually:  rc projects create --name \"My App\" --use")
+	// When setup drives signup it owns the next-steps guidance on the rail, so
+	// skip signup's own standalone epilogue to avoid duplicated/contradictory hints.
+	if !suppressNextSteps {
+		rt.Out.Info("Next, copy this into a new agent session:")
+		rt.Out.Info(projectSkillTrigger)
+		rt.Out.Hint("Install agent workflows:  rc skills install")
+		rt.Out.Hint("Or start manually:  rc projects create --name \"My App\" --use")
+	}
 	result := map[string]any{
 		"account_created":             true,
 		"authenticated":               true,

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -779,7 +779,7 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 	if !fromSetup {
 		rt.Out.Success(fmt.Sprintf("Account created and logged in (profile: %s)", profile))
 	}
-	if generatedPassword && !passwordSaved {
+	if generatedPassword && !passwordSaved && !fromSetup {
 		rt.Out.Warn("The generated password was not saved. Use password reset if you need dashboard access later.")
 	}
 	say("Check your email to verify the account.")

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -51,7 +51,6 @@ func newAuthSignupCmd() *cobra.Command {
 	var password string
 	var generatePassword bool
 	var savePassword bool
-	var fromSetup bool
 
 	cmd := &cobra.Command{
 		Use:   "signup",
@@ -177,17 +176,17 @@ You must accept the RevenueCat Terms of Service and Privacy Policy:
 			}
 
 			if password == "" {
-				passwordBytes := make([]byte, 32)
-				if _, err := rand.Read(passwordBytes); err != nil {
-					return fmt.Errorf("generating signup credential: %w", err)
+				generated, err := generateSignupPassword()
+				if err != nil {
+					return err
 				}
-				password = base64.RawURLEncoding.EncodeToString(passwordBytes)
+				password = generated
 				generatePassword = true
 			}
 			if err := validateSignupPassword(password); err != nil {
 				return err
 			}
-			return signupWithOAuth(cmd.Context(), rt, email, name, password, marketingEmails, savePassword, generatePassword, fromSetup)
+			return signupWithOAuth(cmd.Context(), rt, email, name, password, marketingEmails, savePassword, generatePassword, false)
 		},
 	}
 
@@ -198,9 +197,6 @@ You must accept the RevenueCat Terms of Service and Privacy Policy:
 	cmd.Flags().BoolVar(&savePassword, "save-password", false, "save the website password in the local macOS login Keychain; does not sync to Apple Passwords/iCloud")
 	cmd.Flags().BoolVar(&acceptTerms, "accept-terms", false, "accept the RevenueCat Terms of Service and Privacy Policy")
 	cmd.Flags().BoolVar(&marketingEmails, "marketing-emails", false, "receive RevenueCat product and marketing emails")
-	// Set by rc setup, which owns the post-signup next-steps guidance itself.
-	cmd.Flags().BoolVar(&fromSetup, "from-setup", false, "")
-	_ = cmd.Flags().MarkHidden("from-setup")
 	return cmd
 }
 
@@ -703,7 +699,14 @@ func loginWithOAuth(ctx context.Context, rt *Runtime) error {
 	return finishLogin(ctx, rt, client)
 }
 
-func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password string, marketingEmails, savePassword, generatedPassword, suppressNextSteps bool) error {
+func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password string, marketingEmails, savePassword, generatedPassword, fromSetup bool) error {
+	// When setup drives signup it renders progress on its own rail (a ledger),
+	// so suppress this command's standalone chatter to avoid off-rail lines.
+	say := func(msg string) {
+		if !fromSetup {
+			rt.Out.Info(msg)
+		}
+	}
 	verifier, challenge, err := api.GeneratePKCE()
 	if err != nil {
 		return fmt.Errorf("generating PKCE: %w", err)
@@ -721,7 +724,7 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 	redirectURI := fmt.Sprintf("http://localhost:%d/callback", port)
 
 	svc := api.NewOAuthService(oauthBaseURL(), oauthClientID())
-	rt.Out.Info("Creating your RevenueCat account…")
+	say("Creating your RevenueCat account…")
 	if err := svc.ProvisionAccount(ctx, api.ProvisionAccountRequest{
 		Email:                 email,
 		Name:                  name,
@@ -732,7 +735,7 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 	}
 	passwordSaved := false
 	if savePassword {
-		rt.Out.Info("Saving the website password in macOS Keychain…")
+		say("Saving the website password in macOS Keychain…")
 		if err := saveRevenueCatPasswordToKeychain(email, password); err != nil {
 			rt.Out.Warn(fmt.Sprintf("Account created, but the password could not be saved to Keychain: %v", err))
 		} else {
@@ -740,17 +743,17 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 		}
 	}
 
-	rt.Out.Info("Starting a temporary secure login…")
+	say("Starting a temporary secure login…")
 	login, err := svc.Login(ctx, email, password)
 	if err != nil {
 		return signupAuthenticationError(err)
 	}
-	rt.Out.Info("Authorizing renewable CLI access…")
+	say("Authorizing renewable CLI access…")
 	code, err := svc.AuthorizeWithLoginToken(ctx, login.AuthenticationToken, redirectURI, challenge, state)
 	if err != nil {
 		return signupAuthenticationError(err)
 	}
-	rt.Out.Info("Exchanging the temporary session for OAuth tokens…")
+	say("Exchanging the temporary session for OAuth tokens…")
 	tokens, err := svc.ExchangeCode(ctx, code, redirectURI, verifier)
 	if err != nil {
 		return signupAuthenticationError(err)
@@ -768,19 +771,21 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 	clearProjectBinding(rt)
 	rt.client = nil
 
-	rt.Out.Info("Saving OAuth credentials in the active CLI profile…")
+	say("Saving OAuth credentials in the active CLI profile…")
 	if err := config.Save(rt.Globals.Profile, rt.Config); err != nil {
 		return err
 	}
 	profile := config.ProfileName(rt.Globals.Profile)
-	rt.Out.Success(fmt.Sprintf("Account created and logged in (profile: %s)", profile))
+	if !fromSetup {
+		rt.Out.Success(fmt.Sprintf("Account created and logged in (profile: %s)", profile))
+	}
 	if generatedPassword && !passwordSaved {
 		rt.Out.Warn("The generated password was not saved. Use password reset if you need dashboard access later.")
 	}
-	rt.Out.Info("Check your email to verify the account.")
+	say("Check your email to verify the account.")
 	// When setup drives signup it owns the next-steps guidance on the rail, so
 	// skip signup's own standalone epilogue to avoid duplicated/contradictory hints.
-	if !suppressNextSteps {
+	if !fromSetup {
 		rt.Out.Info("Next, copy this into a new agent session:")
 		rt.Out.Info(projectSkillTrigger)
 		rt.Out.Hint("Install agent workflows:  rc skills install")
@@ -817,6 +822,15 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 		return rt.Out.Render(result)
 	}
 	return nil
+}
+
+// generateSignupPassword returns a strong random account password.
+func generateSignupPassword() (string, error) {
+	passwordBytes := make([]byte, 32)
+	if _, err := rand.Read(passwordBytes); err != nil {
+		return "", fmt.Errorf("generating signup credential: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(passwordBytes), nil
 }
 
 func validateSignupPassword(password string) error {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -186,7 +186,8 @@ You must accept the RevenueCat Terms of Service and Privacy Policy:
 			if err := validateSignupPassword(password); err != nil {
 				return err
 			}
-			return signupWithOAuth(cmd.Context(), rt, email, name, password, marketingEmails, savePassword, generatePassword, false)
+			_, serr := signupWithOAuth(cmd.Context(), rt, email, name, password, marketingEmails, savePassword, generatePassword, false)
+			return serr
 		},
 	}
 
@@ -699,7 +700,7 @@ func loginWithOAuth(ctx context.Context, rt *Runtime) error {
 	return finishLogin(ctx, rt, client)
 }
 
-func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password string, marketingEmails, savePassword, generatedPassword, fromSetup bool) error {
+func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password string, marketingEmails, savePassword, generatedPassword, fromSetup bool) (bool, error) {
 	// When setup drives signup it renders progress on its own rail (a ledger),
 	// so suppress this command's standalone chatter to avoid off-rail lines.
 	say := func(msg string) {
@@ -709,15 +710,15 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 	}
 	verifier, challenge, err := api.GeneratePKCE()
 	if err != nil {
-		return fmt.Errorf("generating PKCE: %w", err)
+		return false, fmt.Errorf("generating PKCE: %w", err)
 	}
 	state, err := api.GenerateState()
 	if err != nil {
-		return fmt.Errorf("generating OAuth state: %w", err)
+		return false, fmt.Errorf("generating OAuth state: %w", err)
 	}
 	listener, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		return fmt.Errorf("reserving local OAuth callback: %w", err)
+		return false, fmt.Errorf("reserving local OAuth callback: %w", err)
 	}
 	defer listener.Close()
 	port := listener.Addr().(*net.TCPAddr).Port
@@ -731,13 +732,15 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 		Password:              password,
 		MarketingEmailEnabled: marketingEmails,
 	}); err != nil {
-		return fmt.Errorf("creating RevenueCat account: %w", err)
+		return false, fmt.Errorf("creating RevenueCat account: %w", err)
 	}
 	passwordSaved := false
 	if savePassword {
 		say("Saving the website password in macOS Keychain…")
 		if err := saveRevenueCatPasswordToKeychain(email, password); err != nil {
-			rt.Out.Warn(fmt.Sprintf("Account created, but the password could not be saved to Keychain: %v", err))
+			if !fromSetup {
+				rt.Out.Warn(fmt.Sprintf("Account created, but the password could not be saved to Keychain: %v", err))
+			}
 		} else {
 			passwordSaved = true
 		}
@@ -746,17 +749,17 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 	say("Starting a temporary secure login…")
 	login, err := svc.Login(ctx, email, password)
 	if err != nil {
-		return signupAuthenticationError(err)
+		return false, signupAuthenticationError(err)
 	}
 	say("Authorizing renewable CLI access…")
 	code, err := svc.AuthorizeWithLoginToken(ctx, login.AuthenticationToken, redirectURI, challenge, state)
 	if err != nil {
-		return signupAuthenticationError(err)
+		return false, signupAuthenticationError(err)
 	}
 	say("Exchanging the temporary session for OAuth tokens…")
 	tokens, err := svc.ExchangeCode(ctx, code, redirectURI, verifier)
 	if err != nil {
-		return signupAuthenticationError(err)
+		return false, signupAuthenticationError(err)
 	}
 	_ = svc.LogoutLoginToken(ctx, login.AuthenticationToken)
 
@@ -773,7 +776,7 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 
 	say("Saving OAuth credentials in the active CLI profile…")
 	if err := config.Save(rt.Globals.Profile, rt.Config); err != nil {
-		return err
+		return false, err
 	}
 	profile := config.ProfileName(rt.Globals.Profile)
 	if !fromSetup {
@@ -819,9 +822,9 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 		result["dashboard_password_action"] = "store_the_user_provided_password_safely"
 	}
 	if rt.Out.IsJSON() {
-		return rt.Out.Render(result)
+		return passwordSaved, rt.Out.Render(result)
 	}
-	return nil
+	return passwordSaved, nil
 }
 
 // generateSignupPassword returns a strong random account password.

--- a/internal/cli/design_boundaries_test.go
+++ b/internal/cli/design_boundaries_test.go
@@ -53,6 +53,7 @@ func TestDesignSystemBoundaries(t *testing.T) {
 				"skills.go":       "install-consent policy check, not a prompt",
 				"apps_apple.go":   "guided-flow prompt-eligibility checks",
 				"setup_google.go": "guided-flow prompt-eligibility checks",
+				"setup.go":        "guided-flow launch gate; --yes skips it on the rail",
 				"rico.go":         "tool-approval policy for destructive agent actions",
 			},
 			useThis: "use confirmOrAbort(rt, msg) so --yes/--no-input behave uniformly",

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -745,7 +745,7 @@ func setupSignup(cmd *cobra.Command, rt *Runtime, fl *tui.Flow) error {
 	}
 
 	fl.Say("Terms: https://www.revenuecat.com/terms · Privacy: https://www.revenuecat.com/privacy")
-	accepted, err := fl.Confirm("Accept the Terms of Service and Privacy Policy?", true)
+	accepted, err := fl.Confirm("Accept the Terms of Service and Privacy Policy?", false)
 	if err != nil {
 		return err
 	}
@@ -757,15 +757,16 @@ func setupSignup(cmd *cobra.Command, rt *Runtime, fl *tui.Flow) error {
 	led := fl.Ledger("Create account & sign in")
 	led.Start()
 	led.Running(0)
-	if err := signupWithOAuth(cmd.Context(), rt, email, name, password, marketing, savePassword, generated, true); err != nil {
+	saved, err := signupWithOAuth(cmd.Context(), rt, email, name, password, marketing, savePassword, generated, true)
+	if err != nil {
 		led.Fail(0, "failed")
 		led.Stop()
 		return err
 	}
 	led.Done(0, "")
 	led.Stop()
-	if generated && !savePassword {
-		fl.Warn("The generated password wasn't saved — use \"Forgot password?\" at revenuecat.com if you need dashboard access later.")
+	if generated && !saved {
+		fl.Warn("The generated password isn't saved. Use \"Forgot password?\" at revenuecat.com if you need dashboard access later.")
 	}
 	fl.Say("Check your email to verify the account.")
 	return nil

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -122,8 +122,24 @@ the step-by-step commands in the docs.`,
 			return runSetup(cmd)
 		},
 	}
+	cmd.Flags().String("autonomy", autonomyAuto, "how much the agent can do without asking: auto|trusted|full|manual")
+	cmd.Flags().String("skills-scope", "global", "where to install the RevenueCat skills: global|project")
 	cmd.AddCommand(newSetupGoogleCmd(), newSetupAppleCmd())
 	return cmd
+}
+
+// setupAutonomyAndScope resolves the agent autonomy and skills-install scope from
+// flags (sensible defaults, not prompts), validating the values.
+func setupAutonomyAndScope(cmd *cobra.Command) (autonomy, scope string, err error) {
+	autonomy, _ = cmd.Flags().GetString("autonomy")
+	if _, ok := autonomyLabels[autonomy]; !ok {
+		return "", "", fmt.Errorf("--autonomy must be one of: auto, trusted, full, manual")
+	}
+	scope, _ = cmd.Flags().GetString("skills-scope")
+	if _, ok := skillsScopeLabels[scope]; !ok {
+		return "", "", fmt.Errorf("--skills-scope must be one of: global, project")
+	}
+	return autonomy, scope, nil
 }
 
 func runSetup(cmd *cobra.Command) error {
@@ -219,32 +235,13 @@ func runSetup(cmd *cobra.Command) error {
 	}
 	fl.Receipt("Agent", choice.Name)
 
-	fl.Step("Autonomy")
-	autonomy, err := fl.Select("How much can "+choice.Name+" do without stopping to ask?",
-		[]tui.Option{
-			{Label: "Auto — use " + choice.Name + "'s built-in auto-approve mode", Value: autonomyAuto},
-			{Label: "Run freely — no approval prompts", Value: autonomyFull},
-			{Label: "Pre-approve rc, edits, and builds; ask for anything unusual", Value: autonomyTrusted},
-			{Label: "Ask me before each step", Value: autonomyManual},
-		},
-		"You can interrupt anytime.",
-	)
+	// Autonomy and skills scope are sensible defaults, not questions — override
+	// with --autonomy / --skills-scope. Shown as receipts so the choice is visible.
+	autonomy, skillsScope, err := setupAutonomyAndScope(cmd)
 	if err != nil {
 		return err
 	}
 	fl.Receipt("Autonomy", autonomyLabels[autonomy])
-
-	fl.Step("Skills")
-	skillsScope, err := fl.Select("Install the RevenueCat skills here or globally?",
-		[]tui.Option{
-			{Label: "This project only", Value: "project"},
-			{Label: "Globally (all projects on this machine)", Value: "global"},
-		},
-		"Project keeps them with this repo; global shares them across every project on this machine.",
-	)
-	if err != nil {
-		return err
-	}
 	fl.Receipt("Skills", skillsScopeLabels[skillsScope])
 
 	// Apple needs a browser + 2FA; setup always defers it to the agent hand-back.
@@ -749,6 +746,9 @@ func setupSignup(cmd *cobra.Command, rt *Runtime, fl *tui.Flow) error {
 	}
 	led.Done(0, "")
 	led.Stop()
+	if generated && !savePassword {
+		fl.Warn("The generated password wasn't saved — use \"Forgot password?\" at revenuecat.com if you need dashboard access later.")
+	}
 	fl.Say("Check your email to verify the account.")
 	return nil
 }

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -765,8 +765,11 @@ func setupSignup(cmd *cobra.Command, rt *Runtime, fl *tui.Flow) error {
 	}
 	led.Done(0, "")
 	led.Stop()
-	if generated && !saved {
+	switch {
+	case generated && !saved:
 		fl.Warn("The generated password isn't saved. Use \"Forgot password?\" at revenuecat.com if you need dashboard access later.")
+	case savePassword && !saved:
+		fl.Warn("Your password couldn't be saved to the Keychain. Keep your own copy for dashboard access.")
 	}
 	fl.Say("Check your email to verify the account.")
 	return nil

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -128,6 +128,23 @@ the step-by-step commands in the docs.`,
 	return cmd
 }
 
+// setupRoadmap previews the journey at the intro so the user knows what's coming.
+// It reflects the actual path: no "sign in" when already authenticated, and the
+// copy-the-prompt ending when no agent is installed.
+func setupRoadmap(rt *Runtime, agents []agentClient) string {
+	steps := []string{}
+	if rt.Config == nil || rt.Config.BearerToken() == "" {
+		steps = append(steps, "sign in")
+	}
+	steps = append(steps, "pick a project")
+	if len(agents) > 0 {
+		steps = append(steps, "pick an agent", "launch")
+	} else {
+		steps = append(steps, "copy the prompt")
+	}
+	return strings.Join(steps, " → ")
+}
+
 // setupAutonomyAndScope resolves the agent autonomy and skills-install scope from
 // flags (sensible defaults, not prompts), validating the values.
 func setupAutonomyAndScope(cmd *cobra.Command) (autonomy, scope string, err error) {
@@ -158,6 +175,7 @@ func runSetup(cmd *cobra.Command) error {
 	fl := tui.NewFlow(rt.Out.Stderr(), !rt.CanPrompt(), rt.Out.NoColor(), rt.Globals.Quiet)
 	fl.Intro("RevenueCat setup · " + filepath.Base(dir))
 	fl.Say("An AI agent sets up RevenueCat for this app — you approve each step.")
+	fl.Say("Steps: " + setupRoadmap(rt, agents))
 	fl.Receipt("Project", projectLabel)
 	fl.Receipt("Location", collapseHome(dir))
 	if account := setupAccountIdentity(rt); account != "" {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -144,6 +144,9 @@ func runSetup(cmd *cobra.Command) error {
 	fl.Say("An AI agent sets up RevenueCat for this app — you approve each step.")
 	fl.Receipt("Project", projectLabel)
 	fl.Receipt("Location", collapseHome(dir))
+	if account := setupAccountIdentity(rt); account != "" {
+		fl.Receipt("Account", account)
+	}
 	if len(agents) == 0 {
 		fl.Warn("No AI agents found — install Claude Code, Codex, Cursor, or Gemini CLI, or copy the prompt below.")
 	}
@@ -406,6 +409,26 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, fl *tui.Flow, dir stri
 				return false, err
 			}
 		}
+	}
+}
+
+// setupAccountIdentity returns the logged-in account label (name <email>, or
+// whichever is known) for the setup header, or "" when logged out. Mirrors the
+// identity format used by rc auth status.
+func setupAccountIdentity(rt *Runtime) string {
+	if rt.Config == nil || rt.Config.BearerToken() == "" {
+		return ""
+	}
+	email, name := rt.Config.AccountEmail, rt.Config.AccountName
+	switch {
+	case name != "" && email != "":
+		return fmt.Sprintf("%s <%s>", name, email)
+	case email != "":
+		return email
+	case name != "":
+		return name
+	default:
+		return "logged in"
 	}
 }
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 
 	"github.com/revenuecat/cli/internal/api"
@@ -139,6 +140,18 @@ func runSetup(cmd *cobra.Command) error {
 	projectLabel, platform, projStatus, appDirs := detectAppProject(dir)
 	agents := detectAgents()
 
+	// Sign-in is a prerequisite, not a rail step — resolve it (browser login or
+	// signup, each its own sub-command UI) before the guided rail opens, so the
+	// rail is one uninterrupted experience rather than being torn open by another
+	// command's output mid-flow.
+	justAuthed := false
+	if rt.Config == nil || rt.Config.BearerToken() == "" {
+		if err := setupAuthenticate(cmd, rt); err != nil {
+			return err
+		}
+		justAuthed = true
+	}
+
 	fl := tui.NewFlow(rt.Out.Stderr(), !rt.CanPrompt(), rt.Out.NoColor(), rt.Globals.Quiet)
 	fl.Intro("RevenueCat setup · " + filepath.Base(dir))
 	fl.Say("An AI agent sets up RevenueCat for this app — you approve each step.")
@@ -149,14 +162,6 @@ func runSetup(cmd *cobra.Command) error {
 	}
 	if len(agents) == 0 {
 		fl.Warn("No AI agents found — install Claude Code, Codex, Cursor, or Gemini CLI, or copy the prompt below.")
-	}
-
-	justAuthed := false
-	if rt.Config == nil || rt.Config.BearerToken() == "" {
-		if err := setupAuthenticate(cmd, rt, fl); err != nil {
-			return err
-		}
-		justAuthed = true
 	}
 
 	newProjectPending := false
@@ -655,25 +660,30 @@ func setupToolingNote(rt *Runtime) string {
 // setupAuthenticate resolves auth before the terminal is handed to an agent:
 // browser login and signup are human actions, and doing them mid-agent-run
 // means fighting the agent for the terminal.
-func setupAuthenticate(cmd *cobra.Command, rt *Runtime, fl *tui.Flow) error {
-	fl.Step("Sign in")
-	choice, err := fl.Select("You're not logged in — how would you like to sign in?",
-		[]tui.Option{
-			{Label: "Log in (opens your browser)", Value: "login"},
-			{Label: "Create a RevenueCat account", Value: "signup"},
-		})
-	if err != nil {
+func setupAuthenticate(cmd *cobra.Command, rt *Runtime) error {
+	const (
+		optLogin = iota
+		optSignup
+	)
+	choice := optLogin
+	if err := tui.Form(false).
+		Field(huh.NewSelect[int]().
+			Title("You're not logged in — how would you like to sign in?").
+			Options(
+				huh.NewOption("Log in (opens your browser)", optLogin),
+				huh.NewOption("Create a RevenueCat account", optSignup),
+			).
+			Value(&choice)).
+		Run(); err != nil {
 		return err
 	}
-	// Both branches hand off to a sub-command with its own UI (browser OAuth or
-	// the signup form); the rail pauses for it and resumes afterward.
-	if choice == "signup" {
-		fl.Say("Starting signup…")
+	if choice == optSignup {
 		signup := newAuthSignupCmd()
 		signup.SetContext(cmd.Context())
+		// setup owns the post-signup next steps on the rail; suppress signup's own.
+		_ = signup.Flags().Set("from-setup", "true")
 		return signup.RunE(signup, nil)
 	}
-	fl.Say("Opening your browser to sign in…")
 	return loginWithOAuth(cmd.Context(), rt)
 }
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -725,15 +725,18 @@ func setupSignup(cmd *cobra.Command, rt *Runtime, fl *tui.Flow) error {
 			return err
 		}
 	} else {
-		if password, err = fl.Password("Create a password", validateSignupPassword); err != nil {
-			return err
-		}
-		confirm, err := fl.Password("Confirm password", nil)
-		if err != nil {
-			return err
-		}
-		if password != confirm {
-			return errors.New("passwords do not match")
+		for {
+			if password, err = fl.Password("Create a password", validateSignupPassword); err != nil {
+				return err
+			}
+			confirm, cerr := fl.Password("Confirm password", nil)
+			if cerr != nil {
+				return cerr
+			}
+			if password == confirm {
+				break
+			}
+			fl.Warn("Passwords do not match. Try again.")
 		}
 	}
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -6,9 +6,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
-	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 
 	"github.com/revenuecat/cli/internal/api"
@@ -138,17 +138,18 @@ func runSetup(cmd *cobra.Command) error {
 	projectLabel, platform, projStatus, appDirs := detectAppProject(dir)
 	agents := detectAgents()
 
-	rt.Out.Title("RevenueCat setup  ·  " + filepath.Base(dir))
-	rt.Out.Lead("An AI agent sets up RevenueCat for this app — you approve each step.")
-	rt.Out.Field("Project", projectLabel)
-	rt.Out.Field("Location", collapseHome(dir))
+	fl := tui.NewFlow(rt.Out.Stderr(), !rt.CanPrompt(), rt.Out.NoColor(), rt.Globals.Quiet)
+	fl.Intro("RevenueCat setup · " + filepath.Base(dir))
+	fl.Say("An AI agent sets up RevenueCat for this app — you approve each step.")
+	fl.Receipt("Project", projectLabel)
+	fl.Receipt("Location", collapseHome(dir))
 	if len(agents) == 0 {
-		rt.Out.Field("Agents", "none found", "install Claude Code, Codex, Cursor, or Gemini CLI, or copy the prompt below")
+		fl.Warn("No AI agents found — install Claude Code, Codex, Cursor, or Gemini CLI, or copy the prompt below.")
 	}
 
 	justAuthed := false
 	if rt.Config == nil || rt.Config.BearerToken() == "" {
-		if err := setupAuthenticate(cmd, rt); err != nil {
+		if err := setupAuthenticate(cmd, rt, fl); err != nil {
 			return err
 		}
 		justAuthed = true
@@ -157,29 +158,30 @@ func runSetup(cmd *cobra.Command) error {
 	newProjectPending := false
 	if rt.Config != nil && rt.Config.BearerToken() != "" {
 		var err error
-		newProjectPending, err = confirmSetupAccount(cmd, rt, dir, justAuthed)
+		newProjectPending, err = confirmSetupAccount(cmd, rt, fl, dir, justAuthed)
 		if err != nil {
 			return err
 		}
 	}
 
-	rt.Out.Info("Checking where this project stands…")
+	fl.Step("Where this project stands")
+	fl.Say("Checking…")
 	stage := detectSetupStage(cmd, rt, platform)
-	rt.Out.Field("Stage", stage.Label)
+	fl.Receipt("Stage", stage.Label)
 
 	switch projStatus {
 	case projectAmbiguous:
-		rt.Out.Info("Several project markers here — the agent will figure out which app and platform to set up.")
+		fl.Say("Several project markers here — the agent will figure out which app and platform to set up.")
 	case projectNonMobile:
-		rt.Out.Info("This doesn't look like a mobile app — the agent will confirm what needs RevenueCat and pick the platform.")
+		fl.Say("This doesn't look like a mobile app — the agent will confirm what needs RevenueCat and pick the platform.")
 	case projectNone:
-		cont, err := tui.ConfirmDefault(false, "No app project detected in this directory. Set up here anyway?", false)
+		cont, err := fl.Confirm("No app project detected in this directory. Set up here anyway?", false)
 		if err != nil {
 			return err
 		}
 		if !cont {
-			rt.Out.Info("Nothing changed.")
-			rt.Out.Hint("cd into your app's root directory (the one with the Xcode project, package.json, or pubspec.yaml) and run rc setup again")
+			fl.Outro("Nothing changed",
+				"cd into your app's root directory (the one with the Xcode project, package.json, or pubspec.yaml) and run rc setup again.")
 			return nil
 		}
 	}
@@ -188,94 +190,130 @@ func runSetup(cmd *cobra.Command) error {
 	applePending := (platform == "ios" || platform == "cross") &&
 		(stage.PromptID == "test-store-ready" || stage.PromptID == "connect-apple")
 
-	rt.Out.Title("Step 1 · Choose your agent")
-	choice, err := pickSetupAgent(agents)
+	fl.Step("Choose your agent")
+	choice, err := pickSetupAgent(fl, agents)
 	if err != nil {
 		return err
 	}
 	if choice == nil {
-		rt.Out.Answer("Agent", "none — copy the prompt")
-		rt.Out.Blank()
-		rt.Out.Info("Run rc skills install, then paste this into any agent:")
-		rt.Out.Info(setupAgentPrompt(rt, stage, applePending, projStatus, appDirs))
+		fl.Receipt("Agent", "none — copy the prompt")
+		fl.Say("Run rc skills install, then paste this prompt into any agent:")
+		fl.Outro("Copy the prompt below")
+		// The prompt is copyable data — print it raw (no rail gutter) to stdout so
+		// it stays selectable and paste-clean.
+		fmt.Fprintln(cmd.OutOrStdout(), setupAgentPrompt(rt, stage, applePending, projStatus, appDirs))
 		rt.Out.Hint("more starter prompts:  rc skills prompts")
 		return nil
 	}
-	rt.Out.Answer("Agent", choice.Name)
+	fl.Receipt("Agent", choice.Name)
 
-	rt.Out.Title("Step 2 · Autonomy")
-	autonomy := autonomyAuto
-	if err := tui.Form(false).
-		Field(huh.NewSelect[string]().
-			Title("How much can "+choice.Name+" do without stopping to ask?").
-			Description("You can interrupt anytime.").
-			Options(
-				huh.NewOption("Auto — use "+choice.Name+"'s built-in auto-approve mode", autonomyAuto),
-				huh.NewOption("Run freely — no approval prompts", autonomyFull),
-				huh.NewOption("Pre-approve rc, edits, and builds; ask for anything unusual", autonomyTrusted),
-				huh.NewOption("Ask me before each step", autonomyManual),
-			).
-			Value(&autonomy)).
-		Run(); err != nil {
+	fl.Step("Autonomy")
+	autonomy, err := fl.Select("How much can "+choice.Name+" do without stopping to ask?",
+		[]tui.Option{
+			{Label: "Auto — use " + choice.Name + "'s built-in auto-approve mode", Value: autonomyAuto},
+			{Label: "Run freely — no approval prompts", Value: autonomyFull},
+			{Label: "Pre-approve rc, edits, and builds; ask for anything unusual", Value: autonomyTrusted},
+			{Label: "Ask me before each step", Value: autonomyManual},
+		},
+		"You can interrupt anytime.",
+	)
+	if err != nil {
 		return err
 	}
-	rt.Out.Answer("Autonomy", autonomyLabels[autonomy])
+	fl.Receipt("Autonomy", autonomyLabels[autonomy])
 
-	rt.Out.Title("Step 3 · Skills")
-	skillsScope := "project"
-	if err := tui.Form(false).
-		Field(huh.NewSelect[string]().
-			Title("Install the RevenueCat skills here or globally?").
-			Description("Project keeps them with this repo; global shares them across every project on this machine.").
-			Options(
-				huh.NewOption("This project only", "project"),
-				huh.NewOption("Globally (all projects on this machine)", "global"),
-			).
-			Value(&skillsScope)).
-		Run(); err != nil {
+	fl.Step("Skills")
+	skillsScope, err := fl.Select("Install the RevenueCat skills here or globally?",
+		[]tui.Option{
+			{Label: "This project only", Value: "project"},
+			{Label: "Globally (all projects on this machine)", Value: "global"},
+		},
+		"Project keeps them with this repo; global shares them across every project on this machine.",
+	)
+	if err != nil {
 		return err
 	}
-	rt.Out.Answer("Skills", skillsScopeLabels[skillsScope])
+	fl.Receipt("Skills", skillsScopeLabels[skillsScope])
 
 	// Apple needs a browser + 2FA; setup always defers it to the agent hand-back.
 	appleDeferred := applePending
-
 	prompt := setupAgentPrompt(rt, stage, appleDeferred, projStatus, appDirs)
 
-	rt.Out.Plan([]string{
-		"Install the RevenueCat AI Toolkit skills for " + choice.Name,
-		"Configure the RevenueCat MCP for " + choice.Name,
-		"Launch " + choice.Name + " to build your Test Store catalog, paywall, and SDK integration",
-	})
+	fl.Step("Ready to launch " + choice.Name)
+	fl.Item("Install the RevenueCat AI Toolkit skills for " + choice.Name)
+	fl.Item("Configure the RevenueCat MCP for " + choice.Name)
+	fl.Item("Launch " + choice.Name + " to build your Test Store catalog, paywall, and SDK integration")
 	if appleDeferred {
-		rt.Out.Info("Apple is deferred — the agent finishes everything that doesn't need it, then hands you the exact commands to connect App Store Connect when you're ready to ship.")
+		fl.Say("Apple is deferred — the agent finishes everything that doesn't need it, then hands you the exact commands to connect App Store Connect when you're ready to ship.")
 	}
-	if err := confirmOrAbort(rt, "Launch "+choice.Name+" now?"); err != nil {
-		return err
+	ok := rt.Globals.AssumeYes // --yes skips the final launch gate, as before
+	if !ok {
+		ok, err = fl.Confirm("Launch "+choice.Name+" now?", true)
+		if err != nil {
+			return err
+		}
+	}
+	if !ok {
+		fl.Outro("Cancelled — nothing was changed")
+		return nil
 	}
 
 	// deferred to here so canceling setup above doesn't wipe the active project
 	if newProjectPending {
 		if err := config.Save(rt.Globals.Profile, rt.Config); err != nil {
-			rt.Out.Warn("Couldn't save the cleared project to your profile: " + err.Error())
+			fl.Warn("Couldn't save the cleared project to your profile: " + err.Error())
 		}
 	}
 
-	rt.Out.Info("Installing the RevenueCat AI Toolkit skills…")
 	toolkitSource := officialToolkitSource
 	if branch := os.Getenv("RC_SKILLS_BRANCH"); branch != "" {
 		toolkitSource = "https://github.com/RevenueCat/ai-toolkit/tree/" + branch
-		rt.Out.Info("Using toolkit branch " + branch + " (RC_SKILLS_BRANCH)")
+		fl.Say("Using toolkit branch " + branch + " (RC_SKILLS_BRANCH)")
 	}
+
+	fl.Step("Setting up")
+	led := fl.Ledger(
+		"Install the RevenueCat skills",
+		"Configure the RevenueCat MCP for "+choice.Name,
+	)
+	led.Start()
+	led.Running(0)
+	if err := installSetupSkills(cmd, choice, skillsScope, toolkitSource); err != nil {
+		led.Fail(0, "failed")
+		led.Stop()
+		return err
+	}
+	led.Done(0, "")
+	led.Running(1)
+	mcp := configureAgentMCP(cmd, rt, choice)
+	if mcp.warn != "" {
+		led.Fail(1, "not configured")
+	} else {
+		led.Done(1, mcp.note)
+	}
+	led.Stop()
+	if mcp.warn != "" {
+		fl.Warn(mcp.warn)
+	}
+	if mcp.hint != "" {
+		fl.Hint(mcp.hint)
+	}
+
+	fl.Outro("Launching " + choice.Name + " …")
+	agent := exec.CommandContext(cmd.Context(), choice.Binary, choice.LaunchArgs(prompt, autonomy)...)
+	agent.Stdin, agent.Stdout, agent.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return agent.Run()
+}
+
+// installSetupSkills runs the toolkit install silently — setup owns the
+// questions, so the skills CLI's own UI appears only on failure (via the error).
+func installSetupSkills(cmd *cobra.Command, choice *agentClient, skillsScope, toolkitSource string) error {
 	installArgs := []string{"--yes", "skills", "add", toolkitSource, "--agent", choice.ToolkitKey}
 	if skillsScope == "global" {
 		installArgs = append(installArgs, "--global")
 	}
 	installArgs = append(installArgs, "--skill")
 	installArgs = append(installArgs, defaultToolkitSkills...)
-	// The skills CLI is a whole guided UI of its own; inside setup it runs
-	// silently — our flow owns the questions, its output appears only on
-	// failure.
 	npxPath, err := exec.LookPath("npx")
 	if err != nil {
 		return fmt.Errorf("npx is required to install the RevenueCat AI Toolkit: %w", err)
@@ -288,15 +326,7 @@ func runSetup(cmd *cobra.Command) error {
 		}
 		return fmt.Errorf("install skills: %w\n%s", err, strings.TrimSpace(tail))
 	}
-	rt.Out.Info("Skills installed")
-
-	configureAgentMCP(cmd, rt, choice)
-
-	rt.Out.Info("Launching " + choice.Name + "…")
-	rt.Out.Blank()
-	agent := exec.CommandContext(cmd.Context(), choice.Binary, choice.LaunchArgs(prompt, autonomy)...)
-	agent.Stdin, agent.Stdout, agent.Stderr = os.Stdin, os.Stdout, os.Stderr
-	return agent.Run()
+	return nil
 }
 
 var autonomyLabels = map[string]string{
@@ -313,59 +343,59 @@ var skillsScopeLabels = map[string]string{
 
 // confirmSetupAccount confirms the account and picks the project for this app,
 // defaulting a new app to a fresh project rather than the active one.
-func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, dir string, justAuthed bool) (newProjectPending bool, err error) {
-	const (
-		optNewProject = iota
-		optExistingProject
-		optSwitchAccount
-		optContinue
-	)
+func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, fl *tui.Flow, dir string, justAuthed bool) (newProjectPending bool, err error) {
+	fl.Step("Project")
 	for {
 		active := rt.Config != nil && rt.Config.ProjectID != ""
+		activeLbl := ""
 		title := "Create a new RevenueCat project for " + filepath.Base(dir) + "?"
-		opts := []huh.Option[int]{
-			huh.NewOption("Yes — new project", optNewProject),
-			huh.NewOption("Use an existing project", optExistingProject),
+		opts := []tui.Option{
+			{Label: "Yes — new project", Value: "new"},
+			{Label: "Use an existing project", Value: "existing"},
 		}
-		choice := optNewProject
 		if active {
-			// New stays the default: the active project is profile-global, not this dir's
+			// New stays first: the active project is profile-global, not this dir's.
+			activeLbl = activeProjectLabel(cmd, rt)
 			title = "Set up " + filepath.Base(dir) + " — new project, or continue an existing one?"
-			opts = []huh.Option[int]{
-				huh.NewOption("New project for "+filepath.Base(dir), optNewProject),
-				huh.NewOption("Continue with "+activeProjectLabel(cmd, rt), optContinue),
-				huh.NewOption("Use a different project", optExistingProject),
+			opts = []tui.Option{
+				{Label: "New project for " + filepath.Base(dir), Value: "new"},
+				{Label: "Continue with " + activeLbl, Value: "continue"},
+				{Label: "Use a different project", Value: "existing"},
 			}
 		}
 		// Switching accounts only makes sense if we didn't just log them in.
 		if !justAuthed {
-			opts = append(opts, huh.NewOption("Switch account", optSwitchAccount))
+			opts = append(opts, tui.Option{Label: "Switch account", Value: "switch"})
 		}
-		if err := tui.Form(false).
-			Field(huh.NewSelect[int]().Title(title).Options(opts...).Value(&choice)).
-			Run(); err != nil {
+		choice, err := fl.Select(title, opts)
+		if err != nil {
 			return false, err
 		}
 
 		switch choice {
-		case optContinue:
+		case "continue":
+			fl.Receipt("Project", activeLbl)
 			return false, nil
-		case optNewProject:
+		case "new":
 			// persisted after launch is confirmed, not here
 			rt.Config.ProjectID = ""
+			fl.Receipt("Project", "new project for "+filepath.Base(dir))
 			return true, nil
-		case optExistingProject:
+		case "existing":
+			// The project picker is its own command with its own UI — the rail
+			// pauses for it, then resumes with the chosen project.
 			use, _, err := cmd.Root().Find([]string{"projects", "use"})
 			if err != nil || use == nil {
 				return false, fmt.Errorf("couldn't open the project picker — run `rc projects use`, then rerun setup")
 			}
 			use.SetContext(cmd.Context())
 			if err := use.RunE(use, nil); err != nil {
-				rt.Out.Warn("Project not changed: " + err.Error())
+				fl.Warn("Project not changed: " + err.Error())
 				continue
 			}
+			fl.Receipt("Project", activeProjectLabel(cmd, rt))
 			return false, nil
-		case optSwitchAccount:
+		case "switch":
 			rt.Config.AccountEmail = ""
 			rt.Config.AccountName = ""
 			if err := loginWithOAuth(cmd.Context(), rt); err != nil {
@@ -598,24 +628,19 @@ func setupToolingNote(rt *Runtime) string {
 // setupAuthenticate resolves auth before the terminal is handed to an agent:
 // browser login and signup are human actions, and doing them mid-agent-run
 // means fighting the agent for the terminal.
-func setupAuthenticate(cmd *cobra.Command, rt *Runtime) error {
-	const (
-		optLogin = iota
-		optSignup
-	)
-	choice := optLogin
-	if err := tui.Form(false).
-		Field(huh.NewSelect[int]().
-			Title("You're not logged in — how would you like to sign in?").
-			Options(
-				huh.NewOption("Log in (opens your browser)", optLogin),
-				huh.NewOption("Create a RevenueCat account", optSignup),
-			).
-			Value(&choice)).
-		Run(); err != nil {
+func setupAuthenticate(cmd *cobra.Command, rt *Runtime, fl *tui.Flow) error {
+	fl.Step("Sign in")
+	choice, err := fl.Select("You're not logged in — how would you like to sign in?",
+		[]tui.Option{
+			{Label: "Log in (opens your browser)", Value: "login"},
+			{Label: "Create a RevenueCat account", Value: "signup"},
+		})
+	if err != nil {
 		return err
 	}
-	if choice == optSignup {
+	// Both branches hand off to a sub-command with its own UI (browser OAuth or
+	// the signup form); the rail pauses for it and resumes afterward.
+	if choice == "signup" {
 		signup := newAuthSignupCmd()
 		signup.SetContext(cmd.Context())
 		return signup.RunE(signup, nil)
@@ -632,25 +657,21 @@ func starterPromptByID(id string) string {
 	return "Use the create-revenuecat-project skill to set up RevenueCat for the app in this directory."
 }
 
-func pickSetupAgent(agents []agentClient) (*agentClient, error) {
-	options := make([]huh.Option[int], 0, len(agents)+1)
+func pickSetupAgent(fl *tui.Flow, agents []agentClient) (*agentClient, error) {
+	opts := make([]tui.Option, 0, len(agents)+1)
 	for i, a := range agents {
-		options = append(options, huh.NewOption(a.Name, i))
+		opts = append(opts, tui.Option{Label: a.Name, Value: strconv.Itoa(i)})
 	}
-	options = append(options, huh.NewOption("None — just show me the prompt", -1))
-	selected := 0
-	if len(agents) == 0 {
-		selected = -1
-	}
-	if err := tui.Form(false).
-		Field(huh.NewSelect[int]().Title("Which agent should run the setup?").Options(options...).Value(&selected)).
-		Run(); err != nil {
+	opts = append(opts, tui.Option{Label: "None — just show me the prompt", Value: "-1"})
+	choice, err := fl.Select("Which agent should run the setup?", opts)
+	if err != nil {
 		return nil, err
 	}
-	if selected < 0 {
+	idx, _ := strconv.Atoi(choice)
+	if idx < 0 {
 		return nil, nil
 	}
-	return &agents[selected], nil
+	return &agents[idx], nil
 }
 
 func detectAgents() []agentClient {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -190,15 +191,20 @@ func runSetup(cmd *cobra.Command) error {
 	applePending := (platform == "ios" || platform == "cross") &&
 		(stage.PromptID == "test-store-ready" || stage.PromptID == "connect-apple")
 
-	fl.Step("Choose your agent")
-	choice, err := pickSetupAgent(fl, agents)
-	if err != nil {
-		return err
+	// With no agent installed there's nothing to pick — skip straight to the
+	// copyable prompt rather than showing a one-option picker.
+	var choice *agentClient
+	if len(agents) > 0 {
+		fl.Step("Choose your agent")
+		choice, err = pickSetupAgent(fl, agents)
+		if err != nil {
+			return err
+		}
 	}
 	if choice == nil {
-		fl.Receipt("Agent", "none — copy the prompt")
+		fl.Step("Copy the prompt")
 		fl.Say("Run rc skills install, then paste this prompt into any agent:")
-		fl.Outro("Copy the prompt below")
+		fl.Outro("Prompt below")
 		// The prompt is copyable data — print it raw (no rail gutter) to stdout so
 		// it stays selectable and paste-clean.
 		fmt.Fprintln(cmd.OutOrStdout(), setupAgentPrompt(rt, stage, applePending, projStatus, appDirs))
@@ -254,8 +260,7 @@ func runSetup(cmd *cobra.Command) error {
 		}
 	}
 	if !ok {
-		fl.Outro("Cancelled — nothing was changed")
-		return nil
+		return errors.New("cancelled")
 	}
 
 	// deferred to here so canceling setup above doesn't wipe the active project
@@ -272,10 +277,7 @@ func runSetup(cmd *cobra.Command) error {
 	}
 
 	fl.Step("Setting up")
-	led := fl.Ledger(
-		"Install the RevenueCat skills",
-		"Configure the RevenueCat MCP for "+choice.Name,
-	)
+	led := fl.Ledger("Install the RevenueCat skills")
 	led.Start()
 	led.Running(0)
 	if err := installSetupSkills(cmd, choice, skillsScope, toolkitSource); err != nil {
@@ -284,16 +286,17 @@ func runSetup(cmd *cobra.Command) error {
 		return err
 	}
 	led.Done(0, "")
-	led.Running(1)
-	mcp := configureAgentMCP(cmd, rt, choice)
-	if mcp.warn != "" {
-		led.Fail(1, "not configured")
-	} else {
-		led.Done(1, mcp.note)
-	}
 	led.Stop()
-	if mcp.warn != "" {
+
+	// MCP config isn't a clean pass/fail — it can succeed, be left alone (custom
+	// entry), or need a manual step (agents rc can't configure) — so it's narrated
+	// rather than shown as a ledger ✓/✗ that would over- or under-state it.
+	mcp := configureAgentMCP(cmd, rt, choice)
+	switch {
+	case mcp.warn != "":
 		fl.Warn(mcp.warn)
+	case mcp.note != "":
+		fl.Say("RevenueCat MCP · " + mcp.note)
 	}
 	if mcp.hint != "" {
 		fl.Hint(mcp.hint)
@@ -389,6 +392,7 @@ func confirmSetupAccount(cmd *cobra.Command, rt *Runtime, fl *tui.Flow, dir stri
 				return false, fmt.Errorf("couldn't open the project picker — run `rc projects use`, then rerun setup")
 			}
 			use.SetContext(cmd.Context())
+			fl.Say("Opening the project picker…")
 			if err := use.RunE(use, nil); err != nil {
 				fl.Warn("Project not changed: " + err.Error())
 				continue
@@ -641,10 +645,12 @@ func setupAuthenticate(cmd *cobra.Command, rt *Runtime, fl *tui.Flow) error {
 	// Both branches hand off to a sub-command with its own UI (browser OAuth or
 	// the signup form); the rail pauses for it and resumes afterward.
 	if choice == "signup" {
+		fl.Say("Starting signup…")
 		signup := newAuthSignupCmd()
 		signup.SetContext(cmd.Context())
 		return signup.RunE(signup, nil)
 	}
+	fl.Say("Opening your browser to sign in…")
 	return loginWithOAuth(cmd.Context(), rt)
 }
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -668,18 +668,89 @@ func setupAuthenticate(cmd *cobra.Command, rt *Runtime, fl *tui.Flow) error {
 	if err != nil {
 		return err
 	}
-	// Both branches hand off to a sub-command with its own UI (browser OAuth or
-	// the signup form), so the rail pauses for it and resumes afterward.
 	if choice == "signup" {
-		fl.Say("Starting signup — follow the prompts below.")
-		signup := newAuthSignupCmd()
-		signup.SetContext(cmd.Context())
-		// setup owns the post-signup next steps on the rail; suppress signup's own.
-		_ = signup.Flags().Set("from-setup", "true")
-		return signup.RunE(signup, nil)
+		return setupSignup(cmd, rt, fl)
 	}
+	// Login is a browser handoff — the interactive part is the browser, so there's
+	// no form to render; a short narration around it is enough.
 	fl.Say("Opening your browser to sign in…")
 	return loginWithOAuth(cmd.Context(), rt)
+}
+
+// setupSignup collects account details on the rail (rather than delegating to
+// rc auth signup, which draws its own off-rail UI) and creates the account under
+// a ledger step, so signup stays inside the guided experience.
+func setupSignup(cmd *cobra.Command, rt *Runtime, fl *tui.Flow) error {
+	email, err := fl.Input("Email", "you@example.com", tui.Required("email"))
+	if err != nil {
+		return err
+	}
+	name, err := fl.Input("Your name", "", tui.Required("name"),
+		"Your personal/display name — project naming comes later.")
+	if err != nil {
+		return err
+	}
+	marketing, err := fl.Confirm("Receive RevenueCat product updates?", false)
+	if err != nil {
+		return err
+	}
+
+	mode, err := fl.Select("Account password",
+		[]tui.Option{
+			{Label: "Generate a strong random password", Value: "generate"},
+			{Label: "Create my own", Value: "create"},
+		})
+	if err != nil {
+		return err
+	}
+	var password string
+	generated := mode == "generate"
+	if generated {
+		if password, err = generateSignupPassword(); err != nil {
+			return err
+		}
+	} else {
+		if password, err = fl.Password("Create a password", validateSignupPassword); err != nil {
+			return err
+		}
+		confirm, err := fl.Password("Confirm password", nil)
+		if err != nil {
+			return err
+		}
+		if password != confirm {
+			return errors.New("passwords do not match")
+		}
+	}
+
+	savePassword := false
+	if runtime.GOOS == "darwin" {
+		if savePassword, err = fl.Confirm("Save the password to your macOS Keychain?", true); err != nil {
+			return err
+		}
+	}
+
+	fl.Say("Terms: https://www.revenuecat.com/terms · Privacy: https://www.revenuecat.com/privacy")
+	accepted, err := fl.Confirm("Accept the Terms of Service and Privacy Policy?", true)
+	if err != nil {
+		return err
+	}
+	if !accepted {
+		return errors.New("signup requires accepting the Terms of Service and Privacy Policy")
+	}
+
+	fl.Step("Creating your account")
+	led := fl.Ledger("Create account & sign in")
+	led.Start()
+	led.Running(0)
+	if err := signupWithOAuth(cmd.Context(), rt, email, name, password, marketing, savePassword, generated, true); err != nil {
+		led.Fail(0, "failed")
+		led.Stop()
+		return err
+	}
+	led.Done(0, "")
+	led.Stop()
+	fl.Say("Check your email to verify the account.")
+	return nil
 }
 
 func starterPromptByID(id string) string {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 
 	"github.com/revenuecat/cli/internal/api"
@@ -140,18 +139,6 @@ func runSetup(cmd *cobra.Command) error {
 	projectLabel, platform, projStatus, appDirs := detectAppProject(dir)
 	agents := detectAgents()
 
-	// Sign-in is a prerequisite, not a rail step — resolve it (browser login or
-	// signup, each its own sub-command UI) before the guided rail opens, so the
-	// rail is one uninterrupted experience rather than being torn open by another
-	// command's output mid-flow.
-	justAuthed := false
-	if rt.Config == nil || rt.Config.BearerToken() == "" {
-		if err := setupAuthenticate(cmd, rt); err != nil {
-			return err
-		}
-		justAuthed = true
-	}
-
 	fl := tui.NewFlow(rt.Out.Stderr(), !rt.CanPrompt(), rt.Out.NoColor(), rt.Globals.Quiet)
 	fl.Intro("RevenueCat setup · " + filepath.Base(dir))
 	fl.Say("An AI agent sets up RevenueCat for this app — you approve each step.")
@@ -162,6 +149,17 @@ func runSetup(cmd *cobra.Command) error {
 	}
 	if len(agents) == 0 {
 		fl.Warn("No AI agents found — install Claude Code, Codex, Cursor, or Gemini CLI, or copy the prompt below.")
+	}
+
+	justAuthed := false
+	if rt.Config == nil || rt.Config.BearerToken() == "" {
+		if err := setupAuthenticate(cmd, rt, fl); err != nil {
+			return err
+		}
+		justAuthed = true
+		if account := setupAccountIdentity(rt); account != "" {
+			fl.Receipt("Signed in", account)
+		}
 	}
 
 	newProjectPending := false
@@ -660,30 +658,27 @@ func setupToolingNote(rt *Runtime) string {
 // setupAuthenticate resolves auth before the terminal is handed to an agent:
 // browser login and signup are human actions, and doing them mid-agent-run
 // means fighting the agent for the terminal.
-func setupAuthenticate(cmd *cobra.Command, rt *Runtime) error {
-	const (
-		optLogin = iota
-		optSignup
-	)
-	choice := optLogin
-	if err := tui.Form(false).
-		Field(huh.NewSelect[int]().
-			Title("You're not logged in — how would you like to sign in?").
-			Options(
-				huh.NewOption("Log in (opens your browser)", optLogin),
-				huh.NewOption("Create a RevenueCat account", optSignup),
-			).
-			Value(&choice)).
-		Run(); err != nil {
+func setupAuthenticate(cmd *cobra.Command, rt *Runtime, fl *tui.Flow) error {
+	fl.Step("Sign in")
+	choice, err := fl.Select("You're not logged in — how would you like to sign in?",
+		[]tui.Option{
+			{Label: "Log in (opens your browser)", Value: "login"},
+			{Label: "Create a RevenueCat account", Value: "signup"},
+		})
+	if err != nil {
 		return err
 	}
-	if choice == optSignup {
+	// Both branches hand off to a sub-command with its own UI (browser OAuth or
+	// the signup form), so the rail pauses for it and resumes afterward.
+	if choice == "signup" {
+		fl.Say("Starting signup — follow the prompts below.")
 		signup := newAuthSignupCmd()
 		signup.SetContext(cmd.Context())
 		// setup owns the post-signup next steps on the rail; suppress signup's own.
 		_ = signup.Flags().Set("from-setup", "true")
 		return signup.RunE(signup, nil)
 	}
+	fl.Say("Opening your browser to sign in…")
 	return loginWithOAuth(cmd.Context(), rt)
 }
 

--- a/internal/cli/setup_oneshot.go
+++ b/internal/cli/setup_oneshot.go
@@ -47,19 +47,18 @@ func firstBundleID(path string, pattern *regexp.Regexp) string {
 	return ""
 }
 
-// configureAgentMCP registers the RevenueCat MCP server for the chosen agent
-// with the CLI's credential, so the agent has authenticated MCP access from
-// its first turn. mcp.revenuecat.ai accepts both OAuth tokens and v2 secret
-// API keys as Bearer credentials.
 // mcpResult reports how MCP configuration went so the caller can render it on
-// the rail: note is a short status for the ledger step, hint is optional
-// follow-up guidance, and warn is set (non-fatal) when configuration failed.
+// the rail; warn is set (non-fatal) when configuration failed.
 type mcpResult struct {
 	note string
 	hint string
 	warn string
 }
 
+// configureAgentMCP registers the RevenueCat MCP server for the chosen agent
+// with the CLI's credential, so the agent has authenticated MCP access from
+// its first turn. mcp.revenuecat.ai accepts both OAuth tokens and v2 secret
+// API keys as Bearer credentials.
 func configureAgentMCP(cmd *cobra.Command, rt *Runtime, agent *agentClient) mcpResult {
 	token := ""
 	if rt.Config != nil {

--- a/internal/cli/setup_oneshot.go
+++ b/internal/cli/setup_oneshot.go
@@ -51,7 +51,16 @@ func firstBundleID(path string, pattern *regexp.Regexp) string {
 // with the CLI's credential, so the agent has authenticated MCP access from
 // its first turn. mcp.revenuecat.ai accepts both OAuth tokens and v2 secret
 // API keys as Bearer credentials.
-func configureAgentMCP(cmd *cobra.Command, rt *Runtime, agent *agentClient) {
+// mcpResult reports how MCP configuration went so the caller can render it on
+// the rail: note is a short status for the ledger step, hint is optional
+// follow-up guidance, and warn is set (non-fatal) when configuration failed.
+type mcpResult struct {
+	note string
+	hint string
+	warn string
+}
+
+func configureAgentMCP(cmd *cobra.Command, rt *Runtime, agent *agentClient) mcpResult {
 	token := ""
 	if rt.Config != nil {
 		token = rt.Config.BearerToken()
@@ -66,8 +75,7 @@ func configureAgentMCP(cmd *cobra.Command, rt *Runtime, agent *agentClient) {
 		if strings.Contains(string(existing), "mcp.revenuecat.ai") {
 			_ = exec.CommandContext(cmd.Context(), "claude", "mcp", "remove", "--scope", "user", "RevenueCat").Run()
 		} else if strings.Contains(string(existing), "http") {
-			rt.Out.Info("A RevenueCat MCP entry with a custom URL already exists in Claude Code — leaving it untouched")
-			return
+			return mcpResult{note: "left your custom entry untouched"}
 		}
 		args := []string{"mcp", "add", "--scope", "user", "--transport", "http", "RevenueCat", revenueCatMCPURL}
 		if token != "" {
@@ -75,27 +83,22 @@ func configureAgentMCP(cmd *cobra.Command, rt *Runtime, agent *agentClient) {
 		}
 		run := exec.CommandContext(cmd.Context(), "claude", args...)
 		if out, err := run.CombinedOutput(); err != nil {
-			rt.Out.Warn("Couldn't configure the RevenueCat MCP for Claude Code: " + strings.TrimSpace(string(out)))
-			return
+			return mcpResult{warn: "Couldn't configure the RevenueCat MCP for Claude Code: " + strings.TrimSpace(string(out))}
 		}
-		rt.Out.Info("RevenueCat MCP configured for Claude Code (authenticated with your rc credential)")
+		return mcpResult{note: "authenticated with your rc credential"}
 	case "codex":
 		// Codex owns its own OAuth store, so registration and auth are
 		// separate: register if missing, then hint login only when needed.
 		list, _ := exec.CommandContext(cmd.Context(), "codex", "mcp", "list").CombinedOutput()
 		if strings.Contains(string(list), "RevenueCat") {
-			rt.Out.Info("RevenueCat MCP already registered for Codex")
-			rt.Out.Hint("if it shows as not logged in:  codex mcp login RevenueCat")
-			return
+			return mcpResult{note: "already registered", hint: "if it shows as not logged in:  codex mcp login RevenueCat"}
 		}
 		run := exec.CommandContext(cmd.Context(), "codex", "mcp", "add", "RevenueCat", "--url", revenueCatMCPURL)
 		if out, err := run.CombinedOutput(); err != nil {
-			rt.Out.Warn("Couldn't register the RevenueCat MCP for Codex: " + strings.TrimSpace(string(out)))
-			return
+			return mcpResult{warn: "Couldn't register the RevenueCat MCP for Codex: " + strings.TrimSpace(string(out))}
 		}
-		rt.Out.Info("RevenueCat MCP registered for Codex")
-		rt.Out.Hint("authenticate it once with:  codex mcp login RevenueCat")
+		return mcpResult{note: "registered", hint: "authenticate it once with:  codex mcp login RevenueCat"}
 	default:
-		rt.Out.Hint("connect the RevenueCat MCP in " + agent.Name + " settings:  " + revenueCatMCPURL)
+		return mcpResult{note: "connect it manually", hint: "connect the RevenueCat MCP in " + agent.Name + " settings:  " + revenueCatMCPURL}
 	}
 }

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -22,8 +22,10 @@ const (
 var defaultToolkitSkills = []string{
 	"create-revenuecat-project",
 	"integrate-revenuecat",
+	"revenuecat-cli",
 	"revenuecat-paywall",
 	"revenuecat-store-state",
+	"revenuecat-status",
 }
 
 var defaultToolkitAgents = []string{
@@ -257,7 +259,7 @@ func newSkillsInstallCmd(installer skillsInstaller) *cobra.Command {
 The standard Skills CLI detects supported agents and owns installation paths,
 lock files, security review, and updates. This command does not vendor or cache
 a separate copy of the toolkit inside rc. Pass --project to install into the
-current repository instead. The default installs the four skills needed for
+current repository instead. The default installs the core skills needed for
 complete project setup for RevenueCat's supported agent clients—Claude Code,
 Codex, Cursor, Gemini CLI, and GitHub Copilot/VS Code—without opening the
 underlying agent or skill pickers. Pass --agent to override the targets or

--- a/internal/tui/flow.go
+++ b/internal/tui/flow.go
@@ -25,6 +25,7 @@ type Flow struct {
 	plain   bool
 	noColor bool
 	quiet   bool
+	in      io.Reader // nil = the real terminal (os.Stdin); set by tests to script prompts
 }
 
 func NewFlow(w io.Writer, plain, noColor, quiet bool) *Flow {

--- a/internal/tui/flow.go
+++ b/internal/tui/flow.go
@@ -81,6 +81,10 @@ func (f *Flow) Receipt(key, value string) {
 
 func (f *Flow) Warn(line string) { f.body(prWarnSty.Render("! " + line)) }
 
+// Hint prints a dim guidance line on the rail (rail-native equivalent of
+// Renderer.Hint, so hints stay on the gutter mid-flow).
+func (f *Flow) Hint(line string) { f.body(prDimSty.Render("→ " + line)) }
+
 func (f *Flow) Outro(title string, extras ...string) {
 	if f.quiet {
 		return

--- a/internal/tui/flow_test.go
+++ b/internal/tui/flow_test.go
@@ -1,0 +1,102 @@
+package tui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// asciiProfile makes lipgloss emit no ANSI so rendered output is deterministic
+// to assert on.
+func asciiProfile(t *testing.T) {
+	t.Helper()
+	lipgloss.SetColorProfile(termenv.Ascii)
+}
+
+// TestFlowStaysOnTheGutter is the guard against the "rail disappears" class of
+// regression: every line the Flow emits between the intro and outro must carry a
+// rail marker (┌ │ ◇ └) or be an outro extra, never a bare off-rail line.
+func TestFlowStaysOnTheGutter(t *testing.T) {
+	asciiProfile(t)
+	var buf bytes.Buffer
+	fl := &Flow{w: &buf}
+	fl.Intro("Setup")
+	fl.Say("lead line")
+	fl.Receipt("Project", "Moodly")
+	fl.Item("a bullet")
+	fl.Step("Sign in")
+	fl.Warn("careful")
+	fl.Hint("try this")
+	fl.Outro("Done", "one more thing")
+
+	out := buf.String()
+	for _, want := range []string{"┌  Setup", "◇  Sign in", "└  Done"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		onRail := false
+		for _, p := range []string{"┌", "│", "◇", "└", " "} { // glyphs, gutter, or outro-extra indent
+			if strings.HasPrefix(line, p) {
+				onRail = true
+				break
+			}
+		}
+		if !onRail {
+			t.Errorf("line is off the gutter: %q\nfull:\n%s", line, out)
+		}
+	}
+}
+
+func TestFlowQuietSuppressesEverything(t *testing.T) {
+	asciiProfile(t)
+	var buf bytes.Buffer
+	fl := &Flow{w: &buf, quiet: true}
+	fl.Intro("Setup")
+	fl.Say("lead")
+	fl.Step("Sign in")
+	fl.Receipt("Project", "Moodly")
+	fl.Warn("careful")
+	fl.Outro("Done")
+	if buf.Len() != 0 {
+		t.Errorf("quiet flow should emit nothing, got:\n%q", buf.String())
+	}
+}
+
+func TestFlowPlainDropsGlyphs(t *testing.T) {
+	asciiProfile(t)
+	var buf bytes.Buffer
+	fl := &Flow{w: &buf, plain: true}
+	fl.Intro("Setup")
+	fl.Step("Sign in")
+	out := buf.String()
+	for _, glyph := range []string{"┌", "│", "◇", "└"} {
+		if strings.Contains(out, glyph) {
+			t.Errorf("plain mode should drop %q, got:\n%s", glyph, out)
+		}
+	}
+	if !strings.Contains(out, "Setup") || !strings.Contains(out, "Sign in") {
+		t.Errorf("plain mode should still print the text, got:\n%s", out)
+	}
+}
+
+func TestFlowURLHonorsNoColor(t *testing.T) {
+	asciiProfile(t)
+	const url = "https://example.com/x"
+	// noColor: raw URL, no OSC 8 hyperlink escape.
+	var nc bytes.Buffer
+	(&Flow{w: &nc, noColor: true}).URL(url)
+	if strings.Contains(nc.String(), "\x1b]8;") {
+		t.Errorf("no-color URL must not emit an OSC 8 escape, got:\n%q", nc.String())
+	}
+	if !strings.Contains(nc.String(), url) {
+		t.Errorf("URL text missing:\n%q", nc.String())
+	}
+}

--- a/internal/tui/prompt_rail.go
+++ b/internal/tui/prompt_rail.go
@@ -46,7 +46,7 @@ func (f *Flow) Confirm(question string, def bool) (bool, error) {
 	if f.plain {
 		return def, nil
 	}
-	m, err := runRailPrompt(f.w, confirmModel{title: question, yes: def})
+	m, err := runRailPrompt(f.w, f.in, confirmModel{title: question, yes: def})
 	if err != nil {
 		return false, err
 	}
@@ -64,7 +64,7 @@ func (f *Flow) Select(title string, opts []Option, desc ...string) (string, erro
 	if len(opts) == 0 {
 		return "", errors.New("no options to choose from")
 	}
-	m, err := runRailPrompt(f.w, selectModel{title: title, desc: desc, opts: opts})
+	m, err := runRailPrompt(f.w, f.in, selectModel{title: title, desc: desc, opts: opts})
 	if err != nil {
 		return "", err
 	}
@@ -83,7 +83,7 @@ func (f *Flow) Input(title, placeholder string, validate func(string) error, des
 	ti := textinput.New()
 	ti.Placeholder = placeholder
 	ti.Focus()
-	m, err := runRailPrompt(f.w, inputModel{title: title, desc: desc, ti: ti, validate: validate})
+	m, err := runRailPrompt(f.w, f.in, inputModel{title: title, desc: desc, ti: ti, validate: validate})
 	if err != nil {
 		return "", err
 	}
@@ -103,7 +103,7 @@ func (f *Flow) Password(title string, validate func(string) error, desc ...strin
 	ti := textinput.New()
 	ti.EchoMode = textinput.EchoPassword
 	ti.Focus()
-	m, err := runRailPrompt(f.w, inputModel{title: title, desc: desc, ti: ti, validate: validate, masked: true})
+	m, err := runRailPrompt(f.w, f.in, inputModel{title: title, desc: desc, ti: ti, validate: validate, masked: true})
 	if err != nil {
 		return "", err
 	}
@@ -115,8 +115,12 @@ func (f *Flow) Password(title string, validate func(string) error, desc ...strin
 	return im.ti.Value(), nil
 }
 
-func runRailPrompt(w io.Writer, m tea.Model) (tea.Model, error) {
-	return tea.NewProgram(m, tea.WithOutput(w)).Run()
+func runRailPrompt(w io.Writer, in io.Reader, m tea.Model) (tea.Model, error) {
+	opts := []tea.ProgramOption{tea.WithOutput(w)}
+	if in != nil {
+		opts = append(opts, tea.WithInput(in))
+	}
+	return tea.NewProgram(m, opts...).Run()
 }
 
 // ---- confirm ----

--- a/internal/tui/prompt_rail_test.go
+++ b/internal/tui/prompt_rail_test.go
@@ -1,0 +1,115 @@
+package tui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+// railPrompt runs one rail prompt with scripted keystrokes, guarding against a
+// hang, and returns the rendered output for gutter assertions. keys uses raw
+// terminal input: "\x1b[B" = down arrow, "\r" = enter, "\x03" = ctrl-c.
+func railPrompt(t *testing.T, keys string, fn func(fl *Flow) error) string {
+	t.Helper()
+	asciiProfile(t)
+	var buf bytes.Buffer
+	fl := &Flow{w: &buf, in: strings.NewReader(keys)}
+	done := make(chan error, 1)
+	go func() { done <- fn(fl) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("scripted prompt: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("scripted rail prompt hung")
+	}
+	return buf.String()
+}
+
+func assertGutter(t *testing.T, out string) {
+	t.Helper()
+	if !strings.Contains(out, "│") {
+		t.Errorf("prompt output is not on the rail gutter:\n%q", out)
+	}
+}
+
+func TestRailSelectScripted(t *testing.T) {
+	opts := []Option{{Label: "alpha", Value: "a"}, {Label: "beta", Value: "b"}, {Label: "gamma", Value: "c"}}
+	var got string
+	out := railPrompt(t, "\r", func(fl *Flow) error {
+		v, err := fl.Select("Pick", opts)
+		got = v
+		return err
+	})
+	if got != "a" {
+		t.Errorf("enter on first option = %q, want a", got)
+	}
+	assertGutter(t, out)
+
+	out = railPrompt(t, "\x1b[B\x1b[B\r", func(fl *Flow) error {
+		v, err := fl.Select("Pick", opts)
+		got = v
+		return err
+	})
+	if got != "c" {
+		t.Errorf("down down enter = %q, want c", got)
+	}
+	assertGutter(t, out)
+}
+
+func TestRailConfirmScripted(t *testing.T) {
+	var got bool
+	// 'y' accepts regardless of default.
+	railPrompt(t, "y", func(fl *Flow) error {
+		v, err := fl.Confirm("Proceed?", false)
+		got = v
+		return err
+	})
+	if !got {
+		t.Errorf("'y' = %v, want true", got)
+	}
+	// 'n' declines.
+	railPrompt(t, "n", func(fl *Flow) error {
+		v, err := fl.Confirm("Proceed?", true)
+		got = v
+		return err
+	})
+	if got {
+		t.Errorf("'n' = %v, want false", got)
+	}
+}
+
+func TestRailInputScripted(t *testing.T) {
+	var got string
+	out := railPrompt(t, "hello@example.com\r", func(fl *Flow) error {
+		v, err := fl.Input("Email", "you@example.com", nil)
+		got = v
+		return err
+	})
+	if got != "hello@example.com" {
+		t.Errorf("input = %q, want hello@example.com", got)
+	}
+	assertGutter(t, out)
+}
+
+func TestRailCancelReturnsErr(t *testing.T) {
+	// Esc/ctrl-c must surface ErrPromptCancelled, never a silent zero value.
+	err := func() error {
+		asciiProfile(t)
+		fl := &Flow{w: &bytes.Buffer{}, in: strings.NewReader("\x03")}
+		done := make(chan error, 1)
+		go func() { _, e := fl.Select("Pick", []Option{{Label: "a", Value: "a"}}); done <- e }()
+		select {
+		case e := <-done:
+			return e
+		case <-time.After(5 * time.Second):
+			t.Fatal("scripted cancel hung")
+			return nil
+		}
+	}()
+	if err != ErrPromptCancelled {
+		t.Errorf("ctrl-c = %v, want ErrPromptCancelled", err)
+	}
+}


### PR DESCRIPTION
Puts `rc setup` (the account/app onboarding flow) on the same guided rail as `rc setup google` / `rc setup apple`, so all three setup experiences share the ┌ │ ◇ └ gutter, rail-native pickers, and a spinner ledger.

```
rc setup
```

Reuses the existing Flow / Ledger / rail-prompt primitives — no new UI machinery. The interface is the only thing that changed:

- Step headers, receipts, and rail-native selects/confirms replace the old title/field/answer + huh forms
- Skills install + MCP config run as a spinner→check ledger
- Outro closes the rail cleanly right before the agent takes over the terminal

Edge cases kept intact:
- The copyable agent prompt still prints raw to stdout (no gutter — stays paste-clean)
- Delegated sub-commands (browser login, signup, `projects use` picker) run in their own UI; the rail pauses and resumes
- MCP config returns its status + hint so the ledger shows it and hints (e.g. `codex mcp login`) stay on the rail
- `--yes` still skips the launch gate; `--quiet` and `--no-color` flow through
- Non-interactive / `--json` output is **unchanged** (still the stage-aware prompt)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive onboarding and OAuth signup output paths; auth still uses the same provisioning flow but setup now owns signup UX and credential handling on the rail.
> 
> **Overview**
> **`rc setup`** now runs on the same **guided rail** (`Flow`: intro, steps, receipts, ledger) as the other setup flows, replacing scattered `rt.Out` titles and **huh** forms with rail-native **Select**, **Confirm**, **Input**, and **Password** prompts.
> 
> **Onboarding behavior changes:** a **roadmap** preview at intro; **account identity** receipts; **signup** is collected on the rail via **`setupSignup`** instead of delegating to `rc auth signup` (which would print off-rail). **`signupWithOAuth`** gains a **`fromSetup`** flag and returns **`(passwordSaved, error)`** so setup can drive account creation under a ledger while suppressing duplicate success/hint chatter. **`--autonomy`** and **`--skills-scope`** flags replace interactive autonomy/skills pickers (defaults shown as receipts; **`--skills-scope` default global**).
> 
> **Launch path:** skills install uses a **ledger** step; **MCP configuration** returns an **`mcpResult`** for rail narration instead of writing directly to output; launch confirm respects **`--yes`** via **`AssumeYes`**. Copyable agent prompt still prints **raw to stdout** (no gutter).
> 
> **Toolkit defaults:** **`defaultToolkitSkills`** adds **`revenuecat-cli`** and **`revenuecat-status`**.
> 
> **TUI:** **`Flow.Hint`**, optional scripted **`in`** on rail prompts for tests; new tests guard **gutter** consistency and scripted prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b01de4d61b420484583c2812ff704a72e94e29c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->