### PR TITLE
ci: sign release checksums with keyless cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,7 @@ jobs:
           go-version-file: go.mod
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          # cosign v3 changed the sign-blob flags the signs block below uses; pin v2.
-          cosign-release: v2.6.5
+          cosign-release: v3.1.3
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,7 @@ jobs:
           go-version-file: go.mod
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          # Pin cosign v2: v3 replaced the detached --output-signature/--output-certificate
-          # sign-blob API (used by the signs block below) with --bundle.
+          # cosign v3 changed the sign-blob flags the signs block below uses; pin v2.
           cosign-release: v2.6.5
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           go-version-file: go.mod
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin cosign v2: v3 replaced the detached --output-signature/--output-certificate
+          # sign-blob API (used by the signs block below) with --bundle.
+          cosign-release: v2.6.5
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,21 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+# Keyless (Sigstore/Fulcio) signature over the checksum file, which in turn
+# covers every released artifact. Requires cosign on PATH and id-token: write.
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    output: true
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--yes"
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,13 +51,11 @@ signs:
   - cmd: cosign
     artifacts: checksum
     output: true
-    signature: "${artifact}.sig"
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
       - "--yes"
-      - "--output-signature=${signature}"
-      - "--output-certificate=${certificate}"
+      - "--bundle=${signature}"
       - "${artifact}"
 
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,8 +45,8 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
-# Keyless (Sigstore/Fulcio) signature over the checksum file, which in turn
-# covers every released artifact. Requires cosign on PATH and id-token: write.
+# Sign checksums.txt (it hashes every binary, so one signature covers the whole
+# release) so downloads can be verified. Signing uses CI's GitHub identity, no keys.
 signs:
   - cmd: cosign
     artifacts: checksum


### PR DESCRIPTION
Signs our release binaries so anyone can verify they were built by our CI and haven't been tampered with.

**What changed**
- During a release, cosign signs the `checksums.txt` file. That file already hashes every binary, so one signature covers the whole release. cosign writes a single Sigstore bundle (`checksums.txt.sigstore.json`) that's uploaded alongside the release assets.
- The release workflow installs cosign (v3.1.3).
- No new secrets: signing reuses the GitHub identity the workflow already has for npm.

**Verify a downloaded release:**
```
cosign verify-blob --bundle checksums.txt.sigstore.json \
  --certificate-identity-regexp 'https://github.com/RevenueCat/cli/.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  checksums.txt
```

**Testing:** the config validates locally, but real signing only runs on the next `v*` tag (it needs the CI identity). If it's misconfigured, the release fails at the signing step rather than publishing unsigned binaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release pipeline changes; improves supply-chain verification without altering runtime auth or application logic.
> 
> **Overview**
> Release artifacts can now be verified against **RevenueCat’s GitHub Actions identity** via keyless Sigstore signing—no new signing secrets.
> 
> The **release workflow** installs **cosign v3.1.3** before Goreleaser runs. **Goreleaser** signs **`checksums.txt`** (which already covers all release binaries) with **`cosign sign-blob`**, publishing **`checksums.txt.sigstore.json`** alongside the release. Signing relies on the workflow’s existing **`id-token: write`** OIDC identity, similar to npm provenance.
> 
> If signing fails, the release should fail at that step rather than shipping unsigned checksums; full signing is only exercised on **`v*`** tag releases in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d8e89c999edd407bea5675cb91e9457136d779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->