### PR TITLE
fix(security): warn on non-RevenueCat API host; protect Authorization from RC_HEADERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ route or tag traffic without baking anything into the binary:
 RC_HEADERS=$'X-Some-Header: value' rc offerings list
 ```
 
-One header per line; supplied headers override the CLI's defaults.
+One header per line; supplied headers override the CLI's defaults, except `Authorization`, which is protected so a stray header can't swap your credential.
 
 ## Usage analytics
 

--- a/internal/httpx/headers.go
+++ b/internal/httpx/headers.go
@@ -24,9 +24,14 @@ func ParseHeaders(s string) http.Header {
 	return h
 }
 
-// Apply sets each header from h on req, overriding existing values.
+// Apply sets each header from h on req, overriding existing values, except
+// Authorization: user-supplied headers (RC_HEADERS) must not be able to swap out
+// the CLI's auth credential.
 func Apply(req *http.Request, h http.Header) {
 	for name, values := range h {
+		if strings.EqualFold(name, "Authorization") {
+			continue
+		}
 		for i, v := range values {
 			if i == 0 {
 				req.Header.Set(name, v)

--- a/internal/httpx/headers_test.go
+++ b/internal/httpx/headers_test.go
@@ -32,7 +32,7 @@ func TestParseHeadersEmptyIsNil(t *testing.T) {
 	}
 }
 
-func TestApplyOverridesAndSendsOnRequest(t *testing.T) {
+func TestApplyAppliesExtraHeadersButProtectsAuthorization(t *testing.T) {
 	var gotHeader, gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotHeader = r.Header.Get("X-Example-Header")
@@ -52,8 +52,8 @@ func TestApplyOverridesAndSendsOnRequest(t *testing.T) {
 	if gotHeader != "example-value" {
 		t.Errorf("X-Example-Header = %q, want example-value", gotHeader)
 	}
-	if gotAuth != "Bearer override" {
-		t.Errorf("Authorization = %q, want the applied header to override the default", gotAuth)
+	if gotAuth != "Bearer default" {
+		t.Errorf("Authorization = %q, want the CLI's credential preserved (RC_HEADERS must not override Authorization)", gotAuth)
 	}
 }
 


### PR DESCRIPTION
One safety net: `RC_HEADERS` can no longer override `Authorization`, so a stray or hostile header can't swap out your RevenueCat credential. Other headers still work.

(The RC_BASE_URL half moved to #160, which locks endpoint overrides to dev builds.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow security hardening in shared HTTP header application; only behavior change is blocking Authorization overrides from RC_HEADERS.
> 
> **Overview**
> **RC_HEADERS** can still add or override most custom headers on RevenueCat API traffic, but **`Authorization` is now ignored** when those headers are merged onto outgoing requests.
> 
> `httpx.Apply` skips any `Authorization` entry (case-insensitive) from parsed `RC_HEADERS`, so a misconfigured or hostile header line cannot replace the CLI’s stored API key or OAuth credential. Other headers continue to override defaults as before. README documents the exception, and the apply test now expects the preset bearer token to survive when `RC_HEADERS` includes `Authorization`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8bbf01d7f24880aae81ab33ef993813e3eaf0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->