### PR TITLE
ci: add a 3-day Dependabot cooldown on dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     cooldown:
-      default-days: 7
+      default-days: 3
     groups:
       go-dependencies:
         patterns:
@@ -17,7 +17,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 7
+      default-days: 3
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       go-dependencies:
         patterns:
@@ -14,6 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Adds a supply-chain cooldown so Dependabot won't propose a dependency version until it's been public for 3 days. Most malicious releases are caught and yanked within a few days, so a short hold avoids adopting a compromised version while keeping updates timely. Matches the 3-day `minimumReleaseAge` policy in revenuecat-app (pnpm).

- Applies to both `gomod` and `github-actions`.
- Uses Dependabot's native `cooldown: default-days: 3`.
- Security updates can still be merged manually anytime if we need a fix faster.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Dependabot timing with no runtime or application code impact.
> 
> **Overview**
> Adds Dependabot’s **`cooldown: default-days: 3`** to both the **`gomod`** and **`github-actions`** update entries in `.github/dependabot.yml`, so proposed bumps only appear after a release has been public for three days—aligned with a short supply-chain hold similar to pnpm’s `minimumReleaseAge` elsewhere.
> 
> Weekly schedules and grouping stay the same; this only delays *when* update PRs are opened, not manual security merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db364c15eb1869eaeb1e8cfad9f35eac4127b42c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->