### PR TITLE
ci(release): bake the Google OAuth client into the release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,15 @@ jobs:
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: v3.1.3
+      - name: Require Google OAuth client is set (it gets baked into the binary)
+        env:
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+        run: |
+          if [ -z "$GOOGLE_OAUTH_CLIENT_ID" ] || [ -z "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+            echo "::error::GOOGLE_OAUTH_CLIENT_ID/SECRET secret missing; rc setup google would ship without a baked-in client. Set both repo secrets."
+            exit 1
+          fi
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"
@@ -30,6 +39,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Token with write access to RevenueCat/homebrew-tap
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          # Baked into the binary via ldflags so `rc setup google` works out of the box
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 20

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,13 @@ version: 2
 
 project_name: rc
 
+# Baked into the release binary (via the build ldflags below) so `rc setup google`
+# works with no env setup. Sourced from CI secrets; empty for local builds, where
+# the RC_GOOGLE_CLIENT_ID / --client-id runtime override still works.
+env:
+  - GOOGLE_OAUTH_CLIENT_ID={{ if isEnvSet "GOOGLE_OAUTH_CLIENT_ID" }}{{ .Env.GOOGLE_OAUTH_CLIENT_ID }}{{ end }}
+  - GOOGLE_OAUTH_CLIENT_SECRET={{ if isEnvSet "GOOGLE_OAUTH_CLIENT_SECRET" }}{{ .Env.GOOGLE_OAUTH_CLIENT_SECRET }}{{ end }}
+
 before:
   hooks:
     # just check the deps are intact; don't run `go mod tidy`, which could
@@ -22,6 +29,8 @@ builds:
       - arm64
     ldflags:
       - -s -w -X main.version={{.Version}}
+      - -X github.com/revenuecat/cli/internal/google.DefaultClientID={{ .Env.GOOGLE_OAUTH_CLIENT_ID }}
+      - -X github.com/revenuecat/cli/internal/google.DefaultClientSecret={{ .Env.GOOGLE_OAUTH_CLIENT_SECRET }}
   - id: rc-darwin
     main: ./cmd/rc
     binary: rc
@@ -34,6 +43,8 @@ builds:
       - arm64
     ldflags:
       - -s -w -X main.version={{.Version}}
+      - -X github.com/revenuecat/cli/internal/google.DefaultClientID={{ .Env.GOOGLE_OAUTH_CLIENT_ID }}
+      - -X github.com/revenuecat/cli/internal/google.DefaultClientSecret={{ .Env.GOOGLE_OAUTH_CLIENT_SECRET }}
 
 archives:
   - id: default


### PR DESCRIPTION
`rc setup google` needs a RevenueCat-owned OAuth client baked into the shipped binary — a runtime env override isn't enough when we hand the binary to customers. This injects it at CI build time from repo secrets.

**Changes**
- `.goreleaser.yaml`: inject the client ID + secret via `-X` ldflags from repo secrets. Empty for local builds, so the runtime override still works.
- `release.yml`: pass the secrets to GoReleaser, and fail the release if either is missing.

**Why inject instead of hardcode:** for a Desktop/loopback client the "secret" isn't actually confidential — PKCE is what protects it (RFC 8252). Injecting from a CI secret just keeps it out of public source and satisfies Google's ToS. Security is the same either way.

**Verified:** dummy values land in the binary via `-X`; `goreleaser check` passes.

## ⚠️ Requires before it takes effect
Add two repo secrets with the finalized client, or the release guard fails:
- `GOOGLE_OAUTH_CLIENT_ID`
- `GOOGLE_OAUTH_CLIENT_SECRET`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> OAuth credentials are compiled into shipped binaries and the release pipeline now hard-fails without repo secrets; impact is limited by the existing desktop/PKCE model but distribution and secret management deserve review.
> 
> **Overview**
> Release builds now embed RevenueCat’s Google OAuth **client ID and secret** into `rc` at link time so **`rc setup google`** works for customers without env vars.
> 
> **GoReleaser** reads `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` from the environment and sets `internal/google.DefaultClientID` and `DefaultClientSecret` via `-X` ldflags on all platform builds; local builds stay empty so `RC_GOOGLE_*` overrides still apply.
> 
> The **release workflow** adds a pre-GoReleaser check that fails the job if either secret is missing, and passes both secrets into the GoReleaser step env so they reach the build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 653182de0f80c5c97dbac59dc56ea041970aaffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->