### PR TITLE
feat(customers): surface active entitlements from simulate-purchase

### DIFF
--- a/internal/cli/customers.go
+++ b/internal/cli/customers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -197,9 +198,14 @@ Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`
 				return fmt.Errorf("decoding simulated purchase response: %w", err)
 			}
 			rt.Out.Success(fmt.Sprintf("Simulated purchase for %s", appUserID))
+			// The raw customer_info is the SDK (/receipts) shape — entitlements keyed
+			// by identifier, which differs from `customers show`. Surface the active
+			// entitlement identifiers directly so the purchase can be verified from
+			// this one command instead of switching to `customers show`.
 			return rt.Out.Render(map[string]any{
 				"app_id": appID, "app_user_id": appUserID, "product": *selected,
 				"fetch_token": fetchToken, "customer_info": customerInfo,
+				"active_entitlements": activeEntitlementIDs(raw),
 			})
 		},
 	}
@@ -208,6 +214,42 @@ Confirmation: prompts under TTY; pass --yes to skip. Required under --no-input.`
 	cmd.Flags().StringVar(&appUserID, "app-user-id", os.Getenv("RC_APP_USER_ID"), "customer app user ID (or RC_APP_USER_ID)")
 	cmd.Flags().StringVar(&publicAPIKey, "public-api-key", os.Getenv("RC_PUBLIC_API_KEY"), "Test Store public SDK key; discovered from the app if omitted (or RC_PUBLIC_API_KEY)")
 	return cmd
+}
+
+// activeEntitlementIDs returns the identifiers of entitlements active in an SDK
+// /receipts (customer_info) response — expiry in the future, or none (lifetime).
+// It lets a simulated purchase be verified from this command instead of switching
+// to `customers show` (which uses the different v2 shape). Best-effort: malformed
+// or unparseable entries are skipped rather than reported as active.
+func activeEntitlementIDs(raw json.RawMessage) []string {
+	var resp struct {
+		Subscriber struct {
+			Entitlements map[string]struct {
+				ExpiresDate *string `json:"expires_date"`
+			} `json:"entitlements"`
+		} `json:"subscriber"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil
+	}
+	now := time.Now()
+	var ids []string
+	for id, e := range resp.Subscriber.Entitlements {
+		if e.ExpiresDate == nil {
+			ids = append(ids, id) // non-expiring / lifetime
+			continue
+		}
+		for _, layout := range []string{time.RFC3339, time.RFC3339Nano} {
+			if t, err := time.Parse(layout, *e.ExpiresDate); err == nil {
+				if t.After(now) {
+					ids = append(ids, id)
+				}
+				break
+			}
+		}
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 func simulatedStoreFetchToken() (string, error) {

--- a/internal/cli/customers.go
+++ b/internal/cli/customers.go
@@ -229,11 +229,11 @@ func activeEntitlementIDs(raw json.RawMessage) []string {
 			} `json:"entitlements"`
 		} `json:"subscriber"`
 	}
+	ids := []string{}
 	if err := json.Unmarshal(raw, &resp); err != nil {
-		return nil
+		return ids
 	}
 	now := time.Now()
-	var ids []string
 	for id, e := range resp.Subscriber.Entitlements {
 		if e.ExpiresDate == nil {
 			ids = append(ids, id) // non-expiring / lifetime

--- a/internal/cli/customers_entitlements_test.go
+++ b/internal/cli/customers_entitlements_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestActiveEntitlementIDs(t *testing.T) {
+	future := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	past := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+
+	raw := json.RawMessage(`{
+		"subscriber": {
+			"entitlements": {
+				"premium":  {"expires_date": "` + future + `"},
+				"expired":  {"expires_date": "` + past + `"},
+				"lifetime": {"expires_date": null},
+				"garbage":  {"expires_date": "not-a-date"}
+			}
+		}
+	}`)
+
+	got := activeEntitlementIDs(raw)
+	want := []string{"lifetime", "premium"} // sorted; expired + garbage excluded
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("activeEntitlementIDs = %v, want %v", got, want)
+	}
+}
+
+func TestActiveEntitlementIDs_Malformed(t *testing.T) {
+	// Non-object / missing subscriber → empty, never a panic.
+	for _, in := range []string{`"just a string"`, `{}`, `{"subscriber":{}}`, `not json`} {
+		if got := activeEntitlementIDs(json.RawMessage(in)); len(got) != 0 {
+			t.Errorf("activeEntitlementIDs(%q) = %v, want empty", in, got)
+		}
+	}
+}

--- a/internal/cli/customers_entitlements_test.go
+++ b/internal/cli/customers_entitlements_test.go
@@ -30,10 +30,15 @@ func TestActiveEntitlementIDs(t *testing.T) {
 }
 
 func TestActiveEntitlementIDs_Malformed(t *testing.T) {
-	// Non-object / missing subscriber → empty, never a panic.
+	// Non-object / missing subscriber → empty, never a panic, and must encode
+	// as a JSON array (`[]`) rather than `null` so `--json | jq` stays safe.
 	for _, in := range []string{`"just a string"`, `{}`, `{"subscriber":{}}`, `not json`} {
-		if got := activeEntitlementIDs(json.RawMessage(in)); len(got) != 0 {
+		got := activeEntitlementIDs(json.RawMessage(in))
+		if len(got) != 0 {
 			t.Errorf("activeEntitlementIDs(%q) = %v, want empty", in, got)
+		}
+		if b, _ := json.Marshal(got); string(b) != "[]" {
+			t.Errorf("activeEntitlementIDs(%q) marshals to %s, want []", in, b)
 		}
 	}
 }


### PR DESCRIPTION
`simulate-purchase` returns the SDK `/receipts` `customer_info` — entitlements keyed by identifier — which is a different shape from `customers show` (v2, `active_entitlements.items[]` keyed by internal `entitlement_id`). An agent verifying a simulated purchase had to switch commands to confirm the entitlement was active.

This adds a derived **`active_entitlements`** field (list of active entitlement identifiers) to the `simulate-purchase` output, so the purchase is verifiable from the one command:

```
rc customers simulate-purchase --app-id app_x --product premium_monthly --app-user-id demo --json \
  | jq '.data.active_entitlements'   # ["premium"]
```

Active = expiry in the future, or none (lifetime). Best-effort parse of the stable `/receipts` shape; malformed entries are skipped, never falsely reported active. Raw `customer_info` is unchanged.

Note: this doesn't make the two commands byte-identical — they use different id systems (SDK lookup key vs v2 `entitlement_id`). Full cross-command entitlement-shape unification is a separate, larger API question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only output enrichment and local JSON parsing; no API or purchase flow changes.
> 
> **Overview**
> **`simulate-purchase`** now includes a derived **`active_entitlements`** field (sorted SDK entitlement identifiers) alongside the unchanged raw **`customer_info`**, so scripts and agents can confirm a purchase granted access without running **`customers show`**.
> 
> The new **`activeEntitlementIDs`** helper parses the `/receipts` **`subscriber.entitlements`** map: an ID counts as active when **`expires_date`** is missing (lifetime) or parses as a future RFC3339 timestamp; expired, unparseable, or malformed payloads are skipped (empty slice, never **`null`**). Unit tests cover happy path and malformed JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca528dea5b3531935aeb5530c32cbbd245f84db4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->