### PR TITLE
fix(security): loopback server timeouts, browser URL guard, skills-branch trust note

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -658,7 +658,7 @@ func loginWithOAuth(ctx context.Context, rt *Runtime) error {
 		}
 	})
 
-	srv := &http.Server{Handler: mux}
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go func() {
 		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
 			errCh <- fmt.Errorf("callback server error: %w", err)

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -270,7 +270,8 @@ it discovers the latest skills. Then ask naturally for RevenueCat setup or name
 the create-revenuecat-project skill explicitly.
 
 Set RC_SKILLS_BRANCH to install an unreleased branch for testing. --branch
-overrides the environment variable.`,
+overrides the environment variable. Only point it at a branch you trust: skills
+are installed and run by your agent, so an untrusted branch runs untrusted code.`,
 		Example: `  rc skills install
   rc skills install --project
   RC_SKILLS_BRANCH=my-feature-branch rc skills install

--- a/internal/google/auth.go
+++ b/internal/google/auth.go
@@ -131,7 +131,7 @@ func Authenticate(ctx context.Context, clientID, clientSecret string, scopes []s
 		}
 	})
 
-	server := &http.Server{Handler: mux}
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go func() {
 		if serveErr := server.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 			sendErr(errCh, serveErr)

--- a/internal/tui/browser.go
+++ b/internal/tui/browser.go
@@ -92,6 +92,11 @@ func run(initial bframe) error {
 
 // OpenURL opens url in the default system browser.
 func OpenURL(url string) error {
+	// Only ever hand an http(s) URL to the system opener, so a value starting
+	// with "-" can't be parsed as a flag by open/xdg-open.
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return fmt.Errorf("refusing to open non-http(s) URL: %q", url)
+	}
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":


### PR DESCRIPTION
Grab-bag of low-risk runtime hardening from the security review.

- **`ReadHeaderTimeout` on both loopback OAuth callback servers** (Google sign-in + RC device login). Without it, a client that connects and stalls mid-headers holds the serve goroutine open indefinitely (gosec G112 / Slowloris). 10s is plenty for a localhost redirect.
- **`OpenURL` scheme guard**: refuse anything that isn't `http(s)://`, so a URL beginning with `-` can't be parsed as a flag by `open`/`xdg-open`. All real callers pass constructed https URLs; this is defense-in-depth.
- **`RC_SKILLS_BRANCH` trust note** in `rc skills install` help: installed skills run as code in your agent, so the override must point at a branch you trust.

**Left as-is:** `--apple-password` on argv. It's a deliberate non-interactive affordance (the `--json`/`--no-input` error message points users to it), and its help already tells you to prefer `RC_APPLE_PASSWORD`. Removing it would break scripted/CI use.

Build, vet, and `go test ./internal/cli ./internal/tui ./internal/google` all pass. No golden snapshots affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, defensive hardening on localhost OAuth servers and URL opening; no changes to credential storage or API behavior.
> 
> **Overview**
> Hardens a few local-runtime paths from the security review without changing auth or install behavior for normal use.
> 
> **Loopback OAuth callbacks** in RevenueCat browser login (`internal/cli/auth.go`) and Google sign-in (`internal/google/auth.go`) now set **`ReadHeaderTimeout: 10s`** on the temporary `http.Server`, so a client that stalls while sending headers cannot hold the serve goroutine open indefinitely (Slowloris / gosec G112).
> 
> **`tui.OpenURL`** rejects anything that is not `http://` or `https://` before invoking `open` / `xdg-open`, blocking URLs that start with `-` from being parsed as CLI flags. Call sites that build real https links are unchanged; this is defense-in-depth for the TUI browser’s `o` shortcut.
> 
> **`rc skills install` help** adds a short warning that `RC_SKILLS_BRANCH` / `--branch` must point at a branch you trust, because installed skills run as code in your agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8109d49d0e21c0caa338049765b8f00c2fb67d3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->