### PR TITLE
feat: install the command as both rc and revenuecat

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -82,5 +82,6 @@ brews:
     license: "MIT"
     install: |
       bin.install "rc"
+      bin.install_symlink "rc" => "revenuecat"
     test: |
       system "#{bin}/rc", "--version"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -85,3 +85,4 @@ brews:
       bin.install_symlink "rc" => "revenuecat"
     test: |
       system "#{bin}/rc", "--version"
+      system "#{bin}/revenuecat", "--version"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ npm install -g @revenuecat/cli
 
 Or download a binary directly from the [releases page](../../releases).
 
+Homebrew and npm install the command as both `rc` and `revenuecat` (same binary); use whichever you prefer. Examples throughout use `rc`.
+
 Every command also runs without installing, via `npx @revenuecat/cli <command>`,
 handy for CI and agent sandboxes.
 

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/RevenueCat/revenuecat-cli",
   "repository": { "type": "git", "url": "git+https://github.com/RevenueCat/revenuecat-cli.git" },
   "license": "MIT",
-  "bin": { "rc": "bin/rc.js" },
+  "bin": { "rc": "bin/rc.js", "revenuecat": "bin/rc.js" },
   "files": ["bin/rc.js", "README.md"],
   "engines": { "node": ">=18" },
   "optionalDependencies": {


### PR DESCRIPTION
Ship the CLI under two names from one binary: the short `rc` and the full `revenuecat`.

- **Homebrew**: `bin.install_symlink "rc" => "revenuecat"` in the GoReleaser formula.
- **npm**: the launcher `bin` map exposes both `rc` and `revenuecat`.
- **README**: note that both names are installed.

`rc` stays the canonical name everywhere it matters — help usage, command examples, `rc commands` / `rc schema` discovery output, and the AI Toolkit skills — so nothing desyncs. `revenuecat` is purely a convenience alias. Because both names ship together in the same package, every skill/discovery command (`rc ...`) always resolves.

No behavior change to the binary itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and documentation only; the executable and CLI behavior are unchanged.
> 
> **Overview**
> Install paths now expose **two command names** for the same binary: **`rc`** (unchanged as the documented default) and **`revenuecat`** as a convenience alias.
> 
> **Homebrew** (GoReleaser) symlinks `revenuecat` to `rc` after install and asserts both run `--version` in the formula test. **npm** registers `revenuecat` in `package.json` `bin` alongside `rc`, both dispatching through the existing `bin/rc.js` launcher. **README** states that Homebrew and npm install both names.
> 
> No changes to the Go CLI binary or runtime behavior—only packaging and docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ce8e0b821dc301915d65c70d4ea4286523462f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->