### PR TITLE
chore: scrub internal references and add 0.1.0 CHANGELOG for public release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to the RevenueCat CLI are documented here. This project follows [Keep a Changelog](https://keepachangelog.com) and [Semantic Versioning](https://semver.org).
+
+## [0.1.0] - 2026-08-25
+
+Initial public release of `rc`, the RevenueCat command line interface. It's built to be driven equally well by people and by AI coding agents.
+
+### Added
+- **One-command setup**: `rc setup` guides RevenueCat setup for an app, and `rc setup apple` / `rc setup google` configure App Store Connect and Google Play credentials locally, with no manual key downloads or console clicking.
+- **Project management**: create and manage projects, apps, products, entitlements, offerings, and packages.
+- **Customers and subscriptions**: inspect customers, grant and revoke entitlements, simulate purchases, and manage subscriptions.
+- **Paywalls**: list and publish paywalls, and generate or edit them with AI (`rc paywalls generate` / `rc paywalls edit`).
+- **Rico**: an interactive AI assistant (`rc rico`) with streaming output and tool approvals.
+- **Charts**: view subscription metrics as interactive terminal charts.
+- **Store-state plans**: review and apply App Store / Google Play catalog changes as auditable plans (`rc products store plan` / `apply`).
+- **Agent-native interface**: stable `--json` output, `--no-input` for CI, full command and flag discovery via `rc commands` and `rc schema`, installable AI Toolkit skills (`rc skills install`), and raw API access with `rc api`.
+- **Authentication**: browser OAuth (`rc auth login`), API-key auth, and headless account signup.
+- **Profiles**: separate credentials per environment with `--profile`.
+
+### Install
+- Homebrew: `brew install RevenueCat/tap/rc`
+- npm: `npm install -g @revenuecat/cli`, or run without installing via `npx @revenuecat/cli`
+- Prebuilt binaries on the [releases page](https://github.com/RevenueCat/revenuecat-cli/releases)
+
+[0.1.0]: https://github.com/RevenueCat/revenuecat-cli/releases/tag/v0.1.0

--- a/docs/specs/v2-beta-overlay.yaml
+++ b/docs/specs/v2-beta-overlay.yaml
@@ -1,5 +1,5 @@
-'# NOTE': 'Hand-maintained beta overlay — see DX-880. Seeded from the backend''s openapi-dev.yaml
-  (x-release-status: development endpoints the CLI uses). Merged onto the public spec
+'# NOTE': 'Hand-maintained overlay of v2 endpoints the CLI uses that are not in the
+  published public spec yet. Merged onto the public spec
   by scripts/preprocess-spec.py. Remove entries here once they graduate into the public
   spec.'
 openapi: 3.0.3

--- a/internal/api/apps_types.go
+++ b/internal/api/apps_types.go
@@ -4,7 +4,6 @@ package api
 // oneOf union, which oapi-codegen renders as an opaque json.RawMessage wrapper —
 // but the wire format is still a flat object, so we keep the previous flat shape
 // here and exclude App / AppType / AppObject from codegen (oapi-codegen.yaml).
-// See DX-874.
 
 type AppType string
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -507,7 +507,7 @@ func writeTokenStatus(rt *Runtime) {
 
 // credentialScopes best-effort reports the scopes of the active credential.
 //
-// TODO(DX-940): read authoritative scopes once the API gains a token-introspection endpoint.
+// TODO: read authoritative scopes once the API gains a token-introspection endpoint.
 func credentialScopes(token string) (scopes []string, ok bool) {
 	return jwtScopes(token)
 }

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -271,8 +271,8 @@ Set RC_SKILLS_BRANCH to install an unreleased branch for testing. --branch
 overrides the environment variable.`,
 		Example: `  rc skills install
   rc skills install --project
-  RC_SKILLS_BRANCH=rc-cli-project-setup-workflows rc skills install
-  rc skills install --branch rc-cli-project-setup-workflows
+  RC_SKILLS_BRANCH=my-feature-branch rc skills install
+  rc skills install --branch my-feature-branch
   rc skills install --all
   rc skills install --agent codex --yes --no-input
   rc skills install --skill create-revenuecat-project --yes --no-input`,

--- a/internal/cli/skills_test.go
+++ b/internal/cli/skills_test.go
@@ -156,7 +156,7 @@ func TestSkillsInstallProjectScope(t *testing.T) {
 }
 
 func TestSkillsInstallUsesBranchFromEnvironment(t *testing.T) {
-	t.Setenv("RC_SKILLS_BRANCH", "rc-cli-project-setup-workflows")
+	t.Setenv("RC_SKILLS_BRANCH", "some-feature-branch")
 	installer := &recordingSkillsInstaller{}
 	cmd := newSkillsCmdWithInstaller(installer)
 	var stdout, stderr bytes.Buffer
@@ -170,11 +170,11 @@ func TestSkillsInstallUsesBranchFromEnvironment(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
 	}
-	wantSource := "https://github.com/RevenueCat/ai-toolkit/tree/rc-cli-project-setup-workflows"
+	wantSource := "https://github.com/RevenueCat/ai-toolkit/tree/some-feature-branch"
 	if !slices.Contains(installer.args, wantSource) {
 		t.Fatalf("installer args = %v, want %q", installer.args, wantSource)
 	}
-	for _, want := range []string{`"branch": "rc-cli-project-setup-workflows"`, `"source": "` + wantSource + `"`} {
+	for _, want := range []string{`"branch": "some-feature-branch"`, `"source": "` + wantSource + `"`} {
 		if !bytes.Contains(stdout.Bytes(), []byte(want)) {
 			t.Errorf("install JSON missing %q: %s", want, stdout.String())
 		}

--- a/scripts/preprocess-spec.py
+++ b/scripts/preprocess-spec.py
@@ -14,7 +14,7 @@ Rewrites them as:
       allOf:
         - { $ref: '#/components/schemas/SomeSchema' }
 
-It also merges any beta overlay specs (see DX-880) on top of the base spec
+It also merges any beta overlay specs on top of the base spec
 before the fix runs, so endpoints the CLI uses that are absent from the public
 spec (the store_state family) are present for codegen and diffing. The merge is
 additive — the public spec always wins on conflicts — so the overlay only fills

--- a/scripts/seed-beta-overlay.py
+++ b/scripts/seed-beta-overlay.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Seed docs/specs/v2-beta-overlay.yaml from the backend's full dev OpenAPI spec.
+"""Seed docs/specs/v2-beta-overlay.yaml from a source OpenAPI spec.
 
 The public spec we fetch from docs is release-filtered and omits endpoints the
 CLI uses but that the backend marks `x-release-status: development` (the
@@ -14,7 +14,7 @@ of the dev spec, then hand-maintain the result. Re-run to reseed when the
 upstream store_state schema changes.
 
     python3 scripts/seed-beta-overlay.py \
-        path/to/openapi-dev.yaml \
+        path/to/source-openapi.yaml \
         docs/specs/v2-beta-overlay.yaml
 
 Which paths to pull is controlled by PATH_SUBSTRINGS below — keep it to the
@@ -108,9 +108,8 @@ def main():
 
     overlay = {
         "# NOTE": (
-            "Hand-maintained beta overlay — see DX-880. Seeded from the "
-            "backend's openapi-dev.yaml (x-release-status: development endpoints "
-            "the CLI uses). Merged onto the public spec by "
+            "Hand-maintained overlay of v2 endpoints the CLI uses that are not "
+            "in the published public spec yet. Merged onto the public spec by "
             "scripts/preprocess-spec.py. Remove entries here once they graduate "
             "into the public spec."
         ),


### PR DESCRIPTION
Pre-public cleanup, plus the initial CHANGELOG.

**Leak scrubs** (found by a full-codebase sweep):
- `skills.go` `--help` example hardcoded the internal `rc-cli-project-setup-workflows` branch. Genericized (the `RC_SKILLS_BRANCH` / `--branch` feature stays).
- Removed internal ticket IDs (`DX-###`) from `auth.go`, `apps_types.go`, and the spec tooling.
- Removed the internal source-spec filename (`openapi-dev.yaml`) from the beta-overlay scripts. The overlay files stay, they feed `make gen` codegen.
- `skills_test.go` now uses a generic branch name.

**CHANGELOG**: added `CHANGELOG.md` with a `0.1.0` initial-release entry.

No behavior changes. Build, vet, and the cli/api tests pass.

Base is current `main`; these files are identical on #144, so it merges cleanly regardless of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment, documentation, and example-only edits; no functional code paths or auth/API logic changed.
> 
> **Overview**
> Prepares the repo for the **0.1.0 public release** by adding **`CHANGELOG.md`** with a Keep a Changelog entry that documents the initial `rc` feature set and install paths (Homebrew, npm, releases).
> 
> The rest is **pre-public cleanup with no runtime behavior changes**: internal ticket IDs (`DX-###`) are removed from comments in `auth.go`, `apps_types.go`, and the OpenAPI overlay tooling; beta-overlay notes no longer reference internal spec filenames or tickets. **`rc skills install` help and tests** replace a hardcoded internal ai-toolkit branch name with generic examples like `my-feature-branch`, while **`RC_SKILLS_BRANCH` / `--branch`** behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c92abe9ee6c02f81167e7e5b788fbdc6f14c1e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->