### PR TITLE
feat(setup): mark rc setup google experimental until Google OAuth is verified

### DIFF
--- a/docs/command-surface.md
+++ b/docs/command-surface.md
@@ -68,7 +68,7 @@ names; there's no list endpoint.
 ```
 # Onboarding entry points (the two scoped npx surfaces)
 rc setup                                                 # one-shot agent-driven bootstrap; featured in --help/home/README, runs non-interactively for the prompt
-rc setup google [app-id]                                 # interactive: local Google sign-in, bootstrap the Play service-account credential, grant package-scoped access, upload to RC
+rc setup google [app-id]                                 # experimental (hidden from --help until the Google OAuth consent screen is verified): local Google sign-in, bootstrap the Play service-account credential, grant package-scoped access, upload to RC
 rc setup apple [app-id]                                  # interactive: App Store Connect sign-in + 2FA, create/upload IAP & ASC keys, vendor number (rc apps apple setup is a hidden alias)
 rc                                                       # bare rc -> getting-started help; --all reveals experimental commands
 

--- a/internal/cli/setup_google.go
+++ b/internal/cli/setup_google.go
@@ -67,6 +67,9 @@ func newSetupGoogleCmd() *cobra.Command {
 		Annotations: map[string]string{
 			"requires_human":        "true",
 			"requires_human_reason": "Opens a browser for Google sign-in and manages Play Console access; a human must run it in a local interactive terminal.",
+			// Experimental until the Google OAuth consent screen is verified: until
+			// then sign-in shows the "unverified app" warning and a 100-user cap.
+			annotationSurface: surfaceExperimental,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientID = valueOrEnv(clientID, "RC_GOOGLE_CLIENT_ID")

--- a/internal/cli/surface.go
+++ b/internal/cli/surface.go
@@ -50,6 +50,9 @@ func curateSurface(root *cobra.Command, all bool) {
 		if cmd.Annotations[annotationSurface] == surfaceExperimental {
 			cmd.Hidden = !all
 		}
+		// Recurse so nested experimental subcommands (e.g. `setup google`) are
+		// hidden from their parent's --help too, not just top-level commands.
+		curateSurface(cmd, all)
 	}
 }
 


### PR DESCRIPTION
Marks `rc setup google` as experimental so it's hidden from `rc setup --help` (and `rc --help`) until the Google OAuth consent screen clears verification. Until then, sign-in shows the "unverified app" warning + a 100-user cap, which is a rough look for a default command.

- `setup_google.go`: add `annotationSurface: surfaceExperimental` to the command.
- `surface.go`: make `curateSurface` recurse — the existing logic only walked top-level commands, so a nested subcommand like `setup google` was never hidden. Now nested experimental commands are hidden from their parent's `--help` too.

Still fully **runnable and agent-discoverable**: `rc setup google` works, and it shows up (tagged) in `rc commands --schemas` and `rc schema setup google`. It's only removed from the default `--help` and the flat `capabilities[]` list; `--all` / `RC_SURFACE=full` reveal it.

`rc setup apple` stays default (no Google consent screen, no unverified-warning issue).

Flip back to default the day verification clears. Build + cli tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help visibility and documentation only; no changes to OAuth, credential setup, or API behavior.
> 
> **Overview**
> **`rc setup google` is treated as experimental** until the Google OAuth consent screen is verified, so default `--help` (including `rc setup --help`) no longer promotes a flow that shows Google's "unverified app" warning and 100-user cap.
> 
> The command gets the **`surface: experimental`** annotation in `setup_google.go`, matching the doc update in `command-surface.md`. **`curateSurface` now recurses** into subcommands so nested experimental commands are hidden from their parent's help, not only top-level commands.
> 
> Behavior for users who know the command is unchanged: **`rc setup google` still runs**, and agents can still find it via **`rc commands` / `rc schema`** (tagged experimental) or **`rc --all` / `RC_SURFACE=full`**. **`rc setup apple`** stays on the default surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4e3284a914c4badb21f663c953f6129f8a6ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->