### PR TITLE
ci: pin release/spec-sync Go to go.mod, verify modules at release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: stable
+          go-version-file: go.mod
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
 
       - name: Fetch latest specs

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,9 @@ project_name: rc
 
 before:
   hooks:
-    - go mod tidy
+    # verify module checksums instead of `go mod tidy`, which would mutate
+    # go.mod/go.sum at release time away from what CI tested.
+    - go mod verify
 
 builds:
   - id: rc-unix-windows

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,8 @@ project_name: rc
 
 before:
   hooks:
-    # verify module checksums instead of `go mod tidy`, which would mutate
-    # go.mod/go.sum at release time away from what CI tested.
+    # just check the deps are intact; don't run `go mod tidy`, which could
+    # rewrite go.mod/go.sum during the release and ship different deps than CI tested.
     - go mod verify
 
 builds:


### PR DESCRIPTION
Build-pipeline hygiene from the security review.

- **Pin Go to `go.mod`**: `release.yml` and `spec-sync.yml` used `go-version: stable`, so releases built with whatever floating Go was current that day. Switched both to `go-version-file: go.mod` → always the declared `1.25.13`, matching what the rest of CI tests against.
- **`go mod verify` instead of `go mod tidy`** in the GoReleaser before-hook. `tidy` can rewrite `go.mod`/`go.sum` at release time, drifting from the tested state; `verify` checks module checksums without mutating anything.

`go mod verify` → all modules verified. `goreleaser check` → config valid (only the pre-existing `brews` deprecation, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and release configuration only; no runtime or application logic changes.
> 
> **Overview**
> Release and spec-sync workflows no longer use floating **`go-version: stable`**; they read the toolchain from **`go-version-file: go.mod`** so builds match the declared Go version (e.g. **1.25.13**) used elsewhere in CI.
> 
> GoReleaser’s pre-release hook swaps **`go mod tidy`** for **`go mod verify`**, so releases validate module checksums without rewriting **`go.mod`** / **`go.sum`** at publish time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead6aed6893dd721b6a42fb80cf7417761237b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->