### PR TITLE
ci(release): harden npm publish (provenance + idempotent skip)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write # npm publish --provenance
 
 jobs:
   goreleaser:

--- a/scripts/package-npm.mjs
+++ b/scripts/package-npm.mjs
@@ -110,7 +110,7 @@ writeJSON(path.join(launcherDir, "package.json"), launcherPkg);
 const publishOrder = [...built.map(b => b.pkgDir), launcherDir];
 for (const dir of publishOrder) {
   const args = publish
-    ? ["publish", "--access", "public"]
+    ? ["publish", "--access", "public", "--provenance"]
     : ["pack", "--pack-destination", path.resolve(outDir)];
   console.log(`npm ${args[0]}: ${dir}`);
   execFileSync("npm", args, { cwd: dir, stdio: "inherit" });

--- a/scripts/package-npm.mjs
+++ b/scripts/package-npm.mjs
@@ -108,9 +108,12 @@ writeJSON(path.join(launcherDir, "package.json"), launcherPkg);
 // Platform packages publish before the launcher so the launcher's
 // optionalDependencies always resolve.
 const publishOrder = [...built.map(b => b.pkgDir), launcherDir];
+// Provenance requires OIDC, which only exists in a supported CI (GitHub Actions).
+// A local publish (e.g. the first bootstrap publish) must omit it or npm errors.
+const provenance = publish && process.env.GITHUB_ACTIONS === "true";
 for (const dir of publishOrder) {
   const args = publish
-    ? ["publish", "--access", "public", "--provenance"]
+    ? ["publish", "--access", "public", ...(provenance ? ["--provenance"] : [])]
     : ["pack", "--pack-destination", path.resolve(outDir)];
   console.log(`npm ${args[0]}: ${dir}`);
   execFileSync("npm", args, { cwd: dir, stdio: "inherit" });

--- a/scripts/package-npm.mjs
+++ b/scripts/package-npm.mjs
@@ -112,6 +112,22 @@ const publishOrder = [...built.map(b => b.pkgDir), launcherDir];
 // A local publish (e.g. the first bootstrap publish) must omit it or npm errors.
 const provenance = publish && process.env.GITHUB_ACTIONS === "true";
 for (const dir of publishOrder) {
+  if (publish) {
+    // Skip versions already on the registry so a re-run (or a release whose
+    // version was published out-of-band) is idempotent instead of failing.
+    const pj = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
+    let alreadyPublished = false;
+    try {
+      execFileSync("npm", ["view", `${pj.name}@${pj.version}`, "version"], { stdio: "ignore" });
+      alreadyPublished = true;
+    } catch {
+      alreadyPublished = false;
+    }
+    if (alreadyPublished) {
+      console.log(`skip (already published): ${pj.name}@${pj.version}`);
+      continue;
+    }
+  }
   const args = publish
     ? ["publish", "--access", "public", ...(provenance ? ["--provenance"] : [])]
     : ["pack", "--pack-destination", path.resolve(outDir)];


### PR DESCRIPTION
Two changes to make the CI npm publish robust and verified:

1. **Provenance** — `id-token: write` + `npm publish --provenance` (gated to CI via `GITHUB_ACTIONS`, so a local publish doesn't fail on the OIDC requirement). Published packages get the verified/provenance badge.
2. **Idempotent publish** — each `name@version` is checked against the registry first and skipped if already present. So a re-run, or a release whose version was published out-of-band (the `0.1.0` local bootstrap), succeeds instead of dying on a duplicate. When everything's already published, the step needs no token and goes green.

Net for `v0.1.0`: tagging runs GoReleaser (binaries + GitHub release + Homebrew) and the npm step skips the already-published `0.1.0` packages — a clean green release, no `NPM_TOKEN` required. Future releases publish new versions (with provenance) once trusted publishing/token is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect release CI and the npm packaging script; no runtime product or auth logic is modified.
> 
> **Overview**
> **Hardens the release workflow’s npm publish step** so tagged releases are more reliable and packages can show npm provenance when published from GitHub Actions.
> 
> The release workflow grants **`id-token: write`** so CI can use OIDC for provenance. **`package-npm.mjs`** passes **`--provenance`** only when publishing in GitHub Actions (`GITHUB_ACTIONS`), avoiding local/bootstrap publishes that lack OIDC.
> 
> Before each **`npm publish`**, the script checks whether **`name@version`** already exists on the registry and **skips** if so. Re-runs and versions published out-of-band (e.g. bootstrap `0.1.0`) no longer fail on duplicate publishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 046d43ab32a27bf8adb3cc220ba2597e4f2266d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->