### PR TITLE
fix(products): stop enforcing store rules the server owns

### DIFF
--- a/docs/specs/v2-beta-overlay.yaml
+++ b/docs/specs/v2-beta-overlay.yaml
@@ -623,8 +623,11 @@ paths:
         the app, store identifier, and product metadata; if a RevenueCat product already
         exists for that app and store identifier, the plan will target the existing
         product, otherwise the plan keeps it as a new RevenueCat product to create
-        when applied. Set `store` to `app_store` or `play_store` and populate the
-        matching `store_state` payload. For App Store subscriptions, include `common.pricing.equalize_missing_subscription_prices`
+        when applied. Set `store` to `app_store`, `play_store`, `rc_billing`, or
+        `test_store` and populate the matching `store_state` payload; rc_billing
+        and test_store price per currency via `common.pricing.currency_prices`
+        (keyed by ISO currency code, each with `amount_micros`) instead of
+        `territory_prices`. For App Store subscriptions, include `common.pricing.equalize_missing_subscription_prices`
         with a `base_territory` such as `US` when missing subscription territory prices
         should be filled using Apple''s equalized price points. For App Store subscription
         creation, provide `common.duration` using canonical ISO-like values such as

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -295,12 +295,6 @@ products.`,
 			if isTestStoreApp(app) && productType == "subscription" && duration == "" {
 				return fmt.Errorf("--duration is required for Test Store subscription products (e.g. P1M, P1Y)")
 			}
-			if duration != "" && !isTestStoreApp(app) {
-				return fmt.Errorf("--duration and other subscription parameters are only supported for Test Store products, but app %s is a %s app", appID, app.Type)
-			}
-			if duration != "" && isTestStoreApp(app) && productType != "subscription" {
-				return fmt.Errorf("--duration is only valid for a Test Store subscription product, not a %s product", productType)
-			}
 			body := api.ProductCreate{
 				StoreIdentifier: storeID,
 				// Sent verbatim: Test Store takes consumable/non_consumable but reads back
@@ -310,7 +304,9 @@ products.`,
 				DisplayName: displayName,
 				Title:       title,
 			}
-			if productType == "subscription" && duration != "" {
+			// Sent whenever provided — never silently dropped; whether the
+			// store/type combination takes it is the server's call.
+			if duration != "" {
 				body.Subscription = &api.ProductSubscriptionInput{Duration: api.Duration(duration)}
 			}
 			p, err := client.Products.Create(cmd.Context(), projectID, body)

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -22,7 +22,7 @@ func newProductsCmd() *cobra.Command {
 		Aliases: []string{"product"},
 		Short:   "Manage Products in the project catalog",
 		Long: `A Product is a store SKU a Customer buys — its identifier must match the
-store (App Store, Play, Stripe, Test Store). Attach Products to Packages and
+store (App Store, Play, Stripe, Web Billing, Test Store). Attach Products to Packages and
 Entitlements so a purchase grants access. These commands inspect, create,
 price, and push Products.`,
 		Example: `  rc products list
@@ -226,18 +226,20 @@ func newProductsCreateCmd() *cobra.Command {
 
 --store-id is the Product identifier on the platform store; it must match the
 store exactly (required).
---app-id is the RevenueCat app ID (required; picker shown in a terminal). The
-app's store decides which --type values are valid.
---type is the Product type; valid values depend on the app's store. Test Store
-accepts subscription, consumable, non_consumable; App Store accepts subscription,
-one_time, consumable, non_consumable, non_renewing_subscription; Play Store
-accepts subscription, one_time, consumable, non_consumable; Amazon, Stripe, and
-other stores accept subscription and one_time (required; picker shown in a
-terminal).
+--app-id is the RevenueCat app ID (required; picker shown in a terminal).
+--type is the Product type (required; picker shown in a terminal). Typical
+values per store: Test Store — subscription, consumable, non_consumable;
+App Store — subscription, one_time, consumable, non_consumable,
+non_renewing_subscription; Play Store — subscription, one_time, consumable,
+non_consumable; other stores — subscription, one_time. The server validates
+the combination; the CLI sends whatever you pass.
 --title is the Customer-facing Product title (required for Test Store Products).
---duration is an ISO 8601 duration, e.g. P1M, P1Y. It is required for Test Store
-subscription Products; subscription parameters are only supported for Test Store
-products.`,
+--duration is an ISO 8601 duration, e.g. P1M, P1Y. It is required for Test
+Store subscription Products; for other stores it is passed through and the
+server decides whether it applies.
+
+Web Billing products are created through store-state plans (rc products store
+sync/plan), not this command.`,
 		Example: `  rc products create --store-id premium_monthly --type subscription --app-id test_app --title "Premium Monthly" --duration P1M
   rc products create --store-id coins_100 --type consumable --app-id test_app --title "100 Coins"
   rc products create --store-id com.example.once --type one_time --app-id app_x --display-name "Unlock Everything"`,
@@ -272,9 +274,6 @@ products.`,
 			if err != nil {
 				return err
 			}
-			// Which stores/types the API accepts is the server's call — the
-			// per-store lists below only feed the interactive picker, never
-			// validation, so newly ungated stores work without a CLI release.
 			allowed := productTypesForStore(app.Type)
 			if productType == "" {
 				if !rt.CanPrompt() {
@@ -304,25 +303,29 @@ products.`,
 				DisplayName: displayName,
 				Title:       title,
 			}
-			// Sent whenever provided — never silently dropped; whether the
-			// store/type combination takes it is the server's call.
 			if duration != "" {
 				body.Subscription = &api.ProductSubscriptionInput{Duration: api.Duration(duration)}
 			}
 			p, err := client.Products.Create(cmd.Context(), projectID, body)
 			if err != nil {
+				if string(app.Type) == string(api.RCBillingAppTypeRcBilling) {
+					rt.Out.Hint("Web Billing products are created through store-state plans:  rc products store sync " + appID)
+				}
 				return err
 			}
 			rt.Out.Success(fmt.Sprintf("Created product %s", p.ID))
+			if duration != "" && (p.Subscription == nil || p.Subscription.Duration == nil) {
+				rt.Out.AlwaysWarn("The server ignored --duration for this product.")
+			}
 			return rt.Out.Render(p)
 		},
 	}
 	cmd.Flags().StringVar(&storeID, "store-id", "", "store product identifier (required)")
-	cmd.Flags().StringVar(&productType, "type", "", "product type (valid values depend on the app's store; picker shown in TTY if omitted)")
+	cmd.Flags().StringVar(&productType, "type", "", "product type (picker shown in TTY if omitted; the server validates the store/type combination)")
 	cmd.Flags().StringVar(&appID, "app-id", "", "app ID to associate with (picker shown in TTY if omitted)")
 	cmd.Flags().StringVar(&displayName, "display-name", "", "human-readable display name")
 	cmd.Flags().StringVar(&title, "title", "", "user-facing product title (required for Test Store products)")
-	cmd.Flags().StringVar(&duration, "duration", "", "subscription duration as ISO 8601 (e.g. P1M, P1Y); Test Store products only")
+	cmd.Flags().StringVar(&duration, "duration", "", "subscription duration as ISO 8601 (e.g. P1M, P1Y); required for Test Store subscriptions, passed through elsewhere")
 	return cmd
 }
 

--- a/internal/cli/products.go
+++ b/internal/cli/products.go
@@ -272,9 +272,9 @@ products.`,
 			if err != nil {
 				return err
 			}
-			if string(app.Type) == string(api.RCBillingAppTypeRcBilling) {
-				return fmt.Errorf("can't create Web Billing products via the API; configure them in the RevenueCat dashboard")
-			}
+			// Which stores/types the API accepts is the server's call — the
+			// per-store lists below only feed the interactive picker, never
+			// validation, so newly ungated stores work without a CLI release.
 			allowed := productTypesForStore(app.Type)
 			if productType == "" {
 				if !rt.CanPrompt() {
@@ -288,9 +288,6 @@ products.`,
 				if err := tui.Form(false).Field(sel).Run(); err != nil {
 					return err
 				}
-			}
-			if !containsProductType(allowed, productType) {
-				return fmt.Errorf("--type must be one of %s for a %s app, got %q", strings.Join(productTypeValues(allowed), ", "), app.Type, productType)
 			}
 			if isTestStoreApp(app) && title == "" {
 				return fmt.Errorf("--title is required for Test Store products")
@@ -333,9 +330,9 @@ products.`,
 	return cmd
 }
 
-// productTypesForStore returns the product types each store's API accepts. These
-// aren't in the flat ProductType enum, so they're encoded here; the sets' union
-// must stay covering the enum (TestProductTypeStoreSetsCoverEnum).
+// productTypesForStore returns the product types each store typically offers,
+// for the interactive picker only — the server owns the real rules. The sets'
+// union must stay covering the enum (TestProductTypeStoreSetsCoverEnum).
 func productTypesForStore(appType api.AppType) []api.ProductType {
 	switch string(appType) {
 	case string(api.TestStoreAppTypeTestStore):
@@ -373,15 +370,6 @@ func productTypeValues(types []api.ProductType) []string {
 		out[i] = string(t)
 	}
 	return out
-}
-
-func containsProductType(types []api.ProductType, value string) bool {
-	for _, t := range types {
-		if string(t) == value {
-			return true
-		}
-	}
-	return false
 }
 
 func productTypeLabel(t api.ProductType) string {

--- a/internal/cli/products_create_test.go
+++ b/internal/cli/products_create_test.go
@@ -121,31 +121,23 @@ func TestProductTypeStoreSetsCoverEnum(t *testing.T) {
 	}
 }
 
-func TestProductsCreate_DurationRejectedOnAppStore(t *testing.T) {
-	requests, _, err := runProductsCreate(t, "app_store",
-		"--store-id", "sid", "--type", "subscription", "--app-id", "app", "--title", "T", "--duration", "P1M")
-	if err == nil {
-		t.Fatal("expected client-side rejection for --duration on an App Store app")
-	}
-	if !strings.Contains(err.Error(), "Test Store") {
-		t.Fatalf("error should explain Test Store restriction, got: %v", err)
-	}
-	if postedProducts(requests) {
-		t.Fatalf("--duration reached the server on an App Store app: %v", requests)
-	}
-}
-
-func TestProductsCreate_DurationRejectedOnTestStoreNonSubscription(t *testing.T) {
-	requests, _, err := runProductsCreate(t, "test_store",
-		"--store-id", "sid", "--type", "consumable", "--app-id", "app", "--title", "T", "--duration", "P1M")
-	if err == nil {
-		t.Fatal("expected client-side rejection for --duration on a Test Store consumable")
-	}
-	if !strings.Contains(err.Error(), "--duration") {
-		t.Fatalf("error should mention --duration, got: %v", err)
-	}
-	if postedProducts(requests) {
-		t.Fatalf("--duration reached the server on a Test Store consumable: %v", requests)
+func TestProductsCreate_DurationOutsideTestStoreSubscriptionReachesServer(t *testing.T) {
+	for _, tc := range []struct{ appType, productType string }{
+		{"app_store", "subscription"},
+		{"test_store", "consumable"},
+	} {
+		requests, body, err := runProductsCreate(t, tc.appType,
+			"--store-id", "sid", "--type", tc.productType, "--app-id", "app", "--title", "T", "--duration", "P1M")
+		if err != nil {
+			t.Fatalf("%s %s: create should defer to the server, got: %v", tc.appType, tc.productType, err)
+		}
+		if !postedProducts(requests) {
+			t.Fatalf("%s %s: create did not reach the server: %v", tc.appType, tc.productType, requests)
+		}
+		sub, ok := body["subscription"].(map[string]any)
+		if !ok || sub["duration"] != "P1M" {
+			t.Fatalf("%s %s: outgoing subscription duration missing, body: %v", tc.appType, tc.productType, body)
+		}
 	}
 }
 

--- a/internal/cli/products_create_test.go
+++ b/internal/cli/products_create_test.go
@@ -53,8 +53,6 @@ func postedProducts(requests []string) bool {
 	return false
 }
 
-// The server owns which store/type combinations are valid — every create
-// reaches it, including combinations the picker wouldn't offer.
 func TestProductsCreate_AnyTypeReachesServer(t *testing.T) {
 	cases := []struct {
 		appType     string

--- a/internal/cli/products_create_test.go
+++ b/internal/cli/products_create_test.go
@@ -53,65 +53,37 @@ func postedProducts(requests []string) bool {
 	return false
 }
 
-func TestProductsCreate_TypeAcceptanceByStore(t *testing.T) {
+// The server owns which store/type combinations are valid — every create
+// reaches it, including combinations the picker wouldn't offer.
+func TestProductsCreate_AnyTypeReachesServer(t *testing.T) {
 	cases := []struct {
-		name        string
 		appType     string
 		productType string
-		accepted    bool
 	}{
-		{"test_store subscription", "test_store", "subscription", true},
-		{"test_store consumable", "test_store", "consumable", true},
-		{"test_store non_consumable", "test_store", "non_consumable", true},
-		{"test_store one_time", "test_store", "one_time", false},
-		{"test_store non_renewing_subscription", "test_store", "non_renewing_subscription", false},
-
-		{"app_store subscription", "app_store", "subscription", true},
-		{"app_store one_time", "app_store", "one_time", true},
-		{"app_store non_renewing_subscription", "app_store", "non_renewing_subscription", true},
-		{"app_store consumable", "app_store", "consumable", true},
-		{"app_store non_consumable", "app_store", "non_consumable", true},
-
-		{"play_store subscription", "play_store", "subscription", true},
-		{"play_store one_time", "play_store", "one_time", true},
-		{"play_store non_renewing_subscription", "play_store", "non_renewing_subscription", false},
-		{"play_store consumable", "play_store", "consumable", true},
-		{"play_store non_consumable", "play_store", "non_consumable", true},
-
-		{"amazon one_time", "amazon", "one_time", true},
-		{"amazon non_renewing_subscription", "amazon", "non_renewing_subscription", false},
-		{"amazon consumable", "amazon", "consumable", false},
-		{"stripe subscription", "stripe", "subscription", true},
-		{"stripe non_renewing_subscription", "stripe", "non_renewing_subscription", false},
-		{"roku non_renewing_subscription", "roku", "non_renewing_subscription", false},
-		{"roku subscription", "roku", "subscription", true},
-		{"roku one_time", "roku", "one_time", true},
-		{"roku consumable", "roku", "consumable", false},
+		{"test_store", "subscription"},
+		{"test_store", "one_time"},
+		{"app_store", "non_renewing_subscription"},
+		{"play_store", "non_renewing_subscription"},
+		{"amazon", "consumable"},
+		{"stripe", "subscription"},
+		{"roku", "one_time"},
+		{"rc_billing", "subscription"},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.appType+" "+tc.productType, func(t *testing.T) {
 			args := []string{"--store-id", "sid", "--type", tc.productType, "--app-id", "app", "--title", "T"}
 			if tc.appType == "test_store" && tc.productType == "subscription" {
 				args = append(args, "--duration", "P1M")
 			}
 			requests, body, err := runProductsCreate(t, tc.appType, args...)
-			if tc.accepted {
-				if err != nil {
-					t.Fatalf("expected accept, got error: %v", err)
-				}
-				if !postedProducts(requests) {
-					t.Fatalf("accepted type did not reach the create endpoint: %v", requests)
-				}
-				if got, _ := body["type"].(string); got != tc.productType {
-					t.Fatalf("outgoing type = %q, want %q", got, tc.productType)
-				}
-				return
+			if err != nil {
+				t.Fatalf("create should defer to the server, got error: %v", err)
 			}
-			if err == nil {
-				t.Fatal("expected client-side rejection, got nil error")
+			if !postedProducts(requests) {
+				t.Fatalf("create did not reach the create endpoint: %v", requests)
 			}
-			if postedProducts(requests) {
-				t.Fatalf("rejected type still reached the create endpoint: %v", requests)
+			if got, _ := body["type"].(string); got != tc.productType {
+				t.Fatalf("outgoing type = %q, want %q", got, tc.productType)
 			}
 		})
 	}
@@ -174,20 +146,6 @@ func TestProductsCreate_DurationRejectedOnTestStoreNonSubscription(t *testing.T)
 	}
 	if postedProducts(requests) {
 		t.Fatalf("--duration reached the server on a Test Store consumable: %v", requests)
-	}
-}
-
-func TestProductsCreate_RejectsWebBilling(t *testing.T) {
-	requests, _, err := runProductsCreate(t, "rc_billing",
-		"--store-id", "sid", "--type", "subscription", "--app-id", "app", "--title", "T")
-	if err == nil {
-		t.Fatal("expected client-side rejection creating a Web Billing product")
-	}
-	if !strings.Contains(err.Error(), "Web Billing") {
-		t.Fatalf("error should explain Web Billing can't be created, got: %v", err)
-	}
-	if postedProducts(requests) {
-		t.Fatalf("Web Billing create reached the server: %v", requests)
 	}
 }
 

--- a/internal/cli/products_store.go
+++ b/internal/cli/products_store.go
@@ -16,7 +16,7 @@ import (
 func newProductsStoreCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "store",
-		Short: "Plan and sync Product state with the App Store or Google Play",
+		Short: "Plan and sync Product store state (App Store, Google Play, Web Billing, Test Store)",
 		Long: `Product store-state plans are persisted by RevenueCat, not by the rc
 process. Humans can use sync for an in-memory plan/review/apply flow. Agents can
 create a plan, inspect its plan ID in a later process, then apply or discard
@@ -87,8 +87,8 @@ func newProductsStoreSyncCmd() *cobra.Command {
 		Short: "Gather desired state, review its plan, and optionally apply it",
 		Long: `Runs the complete human workflow in one rc process: gather desired state
 interactively or from CSV/JSON, persist it as a RevenueCat plan, wait for its
-diff, display warnings, and ask before applying the exact plan to the App Store
-or Google Play.
+diff, display warnings, and ask before applying the exact plan to the store
+(App Store, Google Play, Web Billing, or Test Store).
 
 No local file is required. Without --file, interactive terminals prompt for
 product fields and keep the answers only in process memory. For automation,
@@ -227,7 +227,7 @@ func newProductsStoreApplyCmd() *cobra.Command {
 		Use:   "apply <plan-id>",
 		Short: "Apply an already-reviewed Product store-state plan",
 		Long: `Fetches the persisted plan, displays its exact diff and warnings, and
-applies it to the App Store or Google Play after confirmation. Automation must
+applies it to the store after confirmation. Automation must
 pass --yes. This command never reconstructs desired state from a local file; it
 applies the plan ID supplied.
 
@@ -279,7 +279,7 @@ func newProductsStoreDiscardCmd() *cobra.Command {
 		Use:   "discard <plan-id>",
 		Short: "Discard a Product store-state plan without applying it",
 		Long: `Discards a persisted plan so it can no longer be applied. Nothing is
-written to the App Store or Google Play.
+written to the store.
 
 Reversibility: irreversible — re-plan to review the changes again.
 

--- a/internal/cli/products_store.go
+++ b/internal/cli/products_store.go
@@ -337,9 +337,6 @@ func resolveStoreStateApp(cmd *cobra.Command, args []string) (string, *api.App, 
 	if err != nil {
 		return "", nil, nil, err
 	}
-	if app.Type != "app_store" && app.Type != "play_store" {
-		return "", nil, nil, fmt.Errorf("app %s does not use the App Store or Play Store", appID)
-	}
 	return projectID, app, client, nil
 }
 

--- a/internal/cli/products_store_csv.go
+++ b/internal/cli/products_store_csv.go
@@ -78,8 +78,7 @@ func readStoreStateCSVReader(input io.Reader, appID string) ([]api.StoreStatePla
 			continue
 		}
 		store, identifier := value("store"), value("store_identifier")
-		// Which stores plans support is the server's call (rc_billing and
-		// test_store joined app_store/play_store); only require the field.
+		// The server owns the supported store set; only require the field.
 		if store == "" {
 			return nil, fmt.Errorf("store-state CSV line %d: store is required", line)
 		}
@@ -143,21 +142,38 @@ func mergeStoreCSVRow(p *storeCSVProduct, value func(string) string, line int) e
 	territory := strings.ToUpper(value("territory"))
 	amount, currency := value("amount"), strings.ToUpper(value("currency"))
 	if amount != "" || currency != "" {
-		if territory == "" || amount == "" || currency == "" {
-			return fmt.Errorf("store-state CSV line %d: territory, amount, and currency must be provided together", line)
-		}
-		micros, err := decimalToMicros(amount)
-		if err != nil {
-			return fmt.Errorf("store-state CSV line %d: invalid amount: %w", line, err)
-		}
-		price := map[string]any{"amount_micros": micros, "currency": currency}
-		if startDate := value("start_date"); startDate != "" {
-			price["start_date"] = startDate
-		}
-		pricing := childMap(p.common, "pricing")
-		prices := childMap(pricing, "territory_prices")
-		if err := mergeCSVMapValue(prices, territory, price, "price", line); err != nil {
-			return err
+		if currencyPricedStore(p.store) {
+			if territory != "" {
+				return fmt.Errorf("store-state CSV line %d: territory does not apply to %s prices; leave it empty", line, p.store)
+			}
+			if amount == "" || currency == "" {
+				return fmt.Errorf("store-state CSV line %d: amount and currency must be provided together", line)
+			}
+			micros, err := decimalToMicros(amount)
+			if err != nil {
+				return fmt.Errorf("store-state CSV line %d: invalid amount: %w", line, err)
+			}
+			prices := childMap(childMap(p.common, "pricing"), "currency_prices")
+			if err := mergeCSVMapValue(prices, currency, map[string]any{"amount_micros": micros}, "price", line); err != nil {
+				return err
+			}
+		} else {
+			if territory == "" || amount == "" || currency == "" {
+				return fmt.Errorf("store-state CSV line %d: territory, amount, and currency must be provided together", line)
+			}
+			micros, err := decimalToMicros(amount)
+			if err != nil {
+				return fmt.Errorf("store-state CSV line %d: invalid amount: %w", line, err)
+			}
+			price := map[string]any{"amount_micros": micros, "currency": currency}
+			if startDate := value("start_date"); startDate != "" {
+				price["start_date"] = startDate
+			}
+			pricing := childMap(p.common, "pricing")
+			prices := childMap(pricing, "territory_prices")
+			if err := mergeCSVMapValue(prices, territory, price, "price", line); err != nil {
+				return err
+			}
 		}
 	}
 	if available := value("available"); available != "" {
@@ -198,10 +214,20 @@ func mergeStoreCSVRow(p *storeCSVProduct, value func(string) string, line int) e
 		}
 	}
 
-	if p.store == "app_store" {
+	switch p.store {
+	case "app_store":
 		return mergeAppStoreCSVRow(p, value, locale, line)
+	case "play_store":
+		return mergePlayStoreCSVRow(p, value, line)
+	default:
+		return nil
 	}
-	return mergePlayStoreCSVRow(p, value, line)
+}
+
+// currencyPricedStore reports stores priced per currency (currency_prices)
+// rather than per territory (territory_prices).
+func currencyPricedStore(store string) bool {
+	return store == "rc_billing" || store == "test_store"
 }
 
 func mergeAppStoreCSVRow(p *storeCSVProduct, value func(string) string, locale string, line int) error {

--- a/internal/cli/products_store_csv.go
+++ b/internal/cli/products_store_csv.go
@@ -116,9 +116,7 @@ func readStoreStateCSVReader(input io.Reader, appID string) ([]api.StoreStatePla
 		if p.productType == "" || p.displayName == "" || p.title == "" {
 			return nil, fmt.Errorf("store-state CSV product %q: product_type, display_name, and title are required", p.storeIdentifier)
 		}
-		if p.title != "" {
-			p.common["title"] = p.title
-		}
+		p.common["title"] = p.title
 		if p.duration != "" {
 			p.common["duration"] = p.duration
 		}
@@ -153,8 +151,12 @@ func mergeStoreCSVRow(p *storeCSVProduct, value func(string) string, line int) e
 		// (App Store, Play), empty → currency_prices (Web Billing, Test
 		// Store). Which shape a store accepts is the server's rule.
 		if territory == "" {
+			price := map[string]any{"amount_micros": micros}
+			if startDate := value("start_date"); startDate != "" {
+				price["start_date"] = startDate
+			}
 			prices := childMap(childMap(p.common, "pricing"), "currency_prices")
-			if err := mergeCSVMapValue(prices, currency, map[string]any{"amount_micros": micros}, "price", line); err != nil {
+			if err := mergeCSVMapValue(prices, currency, price, "price", line); err != nil {
 				return err
 			}
 		} else {

--- a/internal/cli/products_store_csv.go
+++ b/internal/cli/products_store_csv.go
@@ -142,35 +142,27 @@ func mergeStoreCSVRow(p *storeCSVProduct, value func(string) string, line int) e
 	territory := strings.ToUpper(value("territory"))
 	amount, currency := value("amount"), strings.ToUpper(value("currency"))
 	if amount != "" || currency != "" {
-		if currencyPricedStore(p.store) {
-			if territory != "" {
-				return fmt.Errorf("store-state CSV line %d: territory does not apply to %s prices; leave it empty", line, p.store)
-			}
-			if amount == "" || currency == "" {
-				return fmt.Errorf("store-state CSV line %d: amount and currency must be provided together", line)
-			}
-			micros, err := decimalToMicros(amount)
-			if err != nil {
-				return fmt.Errorf("store-state CSV line %d: invalid amount: %w", line, err)
-			}
+		if amount == "" || currency == "" {
+			return fmt.Errorf("store-state CSV line %d: amount and currency must be provided together", line)
+		}
+		micros, err := decimalToMicros(amount)
+		if err != nil {
+			return fmt.Errorf("store-state CSV line %d: invalid amount: %w", line, err)
+		}
+		// The territory column picks the price shape: set → territory_prices
+		// (App Store, Play), empty → currency_prices (Web Billing, Test
+		// Store). Which shape a store accepts is the server's rule.
+		if territory == "" {
 			prices := childMap(childMap(p.common, "pricing"), "currency_prices")
 			if err := mergeCSVMapValue(prices, currency, map[string]any{"amount_micros": micros}, "price", line); err != nil {
 				return err
 			}
 		} else {
-			if territory == "" || amount == "" || currency == "" {
-				return fmt.Errorf("store-state CSV line %d: territory, amount, and currency must be provided together", line)
-			}
-			micros, err := decimalToMicros(amount)
-			if err != nil {
-				return fmt.Errorf("store-state CSV line %d: invalid amount: %w", line, err)
-			}
 			price := map[string]any{"amount_micros": micros, "currency": currency}
 			if startDate := value("start_date"); startDate != "" {
 				price["start_date"] = startDate
 			}
-			pricing := childMap(p.common, "pricing")
-			prices := childMap(pricing, "territory_prices")
+			prices := childMap(childMap(p.common, "pricing"), "territory_prices")
 			if err := mergeCSVMapValue(prices, territory, price, "price", line); err != nil {
 				return err
 			}
@@ -224,8 +216,9 @@ func mergeStoreCSVRow(p *storeCSVProduct, value func(string) string, line int) e
 	}
 }
 
-// currencyPricedStore reports stores priced per currency (currency_prices)
-// rather than per territory (territory_prices).
+// currencyPricedStore reports stores known to price per currency rather than
+// per territory. Interactive-prompt hint only (skips the territory question);
+// the payload shape always follows whether the user provided a territory.
 func currencyPricedStore(store string) bool {
 	return store == "rc_billing" || store == "test_store"
 }

--- a/internal/cli/products_store_csv.go
+++ b/internal/cli/products_store_csv.go
@@ -78,8 +78,10 @@ func readStoreStateCSVReader(input io.Reader, appID string) ([]api.StoreStatePla
 			continue
 		}
 		store, identifier := value("store"), value("store_identifier")
-		if store != "app_store" && store != "play_store" {
-			return nil, fmt.Errorf("store-state CSV line %d: store must be app_store or play_store", line)
+		// Which stores plans support is the server's call (rc_billing and
+		// test_store joined app_store/play_store); only require the field.
+		if store == "" {
+			return nil, fmt.Errorf("store-state CSV line %d: store is required", line)
 		}
 		if identifier == "" {
 			return nil, fmt.Errorf("store-state CSV line %d: store_identifier is required", line)

--- a/internal/cli/products_store_csv.go
+++ b/internal/cli/products_store_csv.go
@@ -147,9 +147,9 @@ func mergeStoreCSVRow(p *storeCSVProduct, value func(string) string, line int) e
 		if err != nil {
 			return fmt.Errorf("store-state CSV line %d: invalid amount: %w", line, err)
 		}
-		// The territory column picks the price shape: set → territory_prices
-		// (App Store, Play), empty → currency_prices (Web Billing, Test
-		// Store). Which shape a store accepts is the server's rule.
+		// A price with a territory goes in territory_prices; one without goes
+		// in currency_prices. The CLI only places the value in the payload —
+		// whether the store accepts that shape is the server's call.
 		if territory == "" {
 			price := map[string]any{"amount_micros": micros}
 			if startDate := value("start_date"); startDate != "" {

--- a/internal/cli/products_store_input.go
+++ b/internal/cli/products_store_input.go
@@ -26,7 +26,7 @@ func (o *storeStateInputOptions) addFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	flags.StringVarP(&o.file, "file", "f", "", "desired state file, or - for stdin (env: RC_STORE_STATE_FILE)")
 	flags.StringVar(&o.inputFormat, "input-format", "", "input format for stdin or extensionless files: csv or json")
-	flags.StringVar(&o.equalizeBaseTerritory, "equalize-base-territory", "", "equalize missing subscription prices from this base territory (e.g. US)")
+	flags.StringVar(&o.equalizeBaseTerritory, "equalize-base-territory", "", "equalize missing subscription prices from this base territory (e.g. US); App Store only")
 }
 
 func (o *storeStateInputOptions) desiredStates(rt *Runtime, app *api.App, stdin io.Reader) ([]api.StoreStatePlanDesiredState, error) {
@@ -35,8 +35,15 @@ func (o *storeStateInputOptions) desiredStates(rt *Runtime, app *api.App, stdin 
 		return nil, err
 	}
 	if base := strings.ToUpper(strings.TrimSpace(o.equalizeBaseTerritory)); base != "" {
+		injected := false
 		for i := range states {
-			injectEqualizeBaseTerritory(&states[i], base)
+			if states[i].Store == "app_store" {
+				injectEqualizeBaseTerritory(&states[i], base)
+				injected = true
+			}
+		}
+		if !injected {
+			return nil, errors.New("--equalize-base-territory applies to App Store desired states, and this input has none")
 		}
 	}
 	return states, nil
@@ -116,6 +123,7 @@ func readStoreStateJSON(input io.Reader, appID string) ([]api.StoreStatePlanDesi
 	}
 	for i := range envelope.DesiredStates {
 		state := &envelope.DesiredStates[i]
+		state.Store = strings.TrimSpace(state.Store)
 		if state.Store == "" {
 			return nil, fmt.Errorf("desired_states[%d].store is required", i)
 		}
@@ -136,16 +144,25 @@ func readStoreStateJSON(input io.Reader, appID string) ([]api.StoreStatePlanDesi
 
 func promptStoreState(app *api.App) ([]api.StoreStatePlanDesiredState, error) {
 	states := make([]api.StoreStatePlanDesiredState, 0, 1)
+	// The desired state's store mirrors the app's store type; never coerce
+	// unknown app types to app_store. Currency-priced stores take
+	// currency_prices, not territory-keyed prices, so their form skips the
+	// territory question.
+	store := string(app.Type)
+	currencyPriced := currencyPricedStore(store)
 	for {
 		var identifier, productType, displayName, title, duration string
 		var territory, amount, currency, locale, localizedName, localizedDescription string
-		if err := tui.Form(false).
+		form := tui.Form(false).
 			Field(huh.NewInput().Title("Store product identifier").Value(&identifier).Validate(tui.Required("store product identifier"))).
 			Field(huh.NewInput().Title("RevenueCat product type").Description("subscription, consumable, non_consumable, non_renewing_subscription, or one_time").Value(&productType).Validate(tui.Required("product type"))).
 			Field(huh.NewInput().Title("Display name").Value(&displayName).Validate(tui.Required("display name"))).
 			Field(huh.NewInput().Title("Store title").Value(&title).Validate(tui.Required("title"))).
-			Field(huh.NewInput().Title("Duration (subscriptions, e.g. P1M)").Value(&duration)).
-			Field(huh.NewInput().Title("Initial territory (e.g. US)").Value(&territory)).
+			Field(huh.NewInput().Title("Duration (subscriptions, e.g. P1M)").Value(&duration))
+		if !currencyPriced {
+			form = form.Field(huh.NewInput().Title("Initial territory (e.g. US)").Value(&territory))
+		}
+		if err := form.
 			Field(huh.NewInput().Title("Price amount (e.g. 9.99)").Value(&amount)).
 			Field(huh.NewInput().Title("Currency (e.g. USD)").Value(&currency)).
 			Field(huh.NewInput().Title("Localization locale (e.g. en-US)").Value(&locale)).
@@ -159,16 +176,26 @@ func promptStoreState(app *api.App) ([]api.StoreStatePlanDesiredState, error) {
 			common["duration"] = duration
 		}
 		if territory != "" || amount != "" || currency != "" {
-			if territory == "" || amount == "" || currency == "" {
+			if currencyPriced {
+				if amount == "" || currency == "" {
+					return nil, errors.New("price amount and currency must be provided together")
+				}
+			} else if territory == "" || amount == "" || currency == "" {
 				return nil, errors.New("territory, price amount, and currency must be provided together")
 			}
 			micros, err := decimalToMicros(amount)
 			if err != nil {
 				return nil, fmt.Errorf("invalid price amount: %w", err)
 			}
-			common["pricing"] = map[string]any{"territory_prices": map[string]any{
-				strings.ToUpper(territory): map[string]any{"amount_micros": micros, "currency": strings.ToUpper(currency)},
-			}}
+			if currencyPriced {
+				common["pricing"] = map[string]any{"currency_prices": map[string]any{
+					strings.ToUpper(currency): map[string]any{"amount_micros": micros},
+				}}
+			} else {
+				common["pricing"] = map[string]any{"territory_prices": map[string]any{
+					strings.ToUpper(territory): map[string]any{"amount_micros": micros, "currency": strings.ToUpper(currency)},
+				}}
+			}
 		}
 		if locale != "" || localizedName != "" || localizedDescription != "" {
 			if locale == "" || localizedName == "" {
@@ -178,10 +205,6 @@ func promptStoreState(app *api.App) ([]api.StoreStatePlanDesiredState, error) {
 				"name": localizedName, "description": localizedDescription,
 			}}
 		}
-		// The desired state's store mirrors the app's store type — plans
-		// support more than Apple/Play (rc_billing, test_store), so never
-		// coerce unknown app types to app_store.
-		store := string(app.Type)
 		var storeState map[string]any
 		if app.Type == "play_store" {
 			parts := strings.SplitN(identifier, ":", 2)

--- a/internal/cli/products_store_input.go
+++ b/internal/cli/products_store_input.go
@@ -116,8 +116,8 @@ func readStoreStateJSON(input io.Reader, appID string) ([]api.StoreStatePlanDesi
 	}
 	for i := range envelope.DesiredStates {
 		state := &envelope.DesiredStates[i]
-		if state.Store != "app_store" && state.Store != "play_store" {
-			return nil, fmt.Errorf("desired_states[%d].store must be app_store or play_store", i)
+		if state.Store == "" {
+			return nil, fmt.Errorf("desired_states[%d].store is required", i)
 		}
 		if state.ProductID == "" && state.CreateRevenueCatProduct == nil {
 			return nil, fmt.Errorf("desired_states[%d] requires product_id or create_revenuecat_product", i)
@@ -178,10 +178,12 @@ func promptStoreState(app *api.App) ([]api.StoreStatePlanDesiredState, error) {
 				"name": localizedName, "description": localizedDescription,
 			}}
 		}
-		store := "app_store"
+		// The desired state's store mirrors the app's store type — plans
+		// support more than Apple/Play (rc_billing, test_store), so never
+		// coerce unknown app types to app_store.
+		store := string(app.Type)
 		var storeState map[string]any
 		if app.Type == "play_store" {
-			store = "play_store"
 			parts := strings.SplitN(identifier, ":", 2)
 			if productType == "subscription" {
 				if len(parts) != 2 || duration == "" {

--- a/internal/cli/products_store_input.go
+++ b/internal/cli/products_store_input.go
@@ -145,9 +145,9 @@ func readStoreStateJSON(input io.Reader, appID string) ([]api.StoreStatePlanDesi
 func promptStoreState(app *api.App) ([]api.StoreStatePlanDesiredState, error) {
 	states := make([]api.StoreStatePlanDesiredState, 0, 1)
 	// The desired state's store mirrors the app's store type; never coerce
-	// unknown app types to app_store. Currency-priced stores take
-	// currency_prices, not territory-keyed prices, so their form skips the
-	// territory question.
+	// unknown app types to app_store. Stores known to price per currency skip
+	// the territory question, but the price shape follows the answer either
+	// way — the server owns which shape a store accepts.
 	store := string(app.Type)
 	currencyPriced := currencyPricedStore(store)
 	for {
@@ -176,18 +176,14 @@ func promptStoreState(app *api.App) ([]api.StoreStatePlanDesiredState, error) {
 			common["duration"] = duration
 		}
 		if territory != "" || amount != "" || currency != "" {
-			if currencyPriced {
-				if amount == "" || currency == "" {
-					return nil, errors.New("price amount and currency must be provided together")
-				}
-			} else if territory == "" || amount == "" || currency == "" {
-				return nil, errors.New("territory, price amount, and currency must be provided together")
+			if amount == "" || currency == "" {
+				return nil, errors.New("price amount and currency must be provided together")
 			}
 			micros, err := decimalToMicros(amount)
 			if err != nil {
 				return nil, fmt.Errorf("invalid price amount: %w", err)
 			}
-			if currencyPriced {
+			if territory == "" {
 				common["pricing"] = map[string]any{"currency_prices": map[string]any{
 					strings.ToUpper(currency): map[string]any{"amount_micros": micros},
 				}}

--- a/internal/cli/products_store_test.go
+++ b/internal/cli/products_store_test.go
@@ -137,10 +137,17 @@ func TestReadStoreStateCSV_CurrencyPricedStores(t *testing.T) {
 		t.Fatalf("no store-specific shaping expected for rc_billing, got: %v", states[0].StoreState)
 	}
 
-	// Territory pricing is Apple/Play-shaped; reject it for currency stores.
-	badCSV := "store,store_identifier,product_type,display_name,title,territory,amount,currency\n" +
+	// The territory column picks the price shape; the CLI forwards it even on
+	// currency-priced stores and lets the server rule on whether it applies.
+	territoryCSV := "store,store_identifier,product_type,display_name,title,territory,amount,currency\n" +
 		"test_store,premium_test,subscription,Premium,Premium,US,9.99,USD\n"
-	if _, err := readStoreStateCSVReader(strings.NewReader(badCSV), "app_x"); err == nil || !strings.Contains(err.Error(), "territory") {
-		t.Fatalf("want a territory-does-not-apply error, got: %v", err)
+	states, err = readStoreStateCSVReader(strings.NewReader(territoryCSV), "app_x")
+	if err != nil {
+		t.Fatalf("territory-priced test_store row should parse: %v", err)
+	}
+	pricing, _ = states[0].Common["pricing"].(map[string]any)
+	territoryPrices, _ := pricing["territory_prices"].(map[string]any)
+	if _, ok := territoryPrices["US"]; !ok {
+		t.Fatalf("want US territory price forwarded as given, got common: %v", states[0].Common)
 	}
 }

--- a/internal/cli/products_store_test.go
+++ b/internal/cli/products_store_test.go
@@ -106,3 +106,16 @@ func runStoreSync(t *testing.T, planOnly bool) (requests []string, stdout, stder
 	err = root.ExecuteContext(context.Background())
 	return requests, out.String(), errOut.String(), err
 }
+
+func TestReadStoreStateJSON_AcceptsAllPlanStores(t *testing.T) {
+	for _, store := range []string{"app_store", "play_store", "rc_billing", "test_store"} {
+		in := strings.NewReader(`{"desired_states":[{"store":"` + store + `","create_revenuecat_product":{"app_id":"app_x","store_identifier":"sid","type":"subscription","display_name":"D","title":"T"}}]}`)
+		states, err := readStoreStateJSON(in, "app_x")
+		if err != nil {
+			t.Fatalf("store %s should parse (the server owns the supported set): %v", store, err)
+		}
+		if len(states) != 1 || states[0].Store != store {
+			t.Fatalf("store %s: unexpected states %+v", store, states)
+		}
+	}
+}

--- a/internal/cli/products_store_test.go
+++ b/internal/cli/products_store_test.go
@@ -112,10 +112,35 @@ func TestReadStoreStateJSON_AcceptsAllPlanStores(t *testing.T) {
 		in := strings.NewReader(`{"desired_states":[{"store":"` + store + `","create_revenuecat_product":{"app_id":"app_x","store_identifier":"sid","type":"subscription","display_name":"D","title":"T"}}]}`)
 		states, err := readStoreStateJSON(in, "app_x")
 		if err != nil {
-			t.Fatalf("store %s should parse (the server owns the supported set): %v", store, err)
+			t.Fatalf("store %s should parse: %v", store, err)
 		}
 		if len(states) != 1 || states[0].Store != store {
 			t.Fatalf("store %s: unexpected states %+v", store, states)
 		}
+	}
+}
+
+func TestReadStoreStateCSV_CurrencyPricedStores(t *testing.T) {
+	csvInput := "store,store_identifier,product_type,display_name,title,amount,currency\n" +
+		"rc_billing,premium_web,subscription,Premium,Premium,9.99,usd\n"
+	states, err := readStoreStateCSVReader(strings.NewReader(csvInput), "app_x")
+	if err != nil {
+		t.Fatalf("rc_billing CSV row should parse: %v", err)
+	}
+	pricing, _ := states[0].Common["pricing"].(map[string]any)
+	prices, _ := pricing["currency_prices"].(map[string]any)
+	price, _ := prices["USD"].(map[string]any)
+	if price["amount_micros"] != int64(9990000) {
+		t.Fatalf("want USD currency price 9990000 micros, got common: %v", states[0].Common)
+	}
+	if states[0].StoreState != nil {
+		t.Fatalf("no store-specific shaping expected for rc_billing, got: %v", states[0].StoreState)
+	}
+
+	// Territory pricing is Apple/Play-shaped; reject it for currency stores.
+	badCSV := "store,store_identifier,product_type,display_name,title,territory,amount,currency\n" +
+		"test_store,premium_test,subscription,Premium,Premium,US,9.99,USD\n"
+	if _, err := readStoreStateCSVReader(strings.NewReader(badCSV), "app_x"); err == nil || !strings.Contains(err.Error(), "territory") {
+		t.Fatalf("want a territory-does-not-apply error, got: %v", err)
 	}
 }


### PR DESCRIPTION
The CLI was enforcing store rules it doesn't own — and they were already stale (the API creates and prices Web Billing and Test Store products; the CLI still said no). Now the server is the only authority. Three changes:

**`rc products create` stops pre-blocking.** Requests go through and the server's error answers, with a hint to what works today:

```
$ rc products create --app-id app_webbilling --store-id premium --type subscription --title Premium
  Web Billing products are created through store-state plans:  rc products store sync app_webbilling
✗ authorization_error: Web Billing product creation is still not supported.
```

**`rc products store` accepts every store the plans API supports.** No more Apple/Play-only gate, and the interactive flow uses the app's real store type instead of coercing everything to `app_store`.

**Prices land in the shape the input implies, not what a store list dictates.** A territory means `territory_prices`; no territory means `currency_prices` (how Web Billing and Test Store price — territory prices sent to them were silently ignored before). No hardcoded store list to go stale when the next store is ungated.

The only client-side errors left are structural — the payload can't be built without the field — and they carry CSV line numbers. Per-store type lists survive only in help text and the interactive picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)