### PR TITLE
ci: hard-fail on dependencies younger than the 3-day cooldown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
           version: v2.12.2
       - name: govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
+      - name: dependency cooldown
+        run: go list -m -json all | go run ./scripts/checkdepage
 
   darwin-build:
     runs-on: macos-14

--- a/scripts/checkdepage/main.go
+++ b/scripts/checkdepage/main.go
@@ -52,7 +52,7 @@ func findTooNew(r io.Reader, now time.Time, window time.Duration, ignore map[str
 }
 
 func main() {
-	days := 7
+	days := 3
 	if v := os.Getenv("DEP_COOLDOWN_DAYS"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 1 {

--- a/scripts/checkdepage/main.go
+++ b/scripts/checkdepage/main.go
@@ -1,0 +1,86 @@
+// Command check-dep-age fails the build when a module in the build list is
+// newer than the cooldown window. Feed it `go list -m -json all` on stdin.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type module struct {
+	Path    string
+	Version string
+	Time    *time.Time
+	Main    bool
+	Replace *module
+}
+
+type finding struct {
+	Path    string
+	Version string
+	Age     time.Duration
+}
+
+func findTooNew(r io.Reader, now time.Time, window time.Duration, ignore map[string]bool) ([]finding, error) {
+	dec := json.NewDecoder(r)
+	var out []finding
+	for dec.More() {
+		var m module
+		if err := dec.Decode(&m); err != nil {
+			return nil, err
+		}
+		eff := m
+		if m.Replace != nil {
+			eff = *m.Replace
+		}
+		if eff.Main || eff.Version == "" || eff.Time == nil || ignore[eff.Path] {
+			continue
+		}
+		if age := now.Sub(*eff.Time); age < window {
+			out = append(out, finding{eff.Path, eff.Version, age})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Age < out[j].Age })
+	return out, nil
+}
+
+func main() {
+	days := 7
+	if v := os.Getenv("DEP_COOLDOWN_DAYS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			fmt.Fprintf(os.Stderr, "invalid DEP_COOLDOWN_DAYS %q\n", v)
+			os.Exit(2)
+		}
+		days = n
+	}
+	ignore := map[string]bool{}
+	for _, p := range strings.Split(os.Getenv("DEP_COOLDOWN_IGNORE"), ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			ignore[p] = true
+		}
+	}
+
+	window := time.Duration(days) * 24 * time.Hour
+	found, err := findTooNew(os.Stdin, time.Now(), window, ignore)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "parsing `go list -m -json all` output:", err)
+		os.Exit(2)
+	}
+	if len(found) == 0 {
+		fmt.Printf("dep-age: all dependencies are at least %d days old\n", days)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "::error::%d dependency version(s) younger than the %d-day cooldown:\n", len(found), days)
+	for _, f := range found {
+		fmt.Fprintf(os.Stderr, "  %s %s (published %.1f days ago)\n", f.Path, f.Version, f.Age.Hours()/24)
+	}
+	fmt.Fprintf(os.Stderr, "Wait for them to age out, or override a specific module with DEP_COOLDOWN_IGNORE=<module-path>.\n")
+	os.Exit(1)
+}

--- a/scripts/checkdepage/main.go
+++ b/scripts/checkdepage/main.go
@@ -1,5 +1,6 @@
-// Command check-dep-age fails the build when a module in the build list is
-// newer than the cooldown window. Feed it `go list -m -json all` on stdin.
+// Command checkdepage fails the build when a module in the build list was
+// published more recently than the cooldown window. Feed it
+// `go list -m -json all` on stdin.
 package main
 
 import (
@@ -54,8 +55,8 @@ func main() {
 	days := 7
 	if v := os.Getenv("DEP_COOLDOWN_DAYS"); v != "" {
 		n, err := strconv.Atoi(v)
-		if err != nil || n < 0 {
-			fmt.Fprintf(os.Stderr, "invalid DEP_COOLDOWN_DAYS %q\n", v)
+		if err != nil || n < 1 {
+			fmt.Fprintf(os.Stderr, "invalid DEP_COOLDOWN_DAYS %q (must be a positive integer)\n", v)
 			os.Exit(2)
 		}
 		days = n
@@ -77,10 +78,10 @@ func main() {
 		fmt.Printf("dep-age: all dependencies are at least %d days old\n", days)
 		return
 	}
-	fmt.Fprintf(os.Stderr, "::error::%d dependency version(s) younger than the %d-day cooldown:\n", len(found), days)
 	for _, f := range found {
 		fmt.Fprintf(os.Stderr, "  %s %s (published %.1f days ago)\n", f.Path, f.Version, f.Age.Hours()/24)
 	}
 	fmt.Fprintf(os.Stderr, "Wait for them to age out, or override a specific module with DEP_COOLDOWN_IGNORE=<module-path>.\n")
+	fmt.Fprintf(os.Stderr, "::error::%d dependency version(s) younger than the %d-day supply-chain cooldown (see the list above)\n", len(found), days)
 	os.Exit(1)
 }

--- a/scripts/checkdepage/main_test.go
+++ b/scripts/checkdepage/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFindTooNew(t *testing.T) {
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	window := 7 * 24 * time.Hour
+
+	input := `
+{"Path":"example.com/main","Main":true}
+{"Path":"example.com/old","Version":"v1.0.0","Time":"2026-01-01T00:00:00Z"}
+{"Path":"example.com/fresh","Version":"v2.3.4","Time":"2026-08-24T00:00:00Z"}
+{"Path":"example.com/edge","Version":"v0.1.0","Time":"2026-08-19T13:00:00Z"}
+{"Path":"example.com/ignored","Version":"v9.9.9","Time":"2026-08-26T00:00:00Z"}
+{"Path":"example.com/notime","Version":"v1.2.3"}
+{"Path":"example.com/wrapper","Version":"v1.0.0","Time":"2026-01-01T00:00:00Z","Replace":{"Path":"example.com/replacement","Version":"v0.0.1","Time":"2026-08-25T00:00:00Z"}}
+`
+	ignore := map[string]bool{"example.com/ignored": true}
+	got, err := findTooNew(strings.NewReader(input), now, window, ignore)
+	if err != nil {
+		t.Fatalf("findTooNew: %v", err)
+	}
+
+	want := map[string]bool{
+		"example.com/fresh":       true, // 2 days old
+		"example.com/edge":        true, // ~6d23h old, just inside the window
+		"example.com/replacement": true, // replacement time is what counts
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d findings, want %d: %+v", len(got), len(want), got)
+	}
+	for _, f := range got {
+		if !want[f.Path] {
+			t.Errorf("unexpected finding: %s %s", f.Path, f.Version)
+		}
+	}
+	// youngest first
+	if got[0].Path != "example.com/replacement" || got[len(got)-1].Path != "example.com/edge" {
+		t.Errorf("not sorted youngest-first: %+v", got)
+	}
+}
+
+func TestFindTooNewAllOld(t *testing.T) {
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	input := `{"Path":"example.com/a","Version":"v1.0.0","Time":"2026-01-01T00:00:00Z"}`
+	got, err := findTooNew(strings.NewReader(input), now, 7*24*time.Hour, nil)
+	if err != nil {
+		t.Fatalf("findTooNew: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no findings, got %+v", got)
+	}
+}

--- a/scripts/checkdepage/main_test.go
+++ b/scripts/checkdepage/main_test.go
@@ -15,6 +15,7 @@ func TestFindTooNew(t *testing.T) {
 {"Path":"example.com/old","Version":"v1.0.0","Time":"2026-01-01T00:00:00Z"}
 {"Path":"example.com/fresh","Version":"v2.3.4","Time":"2026-08-24T00:00:00Z"}
 {"Path":"example.com/edge","Version":"v0.1.0","Time":"2026-08-19T13:00:00Z"}
+{"Path":"example.com/exact","Version":"v0.2.0","Time":"2026-08-19T12:00:00Z"}
 {"Path":"example.com/ignored","Version":"v9.9.9","Time":"2026-08-26T00:00:00Z"}
 {"Path":"example.com/notime","Version":"v1.2.3"}
 {"Path":"example.com/wrapper","Version":"v1.0.0","Time":"2026-01-01T00:00:00Z","Replace":{"Path":"example.com/replacement","Version":"v0.0.1","Time":"2026-08-25T00:00:00Z"}}
@@ -25,8 +26,10 @@ func TestFindTooNew(t *testing.T) {
 		t.Fatalf("findTooNew: %v", err)
 	}
 
+	// example.com/exact is exactly window-old and must NOT be flagged (strict <),
+	// so it's absent here; the len check below catches it if that regresses.
 	want := map[string]bool{
-		"example.com/fresh":       true, // 2 days old
+		"example.com/fresh":       true,
 		"example.com/edge":        true, // ~6d23h old, just inside the window
 		"example.com/replacement": true, // replacement time is what counts
 	}


### PR DESCRIPTION
The Dependabot cooldown (#158) only gates Dependabot's own auto-PRs. This adds a **hard CI gate** so *any* change (manual bump, transitive shift) that pulls in a dependency version younger than 3 days fails CI.

revenuecat-app gets this for free: pnpm's native `minimumReleaseAge` enforces a 3-day hold at install time. **Go has no equivalent**, so CI is the only place to enforce it, this is the Go analog of that policy.

**How it works**
- `scripts/checkdepage` reads `go list -m -json all` and exits non-zero if any module in the resolved build list was published within the cooldown window (default 3 days). Uses the `Time` Go records for each module version; no network calls, no jq.
- Runs in `ci.yml` right after `govulncheck`.
- Skips the main module, local `replace` targets, and modules with no timestamp; follows `replace` to the effective version.

**Overrides**
- `DEP_COOLDOWN_DAYS=N` to change the window (default 3).
- `DEP_COOLDOWN_IGNORE=module/path,other/path` to let a specific dependency through early (e.g. an urgent security patch).

**Behavior:** a bump to a version younger than the window is blocked until it ages out. Passes today on `main` (all current deps are older). Unit-tested (`main_test.go`): fresh/edge/exact-boundary/replaced flagged or skipped correctly, sorted youngest-first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only policy enforcement with no runtime or auth changes; main risk is blocking PRs until dependencies age out or are explicitly ignored.
> 
> **Overview**
> Adds a **supply-chain cooldown gate** to the main Go CI job so merges fail when the resolved module graph includes any version published inside a configurable age window (default **3 days**).
> 
> After `govulncheck`, CI runs `go list -m -json all` piped into new `scripts/checkdepage`, which parses module timestamps (including effective versions after `replace`), skips the main module and ignored paths, and exits with a GitHub Actions error listing versions that are still “too young.” Operators can widen the window with `DEP_COOLDOWN_DAYS` or bypass specific modules via `DEP_COOLDOWN_IGNORE`.
> 
> Unit tests cover boundary behavior (strict `<` window), ignore list, `replace` resolution, and youngest-first sorting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c404e124ab2041c0de2a6a34ebc3836e79f04c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->