### PR TITLE
fix(auth): `RC_API_KEY` outranks the stored OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ toolkit discovers every command with `rc commands --json` and
 | `--json` | Machine-readable output |
 | `--no-input` | Fail rather than prompt (for scripts/CI) |
 | `--profile <name>` | Config profile (precedence: flag → `$RC_PROFILE` → `rc profiles use` → `"default"`) |
-| `--api-key <key>` | Override profile key (`$RC_API_KEY`) |
+| `--api-key <key>` | Override the profile's credential (precedence: flag → `$RC_API_KEY` → OAuth login → stored key) |
 | `--yes, -y` | Skip confirmation prompts |
 | `--all` | Also show experimental (unreleased) commands in help |
 | `--no-color` | Disable ANSI color (also respects `$NO_COLOR`) |

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -95,7 +95,7 @@ func (e *APIError) Hint() string {
 func (e *APIError) credentialSourceNote() string {
 	switch e.CredentialSource {
 	case "env":
-		return " The active credential came from the RC_API_KEY environment variable — check your shell env (e.g. ~/.zshrc), or run `rc login`."
+		return " The active credential came from the RC_API_KEY environment variable, which overrides any stored login — unset it (check your shell env, e.g. ~/.zshrc) or point it at a key with the required scope."
 	case "flag":
 		return " The active credential came from the --api-key flag; pass a key with the required scope, or run `rc login`."
 	case "oauth":

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -56,7 +56,7 @@ func TestRicoChat_JSONApprovesDestructiveToolWithYes(t *testing.T) {
 		"rico", "delete the test offering",
 		"--conversation", "conv1",
 		"--approve-tools", "--yes", "--no-input", "--json",
-		"--api-key", "sk_test",
+		"--api-key", "atk_test",
 	)
 	if err != nil {
 		t.Fatalf("err = %v, stderr %s", err, stderr)
@@ -104,7 +104,7 @@ func TestRicoChat_JSONRejectsDestructiveToolWithoutYes(t *testing.T) {
 		"rico", "delete the test offering",
 		"--conversation", "conv1",
 		"--approve-tools", "--no-input", "--json",
-		"--api-key", "sk_test",
+		"--api-key", "atk_test",
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -136,7 +136,7 @@ func TestRicoChat_RemembersLastConversationForResume(t *testing.T) {
 	_, _, err := runCmdInConfigDir(t, configDir,
 		"rico", "delete the test offering",
 		"--conversation", "conv1",
-		"--approve-tools", "--yes", "--no-input", "--json", "--api-key", "sk_test",
+		"--approve-tools", "--yes", "--no-input", "--json", "--api-key", "atk_test",
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -157,14 +157,14 @@ func TestRicoChat_RemembersLastConversationForResume(t *testing.T) {
 }
 
 func TestRicoChat_ResumeRequiresInteractivePicker(t *testing.T) {
-	_, _, err := runCmd(t, "rico", "hi", "--resume", "--no-input", "--api-key", "sk_test")
+	_, _, err := runCmd(t, "rico", "hi", "--resume", "--no-input", "--api-key", "atk_test")
 	if err == nil || !strings.Contains(err.Error(), "conversation ID is required") {
 		t.Fatalf("err = %v", err)
 	}
 }
 
 func TestRicoChat_RequiresPromptNonInteractive(t *testing.T) {
-	_, _, err := runCmd(t, "rico", "--no-input", "--api-key", "sk_test")
+	_, _, err := runCmd(t, "rico", "--no-input", "--api-key", "atk_test")
 	if err == nil || !strings.Contains(err.Error(), "message is required") {
 		t.Fatalf("err = %v", err)
 	}
@@ -172,7 +172,7 @@ func TestRicoChat_RequiresPromptNonInteractive(t *testing.T) {
 
 // --json is non-interactive: no message must error, not open the chat UI.
 func TestRico_JSONWithoutMessageRequiresMessage(t *testing.T) {
-	_, _, err := runCmd(t, "rico", "--json", "--api-key", "sk_test")
+	_, _, err := runCmd(t, "rico", "--json", "--api-key", "atk_test")
 	if err == nil || !strings.Contains(err.Error(), "message is required") {
 		t.Fatalf("err = %v", err)
 	}
@@ -188,7 +188,7 @@ func TestRicoConversations_ListJSON(t *testing.T) {
 	defer server.Close()
 	t.Setenv("RC_RICO_BASE_URL", server.URL)
 
-	stdout, _, err := runCmd(t, "rico", "conversations", "list", "--json", "--no-input", "--api-key", "sk_test")
+	stdout, _, err := runCmd(t, "rico", "conversations", "list", "--json", "--no-input", "--api-key", "atk_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -220,7 +220,7 @@ Two login methods are available:
                  as-is and never refreshed.
 
 The API key can also be supplied via RC_API_KEY for CI use without storing
-anything on disk.`,
+anything on disk; while set, it overrides the stored login.`,
 		Example: `  # Interactive — prompts for method
   rc auth login
 
@@ -399,11 +399,19 @@ Shows which credential is in control — precedence is the --api-key flag, then 
 				scopes, scopesKnown = credentialScopes(token)
 			}
 
-			identity := rt.Config.AccountEmail
-			if rt.Config.AccountName != "" && identity != "" {
-				identity = fmt.Sprintf("%s <%s>", rt.Config.AccountName, identity)
-			} else if rt.Config.AccountName != "" {
-				identity = rt.Config.AccountName
+			// The cached identity belongs to the profile's stored credential;
+			// under a flag/env override the active key may be a different
+			// account entirely, so only claim an identity when the stored
+			// credential is the one in charge (same gate as auth_origin).
+			profileCredActive := credSource == config.SourceOAuth || credSource == config.SourceProfile
+			var identity string
+			if profileCredActive {
+				identity = rt.Config.AccountEmail
+				if rt.Config.AccountName != "" && identity != "" {
+					identity = fmt.Sprintf("%s <%s>", rt.Config.AccountName, identity)
+				} else if rt.Config.AccountName != "" {
+					identity = rt.Config.AccountName
+				}
 			}
 
 			if !authenticated {
@@ -440,11 +448,15 @@ Shows which credential is in control — precedence is the --api-key flag, then 
 			if !rt.Out.IsJSON() {
 				return nil
 			}
+			accountEmail, accountName := "", ""
+			if profileCredActive {
+				accountEmail, accountName = rt.Config.AccountEmail, rt.Config.AccountName
+			}
 			out := map[string]any{
 				"profile":                profileName,
 				"authenticated":          authenticated,
-				"account_email":          rt.Config.AccountEmail,
-				"account_name":           rt.Config.AccountName,
+				"account_email":          accountEmail,
+				"account_name":           accountName,
 				"method":                 method,
 				"credential_source":      string(credSource),
 				"credential_description": rt.Config.CredentialDescription(),
@@ -454,8 +466,7 @@ Shows which credential is in control — precedence is the --api-key flag, then 
 			}
 			// Only report auth_origin when the stored credential is the active
 			// one; under a flag/env override it's the wrong credential's origin.
-			if authenticated && rt.Config.AuthSource != "" &&
-				(credSource == config.SourceOAuth || credSource == config.SourceProfile) {
+			if authenticated && rt.Config.AuthSource != "" && profileCredActive {
 				out["auth_origin"] = rt.Config.AuthSource
 			}
 			if credSource == config.SourceOAuth {
@@ -572,6 +583,7 @@ func loginWithAPIKey(ctx context.Context, rt *Runtime, key string) error {
 }
 
 func loginWithAPIKeyOrigin(ctx context.Context, rt *Runtime, key, origin string) error {
+	rt.client = nil
 	rt.Config.SetAPIKey(key)
 	rt.Config.AuthSource = origin
 	rt.Config.TokenType = ""

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -684,11 +684,7 @@ func loginWithOAuth(ctx context.Context, rt *Runtime) error {
 		return fmt.Errorf("token exchange: %w", err)
 	}
 
-	rt.Config.TokenType = "oauth"
-	rt.Config.AccessToken = tr.AccessToken
-	rt.Config.RefreshToken = tr.RefreshToken
-	rt.Config.TokenExpiresAt = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
-	rt.Config.APIKey = ""
+	rt.Config.SetOAuthTokens(tr.AccessToken, tr.RefreshToken, time.Now().Add(time.Duration(tr.ExpiresIn)*time.Second))
 	rt.Config.AuthSource = config.AuthOriginOAuthLogin
 	clearProjectBinding(rt)
 
@@ -763,11 +759,7 @@ func signupWithOAuth(ctx context.Context, rt *Runtime, email, name, password str
 	}
 	_ = svc.LogoutLoginToken(ctx, login.AuthenticationToken)
 
-	rt.Config.TokenType = "oauth"
-	rt.Config.AccessToken = tokens.AccessToken
-	rt.Config.RefreshToken = tokens.RefreshToken
-	rt.Config.TokenExpiresAt = time.Now().Add(time.Duration(tokens.ExpiresIn) * time.Second)
-	rt.Config.APIKey = ""
+	rt.Config.SetOAuthTokens(tokens.AccessToken, tokens.RefreshToken, time.Now().Add(time.Duration(tokens.ExpiresIn)*time.Second))
 	rt.Config.AccountEmail = email
 	rt.Config.AccountName = name
 	rt.Config.AuthSource = config.AuthOriginOAuthLogin

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -339,7 +339,7 @@ func newAuthStatusCmd() *cobra.Command {
 		Short:   "Show the current authentication state",
 		Long: `Displays the active profile, cached account identity when known, auth method, and project context. If a project is configured, validates that it is still accessible.
 
-Shows which credential is in control (the OAuth login, an RC_API_KEY env var, the --api-key flag, or a stored key) and warns when more than one is present. Pass --scopes to surface the active credential's scopes before attempting writes.`,
+Shows which credential is in control — precedence is the --api-key flag, then the RC_API_KEY env var, then the OAuth login, then a stored key — and warns when more than one is present. Pass --scopes to surface the active credential's scopes before attempting writes.`,
 		Example: `  rc auth status
   rc auth status --json
   rc auth status --scopes --json`,

--- a/internal/cli/auth_login_test.go
+++ b/internal/cli/auth_login_test.go
@@ -27,7 +27,9 @@ func runStatus(t *testing.T, configDir string, args ...string) (string, string) 
 	return out.String(), errb.String()
 }
 
-func TestAuthStatus_OAuthNotShadowedByEnvAPIKey(t *testing.T) {
+// RC_API_KEY is a per-invocation override: it outranks the stored OAuth
+// login, and the shadowing is reported via credential_conflict.
+func TestAuthStatus_EnvAPIKeyShadowsOAuth(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("RC_CONFIG_DIR", dir)
 	t.Setenv("RC_PROFILE", "")
@@ -50,17 +52,17 @@ func TestAuthStatus_OAuthNotShadowedByEnvAPIKey(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &st); err != nil {
 		t.Fatalf("status not JSON: %v\n%s", err, stdout)
 	}
-	if st.Data.Method != "oauth" {
-		t.Errorf("method should be oauth, got %q", st.Data.Method)
+	if st.Data.Method != "api_key" {
+		t.Errorf("method should be api_key, got %q", st.Data.Method)
 	}
-	if st.Data.CredentialSource != "oauth" {
-		t.Errorf("credential_source should be oauth, got %q", st.Data.CredentialSource)
+	if st.Data.CredentialSource != "env" {
+		t.Errorf("credential_source should be env, got %q", st.Data.CredentialSource)
 	}
 	if st.Data.Conflict == nil {
 		t.Fatal("expected a credential_conflict field when OAuth + RC_API_KEY coexist")
 	}
-	if got, _ := st.Data.Conflict["active_source"].(string); got != "oauth" {
-		t.Errorf("conflict active_source should be oauth, got %q", got)
+	if got, _ := st.Data.Conflict["active_source"].(string); got != "env" {
+		t.Errorf("conflict active_source should be env, got %q", got)
 	}
 }
 

--- a/internal/cli/auth_mcp_import.go
+++ b/internal/cli/auth_mcp_import.go
@@ -142,16 +142,12 @@ func loginWithMCPCredential(ctx context.Context, rt *Runtime, cred mcpCredential
 	if cred.durable {
 		return loginWithAPIKeyOrigin(ctx, rt, cred.Token, config.AuthOriginMCPImport)
 	}
-	rt.Config.APIKey = ""
-	rt.Config.TokenType = "oauth"
-	rt.Config.AccessToken = cred.Token
-	rt.Config.AuthSource = config.AuthOriginMCPImport
 	// No refresh token and no expiry on purpose: this is a borrowed access
 	// token. Empty RefreshToken makes Config.NeedsRefresh() return false, so
 	// rc never tries (and never could) to refresh it — which also means it
 	// can't rotation-revoke the MCP's own session.
-	rt.Config.RefreshToken = ""
-	rt.Config.TokenExpiresAt = time.Time{}
+	rt.Config.SetOAuthTokens(cred.Token, "", time.Time{})
+	rt.Config.AuthSource = config.AuthOriginMCPImport
 	rt.Config.AccountEmail = ""
 	rt.Config.AccountName = ""
 	rt.client = nil

--- a/internal/cli/auth_status_test.go
+++ b/internal/cli/auth_status_test.go
@@ -170,6 +170,25 @@ func TestAuthStatus_ConflictNamesMCPImportedIgnored(t *testing.T) {
 	}
 }
 
+// Under an env override the profile's cached identity is not the active
+// account, so status must not claim it in the header or the JSON fields.
+func TestAuthStatus_EnvOverrideHidesProfileIdentity(t *testing.T) {
+	dir := t.TempDir()
+	seedProfile(t, dir, &config.Config{
+		TokenType:    "oauth",
+		AccessToken:  "atk_live",
+		AccountEmail: "jane@example.com",
+		AccountName:  "Jane",
+		AuthSource:   config.AuthOriginOAuthLogin,
+	})
+	t.Setenv("RC_API_KEY", "sk_env")
+
+	data := statusData(t, dir)
+	wantField(t, data, "credential_source", "env")
+	wantField(t, data, "account_email", "")
+	wantField(t, data, "account_name", "")
+}
+
 // RC_API_KEY outranks an OAuth login, and the shadowed login must be named.
 func TestAuthStatus_ConflictNamesActiveAndIgnored(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/cli/auth_status_test.go
+++ b/internal/cli/auth_status_test.go
@@ -146,9 +146,10 @@ func TestAuthStatus_NamesMCPImportedAPIKey(t *testing.T) {
 	wantField(t, data, "auth_origin", "mcp_import")
 }
 
-// The conflict message must name the active credential with the same
-// provenance-aware phrasing as the Credential line, not a bare source name.
-func TestAuthStatus_ConflictNamesMCPImportedActive(t *testing.T) {
+// The conflict message must name credentials with the same provenance-aware
+// phrasing as the Credential line, not a bare source name — including the
+// shadowed MCP-imported token when RC_API_KEY outranks it.
+func TestAuthStatus_ConflictNamesMCPImportedIgnored(t *testing.T) {
 	dir := t.TempDir()
 	seedProfile(t, dir, &config.Config{
 		TokenType:   "oauth",
@@ -158,7 +159,7 @@ func TestAuthStatus_ConflictNamesMCPImportedActive(t *testing.T) {
 	t.Setenv("RC_API_KEY", "sk_env")
 
 	data := statusData(t, dir)
-	wantField(t, data, "credential_source", "oauth")
+	wantField(t, data, "credential_source", "env")
 	conflict, ok := data["credential_conflict"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected credential_conflict, got %v", data["credential_conflict"])
@@ -169,7 +170,7 @@ func TestAuthStatus_ConflictNamesMCPImportedActive(t *testing.T) {
 	}
 }
 
-// An RC_API_KEY set alongside an OAuth login must not silently take over.
+// RC_API_KEY outranks an OAuth login, and the shadowed login must be named.
 func TestAuthStatus_ConflictNamesActiveAndIgnored(t *testing.T) {
 	dir := t.TempDir()
 	seedProfile(t, dir, &config.Config{
@@ -182,20 +183,20 @@ func TestAuthStatus_ConflictNamesActiveAndIgnored(t *testing.T) {
 	t.Setenv("RC_API_KEY", "sk_env")
 
 	data := statusData(t, dir)
-	wantField(t, data, "credential_source", "oauth")
+	wantField(t, data, "credential_source", "env")
 	conflict, ok := data["credential_conflict"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected credential_conflict, got %v", data["credential_conflict"])
 	}
-	wantField(t, conflict, "active_source", "oauth")
+	wantField(t, conflict, "active_source", "env")
 	ignored, _ := conflict["ignored_sources"].([]any)
 	found := false
 	for _, s := range ignored {
-		if s == "env" {
+		if s == "oauth" {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("ignored_sources should name the env key, got %v", ignored)
+		t.Errorf("ignored_sources should name the OAuth login, got %v", ignored)
 	}
 }

--- a/internal/cli/paywalls_ai.go
+++ b/internal/cli/paywalls_ai.go
@@ -856,6 +856,9 @@ func loadPaywallAIImages(paths []string) ([]paywallai.InputAttachment, error) {
 
 func paywallAIClient(rt *Runtime, baseURL string) (*paywallai.Client, error) {
 	// rt.API() refreshes the OAuth token if needed and enforces login.
+	// Unlike Rico, this backend also accepts sk_ secret keys, as long as they
+	// carry the project_configuration:offerings:read_write scope (verified
+	// against backend auth 2026-08-31) — so no sk_ guard here.
 	if _, err := rt.API(); err != nil {
 		return nil, err
 	}

--- a/internal/cli/rico.go
+++ b/internal/cli/rico.go
@@ -692,6 +692,15 @@ func ricoClient(rt *Runtime, baseURL string) (*rico.Client, error) {
 	if _, err := rt.API(); err != nil {
 		return nil, err
 	}
+	// Rico's backend authenticates logins only — a secret API key is rejected
+	// outright (verified against its auth 2026-08-31), so fail here with the
+	// remedy instead of letting the server return an opaque 401.
+	if token, source := rt.Config.Credential(); strings.HasPrefix(token, "sk_") {
+		if source == config.SourceEnv && rt.Config.IsOAuth() {
+			return nil, fmt.Errorf("your RC_API_KEY is overriding the stored login with an API key, which Rico can't accept — unset RC_API_KEY and retry")
+		}
+		return nil, fmt.Errorf("talking to Rico requires a RevenueCat login; API keys can't authenticate it — run `rc login` (browser)")
+	}
 	return rico.NewClient(rico.Options{
 		BaseURL:      baseURL,
 		Token:        agentAuthToken(rt),
@@ -700,9 +709,12 @@ func ricoClient(rt *Runtime, baseURL string) (*rico.Client, error) {
 	}), nil
 }
 
-// agentAuthToken returns the credential sent to the Rico/Paywalls AI backends —
-// the CLI's own bearer token; both backends accept CLI OAuth tokens
-// (verified live 2026-07-17).
+// agentAuthToken returns the credential sent to the Rico / Paywall AI editor
+// backends — the CLI's own bearer token. Both accept CLI OAuth tokens
+// (verified live 2026-07-17). Secret keys differ (verified against backend
+// auth 2026-08-31): the Paywall AI editor accepts sk_ keys carrying the
+// project_configuration:offerings:read_write scope; Rico rejects sk_ keys
+// entirely — ricoClient guards that before any request.
 func agentAuthToken(rt *Runtime) string {
 	return rt.Config.BearerToken()
 }

--- a/internal/cli/rico_guard_test.go
+++ b/internal/cli/rico_guard_test.go
@@ -1,0 +1,57 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/revenuecat/cli/internal/cli"
+	"github.com/revenuecat/cli/internal/config"
+)
+
+// runRicoList invokes `rc rico conversations list` without the shared helper,
+// which force-clears RC_API_KEY and would defeat the env-override cases.
+func runRicoList(t *testing.T, configDir string) error {
+	t.Helper()
+	t.Setenv("RC_CONFIG_DIR", configDir)
+	t.Setenv("RC_PROFILE", "")
+	t.Setenv("RC_PROJECT_ID", "")
+	t.Setenv("RC_BASE_URL", "")
+	// Hermetic backstop: if the guard ever fails to fire, the request hits a
+	// closed local port instead of the real backend.
+	t.Setenv("RC_RICO_BASE_URL", "http://127.0.0.1:1")
+
+	var out, errb bytes.Buffer
+	root := cli.NewRootCmd("test")
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	root.SetArgs([]string{"rico", "conversations", "list", "--json", "--no-input"})
+	return root.ExecuteContext(context.Background())
+}
+
+// Rico's backend rejects secret API keys, so the CLI fails fast with the
+// remedy instead of surfacing the server's opaque 401.
+func TestRico_SecretKeyFailsFastWithRemedy(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("RC_CONFIG_DIR", configDir)
+	t.Setenv("RC_API_KEY", "")
+	if err := config.Save("", &config.Config{APIKey: "sk_stored", ProjectID: "proj_x"}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runRicoList(t, configDir)
+	if err == nil || !strings.Contains(err.Error(), "rc login") {
+		t.Fatalf("want a fail-fast login remedy for an sk_ credential, got: %v", err)
+	}
+
+	// When RC_API_KEY shadows a working login, the remedy is to unset it.
+	if err := config.Save("", &config.Config{TokenType: "oauth", AccessToken: "atk_live", ProjectID: "proj_x"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RC_API_KEY", "sk_env")
+	err = runRicoList(t, configDir)
+	if err == nil || !strings.Contains(err.Error(), "unset RC_API_KEY") {
+		t.Fatalf("want the unset-RC_API_KEY remedy when a login is shadowed, got: %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -108,7 +108,7 @@ Agent-friendly entrypoints:
 	pf.BoolVarP(&g.Verbose, "verbose", "v", false, "enable verbose logging")
 	_ = pf.MarkHidden("verbose")
 	pf.StringVar(&g.Profile, "profile", "", "configuration profile to use (default: active profile)")
-	pf.StringVar(&g.APIKey, "api-key", "", "RevenueCat API key (overrides profile; or set RC_API_KEY)")
+	pf.StringVar(&g.APIKey, "api-key", "", "RevenueCat API key (precedence: this flag, then RC_API_KEY, then the OAuth login, then the stored key)")
 	pf.StringVar(&g.ProjectID, "project-id", "", "RevenueCat project ID (highest precedence, then RC_PROJECT_ID, then .revenuecat.json in the directory tree, then the profile default)")
 	pf.StringVar(&g.Format, "format", "", "jq expression applied to --json output (e.g. '.data.items[].id')")
 	pf.BoolVar(&g.NoColor, "no-color", false, "disable ANSI color (also honors NO_COLOR)")

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -88,15 +88,14 @@ func RuntimeFrom(ctx context.Context) *Runtime {
 }
 
 // API returns a lazily-initialized API client built from the active config.
-// If the profile holds an OAuth token that is near expiry, a silent refresh
-// is attempted before building the client.
+// If the active credential is a near-expiry OAuth token, a silent refresh is
+// attempted first; when a flag or RC_API_KEY override is in charge the profile
+// isn't touched (or re-saved).
 func (r *Runtime) API() (*api.Client, error) {
 	if r.client != nil {
 		return r.client, nil
 	}
 
-	// Refresh only when the OAuth token is the credential this run will use —
-	// a flag or RC_API_KEY override shouldn't touch (or re-save) the profile.
 	if _, source := r.Config.Credential(); source == config.SourceOAuth && r.Config.NeedsRefresh() {
 		r.silentRefresh()
 	}
@@ -143,6 +142,9 @@ func (r *Runtime) warnCredentialConflict(active config.CredentialSource) {
 	}
 	r.warnedCredConflict = true
 	r.Out.AlwaysWarn(credentialConflictMessage(r.Config, active, present))
+	if active == config.SourceEnv && r.Config.IsOAuth() {
+		r.Out.Hint("Unset RC_API_KEY to use the login stored in this profile.")
+	}
 }
 
 func credentialConflictMessage(cfg *config.Config, active config.CredentialSource, present []config.CredentialSource) string {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -95,7 +95,9 @@ func (r *Runtime) API() (*api.Client, error) {
 		return r.client, nil
 	}
 
-	if r.Config.NeedsRefresh() {
+	// Refresh only when the OAuth token is the credential this run will use —
+	// a flag or RC_API_KEY override shouldn't touch (or re-save) the profile.
+	if _, source := r.Config.Credential(); source == config.SourceOAuth && r.Config.NeedsRefresh() {
 		r.silentRefresh()
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,15 +116,20 @@ func (c *Config) BearerToken() string {
 	return tok
 }
 
+// Credential resolves the active credential. Precedence (highest first):
+// --api-key flag > RC_API_KEY env > OAuth login > stored key. Per-invocation
+// overrides outrank what's saved in the profile, so a CI job or a one-off
+// `RC_API_KEY=... rc ...` always acts on the account it names, even on a
+// machine with a logged-in profile.
 func (c *Config) Credential() (token string, source CredentialSource) {
 	if c.flagAPIKey != "" {
 		return c.flagAPIKey, SourceFlag
 	}
-	if c.TokenType == "oauth" && c.AccessToken != "" {
-		return c.AccessToken, SourceOAuth
-	}
 	if c.envAPIKey.set && c.envAPIKey.env != "" {
 		return c.envAPIKey.env, SourceEnv
+	}
+	if c.TokenType == "oauth" && c.AccessToken != "" {
+		return c.AccessToken, SourceOAuth
 	}
 	if k := c.storedAPIKey(); k != "" {
 		return k, SourceProfile
@@ -196,11 +201,11 @@ func (c *Config) PresentCredentialSources() []CredentialSource {
 	if c.flagAPIKey != "" {
 		s = append(s, SourceFlag)
 	}
-	if c.TokenType == "oauth" && c.AccessToken != "" {
-		s = append(s, SourceOAuth)
-	}
 	if c.envAPIKey.set && c.envAPIKey.env != "" {
 		s = append(s, SourceEnv)
+	}
+	if c.TokenType == "oauth" && c.AccessToken != "" {
+		s = append(s, SourceOAuth)
 	}
 	if c.storedAPIKey() != "" {
 		s = append(s, SourceProfile)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,10 +117,9 @@ func (c *Config) BearerToken() string {
 }
 
 // Credential resolves the active credential. Precedence (highest first):
-// --api-key flag > RC_API_KEY env > OAuth login > stored key. Per-invocation
-// overrides outrank what's saved in the profile, so a CI job or a one-off
-// `RC_API_KEY=... rc ...` always acts on the account it names, even on a
-// machine with a logged-in profile.
+// --api-key flag > RC_API_KEY env > OAuth login > stored key — so a CI job or
+// a one-off `RC_API_KEY=... rc ...` always acts on the account it names, even
+// on a machine with a logged-in profile.
 func (c *Config) Credential() (token string, source CredentialSource) {
 	if c.flagAPIKey != "" {
 		return c.flagAPIKey, SourceFlag

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,6 +222,20 @@ func (c *Config) SetAPIKey(key string) {
 	c.envAPIKey = envOverride{}
 }
 
+// SetOAuthTokens stores OAuth credentials, clearing any flag or env override —
+// like SetAPIKey, an explicit login supersedes ambient credentials for the rest
+// of the invocation, so the token just obtained (not RC_API_KEY) is what gets
+// validated, reported, and saved.
+func (c *Config) SetOAuthTokens(accessToken, refreshToken string, expiresAt time.Time) {
+	c.TokenType = "oauth"
+	c.AccessToken = accessToken
+	c.RefreshToken = refreshToken
+	c.TokenExpiresAt = expiresAt
+	c.APIKey = ""
+	c.flagAPIKey = ""
+	c.envAPIKey = envOverride{}
+}
+
 // IsOAuth reports whether this profile holds OAuth credentials.
 func (c *Config) IsOAuth() bool {
 	return c.TokenType == "oauth"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/revenuecat/cli/internal/config"
 )
@@ -356,6 +357,38 @@ func TestSetAPIKey_SupersedesEnvOverride(t *testing.T) {
 	}
 	if got.APIKey != "sk_typed" {
 		t.Errorf("SetAPIKey value should persist to disk, got %q", got.APIKey)
+	}
+}
+
+// A fresh login must validate and save the token it just obtained, not a
+// lingering RC_API_KEY — SetOAuthTokens supersedes the env override the same
+// way SetAPIKey does.
+func TestSetOAuthTokens_SupersedesEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	setEnv(t, map[string]string{"RC_CONFIG_DIR": dir, "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
+
+	t.Setenv("RC_API_KEY", "sk_env")
+	cfg, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.SetOAuthTokens("atk_fresh", "rt_fresh", time.Now().Add(time.Hour))
+	if tok, src := cfg.Credential(); src != config.SourceOAuth || tok != "atk_fresh" {
+		t.Errorf("want oauth/atk_fresh after SetOAuthTokens, got %q/%q", src, tok)
+	}
+	if err := config.Save("default", cfg); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("RC_API_KEY", "")
+	got, err := config.Load("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessToken != "atk_fresh" || got.RefreshToken != "rt_fresh" {
+		t.Errorf("tokens should persist to disk, got %+v", got)
+	}
+	if got.APIKey != "" {
+		t.Errorf("env API key leaked to disk: %q", got.APIKey)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -253,29 +253,29 @@ func saveOAuthProfile(t *testing.T, name string) {
 	}
 }
 
-func TestCredential_OAuthBeatsEnvAPIKey(t *testing.T) {
+func TestCredential_EnvAPIKeyBeatsOAuth(t *testing.T) {
 	dir := t.TempDir()
 	setEnv(t, map[string]string{"RC_CONFIG_DIR": dir, "RC_API_KEY": "", "RC_PROJECT_ID": "", "RC_BASE_URL": "", "RC_PROFILE": ""})
 	saveOAuthProfile(t, "default")
 
-	t.Setenv("RC_API_KEY", "sk_under_scoped_env")
+	t.Setenv("RC_API_KEY", "sk_env_override")
 	cfg, err := config.Load("default")
 	if err != nil {
 		t.Fatal(err)
 	}
 	tok, src := cfg.Credential()
-	if src != config.SourceOAuth {
-		t.Errorf("want source oauth, got %q", src)
+	if src != config.SourceEnv {
+		t.Errorf("want source env, got %q", src)
 	}
-	if tok != "oauth_access_token" {
-		t.Errorf("want the OAuth token, got %q", tok)
+	if tok != "sk_env_override" {
+		t.Errorf("want the env key, got %q", tok)
 	}
-	if cfg.BearerToken() != "oauth_access_token" {
-		t.Errorf("BearerToken should be the OAuth token, got %q", cfg.BearerToken())
+	if cfg.BearerToken() != "sk_env_override" {
+		t.Errorf("BearerToken should be the env key, got %q", cfg.BearerToken())
 	}
 	present := cfg.PresentCredentialSources()
-	if len(present) != 2 || present[0] != config.SourceOAuth || present[1] != config.SourceEnv {
-		t.Errorf("want [oauth env] present, got %v", present)
+	if len(present) != 2 || present[0] != config.SourceEnv || present[1] != config.SourceOAuth {
+		t.Errorf("want [env oauth] present, got %v", present)
 	}
 }
 


### PR DESCRIPTION
Setting RC_API_KEY had no effect once a profile held an OAuth login — the stored login silently won, so scripts and CI runs could act on the wrong account. Env vars are the standard override everywhere else (gh, aws, stripe), so the credential order now matches: --api-key flag, then RC_API_KEY, then the OAuth login, then the stored key.

The existing multiple-credentials warning now reads the right way around, and a shadowed OAuth token no longer gets silently refreshed and re-saved on runs it isn't used for.

```
$ RC_API_KEY=sk_... rc auth status
✓ Logged in as dev@example.com (profile: default)
  Credential                  the RC_API_KEY environment variable
! Multiple credentials found — using the RC_API_KEY environment variable; ignoring the OAuth login in this profile.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global auth precedence and refresh behavior, which can shift which account commands use when OAuth and env keys coexist; impact is mostly clearer warnings and more predictable overrides.
> 
> **Overview**
> **`RC_API_KEY` and `--api-key` now win over a profile OAuth login**, matching typical CLI override behavior so CI and one-off env runs use the account they name instead of the logged-in profile silently.
> 
> Credential resolution, conflict warnings, and docs are aligned with precedence **flag → `RC_API_KEY` → OAuth → stored key**. **`rc auth status`** no longer shows cached profile email/name or `auth_origin` when an env/flag override is active; conflict output names the shadowed login correctly. OAuth **silent refresh** runs only when OAuth is the active source, avoiding refresh/save of a token that is not in use. Fresh logins use **`SetOAuthTokens`**, which clears ambient overrides for the rest of the invocation like **`SetAPIKey`**.
> 
> **Rico** rejects **`sk_`** credentials up front (login-only backend) with actionable errors, including when **`RC_API_KEY`** overrides a stored login. Paywall AI still accepts scoped **`sk_`** keys; Rico tests use **`atk_`** tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e36aeb0bdb848ee69c719dabd7ff72805eb255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->